### PR TITLE
Fix typo: should use is_mpim instead of is_npim

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/model/Group.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Group.java
@@ -21,8 +21,8 @@ public class Group {
     private String creator;
     @SerializedName("is_archived")
     private boolean archived;
-    @SerializedName("is_npim")
-    private boolean npim;
+    @SerializedName("is_mpim")
+    private boolean mpim;
     private List<String> members;
     private Topic topic;
     private Purpose purpose;


### PR DESCRIPTION
According to the doc: https://api.slack.com/types/group
  
  cc @seratch 