### PR TITLE
Add support for modal dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ jSlack is a Java library to easily integrate your operations with [Slack](https:
   - bots.*
   - channels.*
   - chat.*
+  - dialog.open
   - dnd.*
   - emoji.*
   - files.*
@@ -221,6 +222,56 @@ ChatDeleteResponse deleteResponse = slack.methods().chatDelete(
     .ts(messageTimestamp)
     .build());
 assertThat(deleteResponse.isOk(), is(true));
+```
+
+##### Open a dialog modal
+
+```java
+String token = "api-token";
+    
+    // Required.  See https://api.slack.com/dialogs#implementation
+    String triggerId = "trigger-id";
+    
+    Slack slack = Slack.getInstance();
+    
+    DialogTextElement quanityTextElement = DialogTextElement.builder()
+        .subtype(SubType.NUMBER)
+        .label("Quantity")
+        .name("quantity")
+        .hint("The number you need")
+        .maxLength(3)
+        .minLength(1)
+        .placeholder("Required quantity")
+        .value("1")
+        .build();
+    
+    DialogSelectElement colourSelectElement = DialogSelectElement.builder()
+        .name("colour")
+        .label("Colour")
+        .placeholder("Choose your preferred colour")
+        .options(Arrays.asList(
+            Option.builder().label("Red").value("#FF0000").build(),
+            Option.builder().label("Green").value("#00FF00").build(),
+            Option.builder().label("Blue").value("#0000FF").build(),
+            Option.builder().label("Black").value("#000000").build(),
+            Option.builder().label("White").value("#FFFFFF").build()
+         ))
+        .build();
+        
+    
+    Dialog dialog = Dialog.builder()
+        .title("Request pens")
+        .callbackId("pens-1122")
+        .elements(Arrays.asList(quanityTextElement, colourSelectElement))
+        .submitLabel("")
+        .build();
+
+    DialogOpenResponse openDialogResponse = slack.methods().dialogOpen(
+        DialogOpenRequest.builder()
+        .token(token)
+        .triggerId(triggerId)
+        .dialog(dialog)
+        .build());
 ```
 
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
@@ -9,6 +9,7 @@ import com.github.seratch.jslack.api.methods.request.chat.ChatDeleteRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatMeMessageRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatUpdateRequest;
+import com.github.seratch.jslack.api.methods.request.dialog.DialogOpenRequest;
 import com.github.seratch.jslack.api.methods.request.dnd.*;
 import com.github.seratch.jslack.api.methods.request.emoji.EmojiListRequest;
 import com.github.seratch.jslack.api.methods.request.files.*;
@@ -54,6 +55,7 @@ import com.github.seratch.jslack.api.methods.response.chat.ChatDeleteResponse;
 import com.github.seratch.jslack.api.methods.response.chat.ChatMeMessageResponse;
 import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
 import com.github.seratch.jslack.api.methods.response.chat.ChatUpdateResponse;
+import com.github.seratch.jslack.api.methods.response.dialog.DialogOpenResponse;
 import com.github.seratch.jslack.api.methods.response.dnd.*;
 import com.github.seratch.jslack.api.methods.response.emoji.EmojiListResponse;
 import com.github.seratch.jslack.api.methods.response.files.*;
@@ -164,6 +166,12 @@ public interface MethodsClient {
     ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest req) throws IOException, SlackApiException;
 
     ChatUpdateResponse chatUpdate(ChatUpdateRequest req) throws IOException, SlackApiException;
+    
+    // ------------------------------
+    // dialog
+    // ------------------------------
+    
+    DialogOpenResponse dialogOpen(DialogOpenRequest req) throws IOException, SlackApiException;
 
     // ------------------------------
     // dnd

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/dialog/DialogOpenRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/dialog/DialogOpenRequest.java
@@ -1,0 +1,30 @@
+package com.github.seratch.jslack.api.methods.request.dialog;
+
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+import com.github.seratch.jslack.api.model.dialog.Dialog;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DialogOpenRequest implements SlackApiRequest {
+
+    private String token;
+    
+    /**
+     * The dialog definition. This must be a JSON-encoded string.
+     */
+    private Dialog dialog;
+    
+    /**
+     * Apps can invoke dialogs when users interact with slash commands, message buttons,
+     * or message menus. Each interaction will include a trigger_id.<p>
+     * 
+     * As apps can only open a dialog in response to such a user action, the 
+     * {@code trigger_id} is a required parameter.
+     * 
+     * @see <a href="https://api.slack.com/dialogs#implementation">Implementing dialogs</a>
+     */
+    private String triggerId;
+}

--- a/src/main/java/com/github/seratch/jslack/api/methods/response/dialog/DialogOpenResponse.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/response/dialog/DialogOpenResponse.java
@@ -1,0 +1,13 @@
+package com.github.seratch.jslack.api.methods.response.dialog;
+
+import com.github.seratch.jslack.api.methods.SlackApiResponse;
+
+import lombok.Data;
+
+@Data
+public class DialogOpenResponse implements SlackApiResponse {
+  
+  private boolean ok;
+  private String warning;
+  private String error;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/Action.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Action.java
@@ -6,15 +6,41 @@ import lombok.Data;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gson.annotations.SerializedName;
+
 @Data
 @Builder
 public class Action {
-    public static final String BUTTON = "button";
+    /**
+     * Represents the type of action (e.g Message button or message menu)
+     * @see <a href="https://api.slack.com/interactive-messages#interaction_types">Interaction Types</a>
+     */
+    public enum Type {
+      
+      /**
+       * @see <a href="https://api.slack.com/docs/message-buttons">Message button</a>
+       */
+      @SerializedName("button")
+      BUTTON ("button"),
+      
+      /**
+       * @see <a href="https://api.slack.com/docs/message-menus">Message menus</a>
+       */
+      @SerializedName("select")
+      SELECT ("select");
+      
+      private final String value;
+      Type(String value) {
+        this.value = value;
+      }
+      
+      public String value() { return value; }
+    }
 
     private String name;
     private String text;
     private String style;
-    @Builder.Default private String type = BUTTON;
+    @Builder.Default private Type type = Type.BUTTON;
     private String value;
     private Confirmation confirmation;
     private List<Option> options = new ArrayList<>();

--- a/src/main/java/com/github/seratch/jslack/api/model/dialog/Dialog.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/dialog/Dialog.java
@@ -1,0 +1,39 @@
+package com.github.seratch.jslack.api.model.dialog;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Represents a Slack Modal Dialog
+ * 
+ * @see <a href="https://api.slack.com/dialogs">Slack Modal Dialog</a>
+ */
+@Data
+@Builder
+public class Dialog {
+  /**
+   * User-facing title of this entire dialog. 24 characters to work with and it's required.
+   */
+  private String title;
+  
+  /**
+   * An identifier strictly for you to recognize submissions of this particular instance of
+   * a dialog. Use something meaningful to your app. 255 characters maximum. 
+   * Absolutely required.
+   */
+  private String callbackId;
+  
+  /**
+   * Up to 5 form elements are allowed per dialog. Required.
+   */
+  private List<Element> elements;
+  
+  /**
+   * User-facing string for whichever button-like thing submits the form, depending on
+   * form factor. Defaults to {@code Submit}, localized in whichever language the end user
+   * prefers. 24 characters maximum, and may contain only a single word.
+   */
+  private String submitLabel;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/dialog/DialogSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/dialog/DialogSelectElement.java
@@ -1,0 +1,62 @@
+package com.github.seratch.jslack.api.model.dialog;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Represents a <a href="https://api.slack.com/dialogs#select_elements">select</a> 
+ * dialog element<p>
+ * 
+ * Use the {@code select} element for multiple choice selections allowing users to pick a
+ * single item from a list. True to web roots, this selection is displayed as a dropdown
+ * menu.
+ *
+ */
+@Data
+@Builder
+public class DialogSelectElement implements Element {
+  
+  /**
+   * Label displayed to user. Required. No more than 24 characters.
+   */
+  private String label;
+  
+  /**
+   * Name of form element. Required. No more than 300 characters.
+   */
+  private String name;
+  
+  /**
+   * Type of element.  For a dropdown (select), the type is always
+   * {@code select} . It's required.
+   * 
+   * @see <a href="https://api.slack.com/dialogs#elements">Dialog form elements</a>
+   * 
+   */
+  private final String type = "select";
+  
+  /**
+   * A default value for this field.  Must match a value presented in {@link Option}s.
+   */
+  String value;
+  
+  /**
+   * A string displayed as needed to help guide users in completing the element.
+   * 150 character maximum.
+   */
+  private String placeholder;
+  
+  /**
+   * Provide true when the form element is not required. By default, form elements are
+   * required.
+   */
+  private boolean optional;
+  
+  /**
+   * Provide up to 100 option element attributes. Required for this type.
+   */
+  private List<Option> options;
+  
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/dialog/DialogTextAreaElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/dialog/DialogTextAreaElement.java
@@ -1,0 +1,71 @@
+package com.github.seratch.jslack.api.model.dialog;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Represents a <a href="https://api.slack.com/dialogs#textarea_elements">textarea</a> 
+ * dialog element<p>
+ * 
+ * A {@code textarea} is a multi-line plain text editing control. You've likely encountered
+ * these on the world wide web. Use this element if you want a relatively long answer from 
+ * users.
+ */
+@Data
+@Builder
+public class DialogTextAreaElement implements Element {
+  
+  /**
+   * Label displayed to user. Required. No more than 24 characters.
+   */
+  private String label;
+  
+  /**
+   * Name of form element. Required. No more than 300 characters.
+   */
+  private String name;
+  
+  /**
+   * Type of element.  For a textarea, the type is always {@code textarea} . It's required.
+   * 
+   * @see <a href="https://api.slack.com/dialogs#elements">Dialog form elements</a>
+   */
+  private final String type = "textarea";
+  
+  /**
+   * A default value for this field.  Up to 500 characters.
+   */
+  String value;
+  
+  /**
+   * A string displayed as needed to help guide users in completing the element.
+   * 150 character maximum.
+   */
+  private String placeholder;
+  
+  /**
+   * Provide {@code true} when the form element is not required. By default, 
+   * form elements are required.
+   */
+  boolean optional;
+  
+  /**
+   * Maximum input length allowed for element. 0-500 characters. Defaults to 150.
+   */
+  public int maxLength;
+  
+  /**
+   * Minimum input length allowed for element. 1-500 characters. Defaults to 0.
+   */
+  int minLength;
+  
+  /**
+   * Helpful text provided to assist users in answering a question. Up to 150 characters.
+   */
+  String hint;
+  
+  /**
+   * Subtype for this text type element (e.g. Number)
+   */
+  SubType subtype;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/dialog/DialogTextElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/dialog/DialogTextElement.java
@@ -1,0 +1,72 @@
+package com.github.seratch.jslack.api.model.dialog;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Represents a <a href="https://api.slack.com/dialogs#text_elements">text</a>
+ * dialog element<p>
+ * 
+ * {@code Text} elements are single-line plain text fields.
+ */
+@Data
+@Builder
+public class DialogTextElement implements Element {
+  
+  /**
+   * Label displayed to user. Required. No more than 24 characters.
+   */
+  private String label;
+  
+  /**
+   * Name of form element. Required. No more than 300 characters.
+   */
+  private String name;
+  
+  /**
+   * Type of element.  For a text element, the type is always
+   * {@code text} . It's required.
+   * 
+   * @see <a href="https://api.slack.com/dialogs#elements">Dialog form elements</a>
+   * 
+   */
+  private final String type = "text";
+  
+  /**
+   * A default value for this field. Up to 500 characters.
+   */
+  String value;
+  
+  /**
+   * A string displayed as needed to help guide users in completing the element.
+   * 150 character maximum.
+   */
+  private String placeholder;
+  
+  /**
+   * Provide {@code true} when the form element is not required. By default, 
+   * form elements are required.
+   */
+  boolean optional;
+  
+  /**
+   * Maximum input length allowed for element. Up to 150 characters. Defaults to 150.
+   */
+  public int maxLength;
+  
+  /**
+   * Minimum input length allowed for element.
+   * Type {@code text}: Up to 150 characters. Defaults to 0.
+   */
+  int minLength;
+  
+  /**
+   * Helpful text provided to assist users in answering a question. Up to 150 characters.
+   */
+  String hint;
+  
+  /**
+   * Subtype for this text type element (e.g. Number)
+   */
+  SubType subtype;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/dialog/Element.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/dialog/Element.java
@@ -1,0 +1,33 @@
+package com.github.seratch.jslack.api.model.dialog;
+
+/**
+ * A dialog Form Element such as {@code text}, {@code textarea}, or {@code select}
+ * or {@code select}.
+ * 
+ * @see <a href="https://api.slack.com/dialogs">Slack Modal Dialog</a>
+ */
+public interface Element {
+  
+  String getLabel();
+  
+  void setLabel(String label);
+  
+  String getName();
+  
+  void setName(String name);
+  
+  String getType();
+  
+  
+  String getValue();
+  
+  void setValue(String value);
+  
+  String getPlaceholder();
+  
+  void setPlaceholder(String placeholder);
+  
+  boolean isOptional();
+  
+  void setOptional(boolean isOptional);
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/dialog/Option.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/dialog/Option.java
@@ -1,0 +1,15 @@
+package com.github.seratch.jslack.api.model.dialog;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * A dialog element option used with {@link DialogSelectElement}s
+ *
+ */
+@Data
+@Builder
+public class Option {
+    private String label;
+    private String value;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/dialog/SubType.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/dialog/SubType.java
@@ -1,0 +1,21 @@
+package com.github.seratch.jslack.api.model.dialog;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents the subtype for an {@link DialogTextElement} or {@link DialogTextAreaElement} 
+ * In some form factors, optimized input is provided for this subtype.
+ */
+public enum SubType {
+  @SerializedName("email") EMAIL ("email"),
+  @SerializedName("number") NUMBER ("number"),
+  @SerializedName("tel") TEL ("tel"),
+  @SerializedName("url") URL ("url");
+  
+  private final String value;
+  SubType(String value) {
+    this.value = value;
+  }
+  
+  public String value() { return value; }
+}


### PR DESCRIPTION
Dialogs were recently released by Slack (see here) and a dialog.open web API has also been exposed (see issue #31).

- Added support for `dialog`s including new models
- Added sample usage to the [README.md](https://github.com/seratch/jslack/blob/master/README.md)

**Note: No test added for this API.**  `dialog.open` requests can only be made with a triggerID received within the last 3 seconds, and generating a triggerID requires a user taking action such as clicking a button.  Testing will be more challenging!