### PR TITLE
added support for `user_id` in OAuth response

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/methods/response/oauth/OAuthAccessResponse.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/response/oauth/OAuthAccessResponse.java
@@ -22,6 +22,7 @@ public class OAuthAccessResponse implements SlackApiResponse {
     public static class IncomingWebhook {
         private String url;
         private String channel;
+        private String channelId;
         private String configurationUrl;
     }
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/response/oauth/OAuthAccessResponse.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/response/oauth/OAuthAccessResponse.java
@@ -14,6 +14,7 @@ public class OAuthAccessResponse implements SlackApiResponse {
     private String scope;
     private String teamName;
     private String teamId;
+    private String userId;
     private IncomingWebhook incomingWebhook;
     private Bot bot;
 


### PR DESCRIPTION
OAuth response may also contain `user_id` but the information is lost at the moment

see the sample response:

```
{
  "ok": true,
  "access_token": "xoxp-abcdef-et-cetera",
  "scope": "identify,commands,incoming-webhook,chat:write:bot",
  "user_id": "USERISGOD",
  "team_name": "TestTeam",
  "team_id": "TEAMRULES",
  "incoming_webhook": {
    "channel": "#slack-beta-test",
    "channel_id": "CAFEBABE",
    "configuration_url": "https:\/\/agorapulse.slack.com\/services\/BAFBAFBAF",
    "url": "https:\/\/hooks.slack.com\/services\/ABCDEF123\/ABCDEF123\/acbedf1234567890"
  }
}
```