### PR TITLE
Add SlackApiRequest marker interface

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/methods/SlackApiRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/SlackApiRequest.java
@@ -1,0 +1,8 @@
+package com.github.seratch.jslack.api.methods;
+
+/**
+ * A marker interface for Slack API request objects.
+ */
+public interface SlackApiRequest {
+
+}

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/api/ApiTestRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/api/ApiTestRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.api;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/api/ApiTestRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/api/ApiTestRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.api;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ApiTestRequest {
+public class ApiTestRequest implements SlackApiRequest {
 
     private String foo;
     private String error;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/auth/AuthRevokeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/auth/AuthRevokeRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.auth;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/auth/AuthRevokeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/auth/AuthRevokeRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.auth;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class AuthRevokeRequest {
+public class AuthRevokeRequest implements SlackApiRequest {
 
     private String token;
     private String test;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/auth/AuthTestRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/auth/AuthTestRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.auth;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/auth/AuthTestRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/auth/AuthTestRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.auth;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class AuthTestRequest {
+public class AuthTestRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/bots/BotsInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/bots/BotsInfoRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.bots;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/bots/BotsInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/bots/BotsInfoRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.bots;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class BotsInfoRequest {
+public class BotsInfoRequest implements SlackApiRequest {
 
     private String token;
     private String bot;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsArchiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsArchiveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsArchiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsArchiveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsArchiveRequest {
+public class ChannelsArchiveRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsCreateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsCreateRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsCreateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsCreateRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsCreateRequest {
+public class ChannelsCreateRequest implements SlackApiRequest {
 
     private String token;
     private String name;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsHistoryRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsHistoryRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsHistoryRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsHistoryRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsHistoryRequest {
+public class ChannelsHistoryRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsInfoRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsInfoRequest {
+public class ChannelsInfoRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsInfoRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsInviteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsInviteRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsInviteRequest {
+public class ChannelsInviteRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsInviteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsInviteRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsJoinRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsJoinRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsJoinRequest {
+public class ChannelsJoinRequest implements SlackApiRequest {
 
     private String token;
     private String name;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsJoinRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsJoinRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsKickRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsKickRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsKickRequest {
+public class ChannelsKickRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsKickRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsKickRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsLeaveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsLeaveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsLeaveRequest {
+public class ChannelsLeaveRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsLeaveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsLeaveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsListRequest {
+public class ChannelsListRequest implements SlackApiRequest {
 
     private String token;
     private Integer excludeArchived;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsMarkRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsMarkRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsMarkRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsMarkRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsMarkRequest {
+public class ChannelsMarkRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsRenameRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsRenameRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsRenameRequest {
+public class ChannelsRenameRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsRenameRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsRenameRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsSetPurposeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsSetPurposeRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsSetPurposeRequest {
+public class ChannelsSetPurposeRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsSetPurposeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsSetPurposeRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsSetTopicRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsSetTopicRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsSetTopicRequest {
+public class ChannelsSetTopicRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsSetTopicRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsSetTopicRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsUnarchiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsUnarchiveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChannelsUnarchiveRequest {
+public class ChannelsUnarchiveRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsUnarchiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/channels/ChannelsUnarchiveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.channels;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatDeleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatDeleteRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.chat;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChatDeleteRequest {
+public class ChatDeleteRequest implements SlackApiRequest {
 
     private String token;
     private String ts;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatDeleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatDeleteRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.chat;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatMeMessageRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatMeMessageRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.chat;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatMeMessageRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatMeMessageRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.chat;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ChatMeMessageRequest {
+public class ChatMeMessageRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatPostMessageRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatPostMessageRequest.java
@@ -1,5 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.chat;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import com.github.seratch.jslack.api.model.Attachment;
 import lombok.Builder;
 import lombok.Data;
@@ -8,7 +9,7 @@ import java.util.List;
 
 @Data
 @Builder
-public class ChatPostMessageRequest {
+public class ChatPostMessageRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatUpdateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.chat;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import com.github.seratch.jslack.api.model.Attachment;
 import lombok.Builder;
 import lombok.Data;
@@ -8,7 +9,7 @@ import java.util.List;
 
 @Data
 @Builder
-public class ChatUpdateRequest {
+public class ChatUpdateRequest implements SlackApiRequest {
 
     private String token;
     private String ts;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndEndDndRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndEndDndRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.dnd;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class DndEndDndRequest {
+public class DndEndDndRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndEndDndRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndEndDndRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.dnd;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndEndSnoozeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndEndSnoozeRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.dnd;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndEndSnoozeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndEndSnoozeRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.dnd;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class DndEndSnoozeRequest {
+public class DndEndSnoozeRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndInfoRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.dnd;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndInfoRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.dnd;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class DndInfoRequest {
+public class DndInfoRequest implements SlackApiRequest {
 
     private String token;
     private String user;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndSetSnoozeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndSetSnoozeRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.dnd;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndSetSnoozeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndSetSnoozeRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.dnd;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class DndSetSnoozeRequest {
+public class DndSetSnoozeRequest implements SlackApiRequest {
 
     private String token;
     private Integer numMinutes;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndTeamInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndTeamInfoRequest.java
@@ -5,9 +5,11 @@ import lombok.Data;
 
 import java.util.List;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 @Data
 @Builder
-public class DndTeamInfoRequest {
+public class DndTeamInfoRequest implements SlackApiRequest {
 
     private String token;
     private List<String> users;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndTeamInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dnd/DndTeamInfoRequest.java
@@ -1,11 +1,10 @@
 package com.github.seratch.jslack.api.methods.request.dnd;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
-
-import com.github.seratch.jslack.api.methods.SlackApiRequest;
 
 @Data
 @Builder

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/emoji/EmojiListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/emoji/EmojiListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.emoji;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class EmojiListRequest {
+public class EmojiListRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/emoji/EmojiListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/emoji/EmojiListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.emoji;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesDeleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesDeleteRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class FilesDeleteRequest {
+public class FilesDeleteRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesDeleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesDeleteRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesInfoRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesInfoRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class FilesInfoRequest {
+public class FilesInfoRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesListRequest.java
@@ -1,22 +1,21 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
 
-import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 @Data
 @Builder
 public class FilesListRequest implements SlackApiRequest {
 
-    private String token;
-    private String user;
-    private String channel;
-    private String tsFrom;
-    private String tsTo;
-    private List<String> types;
-    private Integer count;
-    private Integer page;
+	private String token;
+	private String user;
+	private String channel;
+	private String tsFrom;
+	private String tsTo;
+	private List<String> types;
+	private Integer count;
+	private Integer page;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesListRequest.java
@@ -5,9 +5,11 @@ import lombok.Data;
 
 import java.util.List;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 @Data
 @Builder
-public class FilesListRequest {
+public class FilesListRequest implements SlackApiRequest {
 
     private String token;
     private String user;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesRevokePublicURLRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesRevokePublicURLRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesRevokePublicURLRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesRevokePublicURLRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class FilesRevokePublicURLRequest {
+public class FilesRevokePublicURLRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesSharedPublicURLRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesSharedPublicURLRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class FilesSharedPublicURLRequest {
+public class FilesSharedPublicURLRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesSharedPublicURLRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesSharedPublicURLRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesUploadRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesUploadRequest.java
@@ -6,9 +6,11 @@ import lombok.Data;
 import java.io.File;
 import java.util.List;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 @Data
 @Builder
-public class FilesUploadRequest {
+public class FilesUploadRequest implements SlackApiRequest {
 
     private String token;
     private File file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesUploadRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/FilesUploadRequest.java
@@ -1,12 +1,11 @@
 package com.github.seratch.jslack.api.methods.request.files;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
 import java.io.File;
 import java.util.List;
-
-import com.github.seratch.jslack.api.methods.SlackApiRequest;
 
 @Data
 @Builder

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsAddRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.files.comments;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class FilesCommentsAddRequest {
+public class FilesCommentsAddRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsAddRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.files.comments;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsDeleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsDeleteRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.files.comments;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class FilesCommentsDeleteRequest {
+public class FilesCommentsDeleteRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsDeleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsDeleteRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.files.comments;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsEditRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsEditRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.files.comments;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class FilesCommentsEditRequest {
+public class FilesCommentsEditRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsEditRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/files/comments/FilesCommentsEditRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.files.comments;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsArchiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsArchiveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsArchiveRequest {
+public class GroupsArchiveRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsArchiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsArchiveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCloseRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCloseRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsCloseRequest {
+public class GroupsCloseRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCloseRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCloseRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCreateChildRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCreateChildRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCreateChildRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCreateChildRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsCreateChildRequest {
+public class GroupsCreateChildRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCreateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCreateRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsCreateRequest {
+public class GroupsCreateRequest implements SlackApiRequest {
 
     private String token;
     private String name;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCreateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsCreateRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsHistoryRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsHistoryRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsHistoryRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsHistoryRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsHistoryRequest {
+public class GroupsHistoryRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsInfoRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsInfoRequest {
+public class GroupsInfoRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsInfoRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsInviteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsInviteRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsInviteRequest {
+public class GroupsInviteRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsInviteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsInviteRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsKickRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsKickRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsKickRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsKickRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsKickRequest {
+public class GroupsKickRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsLeaveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsLeaveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsLeaveRequest {
+public class GroupsLeaveRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsLeaveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsLeaveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsListRequest {
+public class GroupsListRequest implements SlackApiRequest {
 
     private String token;
     private Integer excludeArchived;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsMarkRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsMarkRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsMarkRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsMarkRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsMarkRequest {
+public class GroupsMarkRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsOpenRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsOpenRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsOpenRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsOpenRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsOpenRequest {
+public class GroupsOpenRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsRenameRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsRenameRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsRenameRequest {
+public class GroupsRenameRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsRenameRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsRenameRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsSetPurposeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsSetPurposeRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsSetPurposeRequest {
+public class GroupsSetPurposeRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsSetPurposeRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsSetPurposeRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsSetTopicRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsSetTopicRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsSetTopicRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsSetTopicRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsSetTopicRequest {
+public class GroupsSetTopicRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsUnarchiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsUnarchiveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class GroupsUnarchiveRequest {
+public class GroupsUnarchiveRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsUnarchiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/groups/GroupsUnarchiveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.groups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImCloseRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImCloseRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImCloseRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImCloseRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ImCloseRequest {
+public class ImCloseRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImHistoryRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImHistoryRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ImHistoryRequest {
+public class ImHistoryRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImHistoryRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImHistoryRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ImListRequest {
+public class ImListRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImMarkRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImMarkRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImMarkRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImMarkRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ImMarkRequest {
+public class ImMarkRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImOpenRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImOpenRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImOpenRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/im/ImOpenRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.im;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ImOpenRequest {
+public class ImOpenRequest implements SlackApiRequest {
 
     private String token;
     private String user;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimCloseRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimCloseRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.mpim;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class MpimCloseRequest {
+public class MpimCloseRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimCloseRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimCloseRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.mpim;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimHistoryRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimHistoryRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.mpim;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimHistoryRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimHistoryRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.mpim;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class MpimHistoryRequest {
+public class MpimHistoryRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.mpim;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.mpim;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class MpimListRequest {
+public class MpimListRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimMarkRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimMarkRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.mpim;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class MpimMarkRequest {
+public class MpimMarkRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimMarkRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimMarkRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.mpim;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimOpenRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimOpenRequest.java
@@ -1,11 +1,10 @@
 package com.github.seratch.jslack.api.methods.request.mpim;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
-
-import com.github.seratch.jslack.api.methods.SlackApiRequest;
 
 @Data
 @Builder

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimOpenRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/mpim/MpimOpenRequest.java
@@ -5,9 +5,11 @@ import lombok.Data;
 
 import java.util.List;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 @Data
 @Builder
-public class MpimOpenRequest {
+public class MpimOpenRequest implements SlackApiRequest {
 
     private String token;
     private List<String> users;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/oauth/OAuthAccessRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/oauth/OAuthAccessRequest.java
@@ -1,5 +1,7 @@
 package com.github.seratch.jslack.api.methods.request.oauth;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -8,7 +10,7 @@ import lombok.Data;
  */
 @Data
 @Builder
-public class OAuthAccessRequest {
+public class OAuthAccessRequest implements SlackApiRequest {
 
     private String clientId;
     private String clientSecret;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/oauth/OAuthAccessRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/oauth/OAuthAccessRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.oauth;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsAddRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.pins;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsAddRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.pins;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class PinsAddRequest {
+public class PinsAddRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.pins;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.pins;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class PinsListRequest {
+public class PinsListRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsRemoveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsRemoveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.pins;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsRemoveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/pins/PinsRemoveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.pins;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class PinsRemoveRequest {
+public class PinsRemoveRequest implements SlackApiRequest {
 
     private String token;
     private String channel;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsAddRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.reactions;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ReactionsAddRequest {
+public class ReactionsAddRequest implements SlackApiRequest {
 
     private String token;
     private String name;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsAddRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.reactions;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsGetRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsGetRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.reactions;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ReactionsGetRequest {
+public class ReactionsGetRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsGetRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsGetRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.reactions;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.reactions;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.reactions;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ReactionsListRequest {
+public class ReactionsListRequest implements SlackApiRequest {
 
     private String token;
     private String user;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsRemoveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsRemoveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.reactions;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class ReactionsRemoveRequest {
+public class ReactionsRemoveRequest implements SlackApiRequest {
 
     private String token;
     private String name;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsRemoveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reactions/ReactionsRemoveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.reactions;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersAddRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class RemindersAddRequest {
+public class RemindersAddRequest implements SlackApiRequest {
 
     private String token;
     private String text;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersAddRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersCompleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersCompleteRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersCompleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersCompleteRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class RemindersCompleteRequest {
+public class RemindersCompleteRequest implements SlackApiRequest {
 
     private String token;
     private String reminder;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersDeleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersDeleteRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class RemindersDeleteRequest {
+public class RemindersDeleteRequest implements SlackApiRequest {
 
     private String token;
     private String reminder;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersDeleteRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersDeleteRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersInfoRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class RemindersInfoRequest {
+public class RemindersInfoRequest implements SlackApiRequest {
 
     private String token;
     private String reminder;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersInfoRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/reminders/RemindersListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.reminders;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class RemindersListRequest {
+public class RemindersListRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/rtm/RTMStartRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/rtm/RTMStartRequest.java
@@ -1,5 +1,7 @@
 package com.github.seratch.jslack.api.methods.request.rtm;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -8,7 +10,7 @@ import lombok.Data;
  */
 @Data
 @Builder
-public class RTMStartRequest {
+public class RTMStartRequest implements SlackApiRequest {
 
     private String token;
     private Boolean noUnreads;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/rtm/RTMStartRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/rtm/RTMStartRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.rtm;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchAllRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchAllRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.search;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchAllRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchAllRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.search;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class SearchAllRequest {
+public class SearchAllRequest implements SlackApiRequest {
 
     private String token;
     private String query;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchFilesRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchFilesRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.search;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class SearchFilesRequest {
+public class SearchFilesRequest implements SlackApiRequest {
 
     private String token;
     private String query;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchFilesRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchFilesRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.search;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchMessagesRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchMessagesRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.search;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchMessagesRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/search/SearchMessagesRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.search;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class SearchMessagesRequest {
+public class SearchMessagesRequest implements SlackApiRequest {
 
     private String token;
     private String query;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsAddRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.stars;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class StarsAddRequest {
+public class StarsAddRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsAddRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsAddRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.stars;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.stars;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class StarsListRequest {
+public class StarsListRequest implements SlackApiRequest {
 
     private String token;
     private Integer count;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.stars;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsRemoveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsRemoveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.stars;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsRemoveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/stars/StarsRemoveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.stars;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class StarsRemoveRequest {
+public class StarsRemoveRequest implements SlackApiRequest {
 
     private String token;
     private String file;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamAccessLogsRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamAccessLogsRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.team;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class TeamAccessLogsRequest {
+public class TeamAccessLogsRequest implements SlackApiRequest {
 
     private String token;
     private Integer count;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamAccessLogsRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamAccessLogsRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.team;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamBillableInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamBillableInfoRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.team;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class TeamBillableInfoRequest {
+public class TeamBillableInfoRequest implements SlackApiRequest {
 
     private String token;
     private String user;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamBillableInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamBillableInfoRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.team;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamInfoRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.team;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class TeamInfoRequest {
+public class TeamInfoRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamInfoRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.team;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamIntegrationLogsRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamIntegrationLogsRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.team;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class TeamIntegrationLogsRequest {
+public class TeamIntegrationLogsRequest implements SlackApiRequest {
 
     private String token;
     private String serviceId;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamIntegrationLogsRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/TeamIntegrationLogsRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.team;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/profile/TeamProfileGetRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/profile/TeamProfileGetRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.team.profile;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class TeamProfileGetRequest {
+public class TeamProfileGetRequest implements SlackApiRequest {
 
     private String token;
     private String visibility;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/team/profile/TeamProfileGetRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/team/profile/TeamProfileGetRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.team.profile;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsCreateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsCreateRequest.java
@@ -1,11 +1,10 @@
 package com.github.seratch.jslack.api.methods.request.usergroups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
-
-import com.github.seratch.jslack.api.methods.SlackApiRequest;
 
 @Data
 @Builder

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsCreateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsCreateRequest.java
@@ -5,9 +5,11 @@ import lombok.Data;
 
 import java.util.List;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 @Data
 @Builder
-public class UsergroupsCreateRequest {
+public class UsergroupsCreateRequest implements SlackApiRequest {
 
     private String token;
     private String name;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsDisableRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsDisableRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.usergroups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsergroupsDisableRequest {
+public class UsergroupsDisableRequest implements SlackApiRequest {
 
     private String token;
     private String usergroup;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsDisableRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsDisableRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.usergroups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsEnableRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsEnableRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.usergroups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsEnableRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsEnableRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.usergroups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsergroupsEnableRequest {
+public class UsergroupsEnableRequest implements SlackApiRequest {
 
     private String token;
     private String usergroup;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.usergroups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsergroupsListRequest {
+public class UsergroupsListRequest implements SlackApiRequest {
 
     private String token;
     private Integer includeDisabled;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.usergroups;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsUpdateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsUpdateRequest.java
@@ -5,9 +5,11 @@ import lombok.Data;
 
 import java.util.List;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 @Data
 @Builder
-public class UsergroupsUpdateRequest {
+public class UsergroupsUpdateRequest implements SlackApiRequest {
 
     private String token;
     private String usergroup;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsUpdateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/UsergroupsUpdateRequest.java
@@ -1,11 +1,10 @@
 package com.github.seratch.jslack.api.methods.request.usergroups;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
-
-import com.github.seratch.jslack.api.methods.SlackApiRequest;
 
 @Data
 @Builder

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/users/UsergroupUsersListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/users/UsergroupUsersListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.usergroups.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/users/UsergroupUsersListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/users/UsergroupUsersListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.usergroups.users;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsergroupUsersListRequest {
+public class UsergroupUsersListRequest implements SlackApiRequest {
 
     private String token;
     private String usergroup;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/users/UsergroupUsersUpdateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/users/UsergroupUsersUpdateRequest.java
@@ -1,11 +1,10 @@
 package com.github.seratch.jslack.api.methods.request.usergroups.users;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
-
-import com.github.seratch.jslack.api.methods.SlackApiRequest;
 
 @Data
 @Builder

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/users/UsergroupUsersUpdateRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/usergroups/users/UsergroupUsersUpdateRequest.java
@@ -5,9 +5,11 @@ import lombok.Data;
 
 import java.util.List;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 @Data
 @Builder
-public class UsergroupUsersUpdateRequest {
+public class UsergroupUsersUpdateRequest implements SlackApiRequest {
 
     private String token;
     private String usergroup;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersGetPresenceRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersGetPresenceRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsersGetPresenceRequest {
+public class UsersGetPresenceRequest implements SlackApiRequest {
 
     private String token;
     private String user;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersGetPresenceRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersGetPresenceRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersIdentityRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersIdentityRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersIdentityRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersIdentityRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsersIdentityRequest {
+public class UsersIdentityRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersInfoRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsersInfoRequest {
+public class UsersInfoRequest implements SlackApiRequest {
 
     private String token;
     private String user;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersInfoRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersInfoRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersListRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsersListRequest {
+public class UsersListRequest implements SlackApiRequest {
 
     private String token;
     private Integer presence;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersListRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersListRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersSetActiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersSetActiveRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsersSetActiveRequest {
+public class UsersSetActiveRequest implements SlackApiRequest {
 
     private String token;
 }

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersSetActiveRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersSetActiveRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersSetPresenceRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersSetPresenceRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersSetPresenceRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersSetPresenceRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.users;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsersSetPresenceRequest {
+public class UsersSetPresenceRequest implements SlackApiRequest {
 
     private String token;
     private String presence;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/profile/UsersProfileGetRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/profile/UsersProfileGetRequest.java
@@ -1,7 +1,6 @@
 package com.github.seratch.jslack.api.methods.request.users.profile;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
-
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/profile/UsersProfileGetRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/profile/UsersProfileGetRequest.java
@@ -1,11 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.users.profile;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsersProfileGetRequest {
+public class UsersProfileGetRequest implements SlackApiRequest {
 
     private String token;
     private String user;

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/profile/UsersProfileSetRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/profile/UsersProfileSetRequest.java
@@ -1,12 +1,13 @@
 package com.github.seratch.jslack.api.methods.request.users.profile;
 
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import com.github.seratch.jslack.api.model.User;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class UsersProfileSetRequest {
+public class UsersProfileSetRequest implements SlackApiRequest {
 
     private String token;
     private String user;


### PR DESCRIPTION
All request objects now implement SlackApiRequest.  As per issue #7 