### PR TITLE
add 'mrkdwn_in' field to Attachments

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/model/Attachment.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Attachment.java
@@ -124,4 +124,12 @@ public class Attachment {
      */
     private Integer ts;
 
+    /**
+     * By default,
+     * <a href="https://api.slack.com/docs/message-formatting#message_formatting>message text
+     * in attachments</a> are not formatted. To enable formatting on attachment fields, add the
+     * name of the field (as defined in the API) in this list.
+     */
+    private List<String> mrkdwnIn = new ArrayList<>();
+
 }

--- a/src/test/java/com/github/seratch/jslack/Slack_incomingWebhooks_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_incomingWebhooks_Test.java
@@ -19,6 +19,9 @@ public class Slack_incomingWebhooks_Test {
     public void incomingWebhook() throws IOException {
         // String url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX";
         String url = System.getenv("SLACK_WEBHOOK_TEST_URL");
+        if (url == null) {
+            throw new IllegalStateException("Environment variable SLACK_WEBHOOK_TEST_URL must be defined");
+        }
 
         Payload payload = Payload.builder()
                 .channel("#random")
@@ -29,7 +32,7 @@ public class Slack_incomingWebhooks_Test {
                 .build();
 
         Attachment attachment = Attachment.builder()
-                .text("This is an attachment.")
+                .text("This is an *attachment*.")
                 .authorName("Smiling Imp")
                 .color("#36a64f")
                 .fallback("Required plain-text summary of the attachment.")
@@ -37,7 +40,11 @@ public class Slack_incomingWebhooks_Test {
                 .titleLink("https://api.slack.com/")
                 .footer("footer")
                 .fields(new ArrayList<>())
+                .mrkdwnIn(new ArrayList<>())
                 .build();
+
+        attachment.getMrkdwnIn().add("text");
+
         {
             Field field = Field.builder()
                     .title("Long Title")


### PR DESCRIPTION
From https://api.slack.com/docs/message-formatting#message_formatting:

> By default bot message text will be formatted, but attachments are
> not. To disable formatting on a non-user message, set the `mrkdwn`
> property to false. To enable formatting on attachment fields, set the
> `mrkdwn_in` array on each attachment to the list of fields to process.

This change allows for attachments in messages sent by bots to use
normal Slack message formatting.