### PR TITLE
adds support for user.lookupByEmail and chat.postEphemeral

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/methods/Methods.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/Methods.java
@@ -2,6 +2,9 @@ package com.github.seratch.jslack.api.methods;
 
 public class Methods {
 
+
+
+
     private Methods() {
     }
 
@@ -50,6 +53,7 @@ public class Methods {
 
     public static final String CHAT_DELETE = "chat.delete";
     public static final String CHAT_ME_MESSAGE = "chat.meMessage";
+    public static final String CHAT_POST_EPHEMERAL = "chat.postEphemeral";
     public static final String CHAT_POST_MESSAGE = "chat.postMessage";
     public static final String CHAT_UPDATE = "chat.update";
 
@@ -254,6 +258,7 @@ public class Methods {
     public static final String USERS_IDENTITY = "users.identity";
     public static final String USERS_INFO = "users.info";
     public static final String USERS_LIST = "users.list";
+    public static final String USERS_LOOKUP_BY_EMAIL = "users.lookupByEmail";
     public static final String USERS_SET_ACTIVE = "users.setActive";
     public static final String USERS_SET_PHOTO = "users.setPhoto";
     public static final String USERS_SET_PRESENCE = "users.setPresence";

--- a/src/main/java/com/github/seratch/jslack/api/methods/Methods.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/Methods.java
@@ -2,9 +2,6 @@ package com.github.seratch.jslack.api.methods;
 
 public class Methods {
 
-
-
-
     private Methods() {
     }
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
@@ -7,10 +7,7 @@ import com.github.seratch.jslack.api.methods.request.auth.AuthRevokeRequest;
 import com.github.seratch.jslack.api.methods.request.auth.AuthTestRequest;
 import com.github.seratch.jslack.api.methods.request.bots.BotsInfoRequest;
 import com.github.seratch.jslack.api.methods.request.channels.*;
-import com.github.seratch.jslack.api.methods.request.chat.ChatDeleteRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatMeMessageRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatUpdateRequest;
+import com.github.seratch.jslack.api.methods.request.chat.*;
 import com.github.seratch.jslack.api.methods.request.conversations.*;
 import com.github.seratch.jslack.api.methods.request.dialog.DialogOpenRequest;
 import com.github.seratch.jslack.api.methods.request.dnd.*;
@@ -54,10 +51,7 @@ import com.github.seratch.jslack.api.methods.response.auth.AuthRevokeResponse;
 import com.github.seratch.jslack.api.methods.response.auth.AuthTestResponse;
 import com.github.seratch.jslack.api.methods.response.bots.BotsInfoResponse;
 import com.github.seratch.jslack.api.methods.response.channels.*;
-import com.github.seratch.jslack.api.methods.response.chat.ChatDeleteResponse;
-import com.github.seratch.jslack.api.methods.response.chat.ChatMeMessageResponse;
-import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
-import com.github.seratch.jslack.api.methods.response.chat.ChatUpdateResponse;
+import com.github.seratch.jslack.api.methods.response.chat.*;
 import com.github.seratch.jslack.api.methods.response.conversations.*;
 import com.github.seratch.jslack.api.methods.response.dialog.DialogOpenResponse;
 import com.github.seratch.jslack.api.methods.response.dnd.*;
@@ -166,6 +160,8 @@ public interface MethodsClient {
     ChatDeleteResponse chatDelete(ChatDeleteRequest req) throws IOException, SlackApiException;
 
     ChatMeMessageResponse chatMeMessage(ChatMeMessageRequest req) throws IOException, SlackApiException;
+
+    ChatPostEphemeralResponse chatPostEphemeral(ChatPostEphemeralRequest req) throws IOException, SlackApiException;
 
     ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest req) throws IOException, SlackApiException;
 
@@ -440,6 +436,8 @@ public interface MethodsClient {
     UsersInfoResponse usersInfo(UsersInfoRequest req) throws IOException, SlackApiException;
 
     UsersListResponse usersList(UsersListRequest req) throws IOException, SlackApiException;
+
+    UsersLookupByEmailResponse usersLookupByEmail(UsersLookupByEmailRequest req) throws IOException, SlackApiException;
 
     UsersSetActiveResponse usersSetActive(UsersSetActiveRequest req) throws IOException, SlackApiException;
 

--- a/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
@@ -14,10 +14,7 @@ import com.github.seratch.jslack.api.methods.request.auth.AuthRevokeRequest;
 import com.github.seratch.jslack.api.methods.request.auth.AuthTestRequest;
 import com.github.seratch.jslack.api.methods.request.bots.BotsInfoRequest;
 import com.github.seratch.jslack.api.methods.request.channels.*;
-import com.github.seratch.jslack.api.methods.request.chat.ChatDeleteRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatMeMessageRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatUpdateRequest;
+import com.github.seratch.jslack.api.methods.request.chat.*;
 import com.github.seratch.jslack.api.methods.request.conversations.*;
 import com.github.seratch.jslack.api.methods.request.dialog.DialogOpenRequest;
 import com.github.seratch.jslack.api.methods.request.dnd.*;
@@ -61,10 +58,7 @@ import com.github.seratch.jslack.api.methods.response.auth.AuthRevokeResponse;
 import com.github.seratch.jslack.api.methods.response.auth.AuthTestResponse;
 import com.github.seratch.jslack.api.methods.response.bots.BotsInfoResponse;
 import com.github.seratch.jslack.api.methods.response.channels.*;
-import com.github.seratch.jslack.api.methods.response.chat.ChatDeleteResponse;
-import com.github.seratch.jslack.api.methods.response.chat.ChatMeMessageResponse;
-import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
-import com.github.seratch.jslack.api.methods.response.chat.ChatUpdateResponse;
+import com.github.seratch.jslack.api.methods.response.chat.*;
 import com.github.seratch.jslack.api.methods.response.conversations.*;
 import com.github.seratch.jslack.api.methods.response.dialog.DialogOpenResponse;
 import com.github.seratch.jslack.api.methods.response.dnd.*;
@@ -309,6 +303,23 @@ public class MethodsClientImpl implements MethodsClient {
         setIfNotNull("channel", req.getChannel(), form);
         setIfNotNull("text", req.getText(), form);
         return doPostForm(form, Methods.CHAT_ME_MESSAGE, ChatMeMessageResponse.class);
+    }
+
+    @Override
+    public ChatPostEphemeralResponse chatPostEphemeral(ChatPostEphemeralRequest req) throws IOException, SlackApiException {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("token", req.getToken(), form);
+        setIfNotNull("channel", req.getChannel(), form);
+        setIfNotNull("text", req.getText(), form);
+        setIfNotNull("user", req.getUser(), form);
+        setIfNotNull("as_user", req.isAsUser(), form);
+        if (req.getAttachments() != null) {
+            String json = GsonFactory.createSnakeCase().toJson(req.getAttachments());
+            form.add("attachments", json);
+        }
+        setIfNotNull("link_names", req.isLinkNames(), form);
+        setIfNotNull("parse", req.getParse(), form);
+        return doPostForm(form, Methods.CHAT_POST_EPHEMERAL, ChatPostEphemeralResponse.class);
     }
 
     @Override
@@ -1311,6 +1322,14 @@ public class MethodsClientImpl implements MethodsClient {
         setIfNotNull("token", req.getToken(), form);
         setIfNotNull("presence", req.getPresence(), form);
         return doPostForm(form, Methods.USERS_LIST, UsersListResponse.class);
+    }
+
+    @Override
+    public UsersLookupByEmailResponse usersLookupByEmail(UsersLookupByEmailRequest req) throws IOException, SlackApiException {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("token", req.getToken(), form);
+        setIfNotNull("email", req.getEmail(), form);
+        return doPostForm(form, Methods.USERS_LOOKUP_BY_EMAIL, UsersLookupByEmailResponse.class);
     }
 
     @Override

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatPostEphemeralRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatPostEphemeralRequest.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.api.methods.request.chat;
+
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+import com.github.seratch.jslack.api.model.Attachment;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class ChatPostEphemeralRequest implements SlackApiRequest {
+
+    private String token;
+    private String channel;
+    private String text;
+    private String user;
+    private boolean asUser=true;
+    private List<Attachment> attachments;
+    private boolean linkNames = true;
+    private String parse = "full";
+}

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersLookupByEmailRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/users/UsersLookupByEmailRequest.java
@@ -1,0 +1,13 @@
+package com.github.seratch.jslack.api.methods.request.users;
+
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UsersLookupByEmailRequest implements SlackApiRequest {
+
+    private String token;
+    private String email;
+}

--- a/src/main/java/com/github/seratch/jslack/api/methods/response/channels/UsersLookupByEmailResponse.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/response/channels/UsersLookupByEmailResponse.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.api.methods.response.channels;
+
+import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.Channel;
+import com.github.seratch.jslack.api.model.User;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class UsersLookupByEmailResponse implements SlackApiResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+
+    private User user;
+}

--- a/src/main/java/com/github/seratch/jslack/api/methods/response/chat/ChatPostEphemeralResponse.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/response/chat/ChatPostEphemeralResponse.java
@@ -1,0 +1,15 @@
+package com.github.seratch.jslack.api.methods.response.chat;
+
+import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import lombok.Data;
+
+@Data
+public class ChatPostEphemeralResponse implements SlackApiResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+
+    private String channel;
+    private String messageTs;
+}

--- a/src/test/java/com/github/seratch/jslack/Slack_channels_chat_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_channels_chat_Test.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.math.BigInteger;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -192,6 +191,4 @@ public class Slack_channels_chat_Test {
             assertThat(fetchedChannel.isArchived(), is(true));
         }
     }
-
-
 }

--- a/src/test/java/com/github/seratch/jslack/Slack_channels_chat_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_channels_chat_Test.java
@@ -2,20 +2,15 @@ package com.github.seratch.jslack;
 
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.request.channels.*;
-import com.github.seratch.jslack.api.methods.request.chat.ChatDeleteRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatMeMessageRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatUpdateRequest;
+import com.github.seratch.jslack.api.methods.request.chat.*;
 import com.github.seratch.jslack.api.methods.response.channels.*;
-import com.github.seratch.jslack.api.methods.response.chat.ChatDeleteResponse;
-import com.github.seratch.jslack.api.methods.response.chat.ChatMeMessageResponse;
-import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
-import com.github.seratch.jslack.api.methods.response.chat.ChatUpdateResponse;
+import com.github.seratch.jslack.api.methods.response.chat.*;
 import com.github.seratch.jslack.api.model.Channel;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.math.BigInteger;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -157,7 +152,6 @@ public class Slack_channels_chat_Test {
                     .build());
             assertThat(deleteResponse.isOk(), is(true));
         }
-
         {
             ChannelsLeaveResponse response = slack.methods().channelsLeave(ChannelsLeaveRequest.builder()
                     .token(token)
@@ -198,5 +192,6 @@ public class Slack_channels_chat_Test {
             assertThat(fetchedChannel.isArchived(), is(true));
         }
     }
+
 
 }

--- a/src/test/java/com/github/seratch/jslack/Slack_users_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_users_Test.java
@@ -2,9 +2,11 @@ package com.github.seratch.jslack;
 
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.request.users.*;
+import com.github.seratch.jslack.api.methods.response.channels.UsersLookupByEmailResponse;
 import com.github.seratch.jslack.api.methods.response.users.*;
 import com.github.seratch.jslack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
@@ -91,4 +93,17 @@ public class Slack_users_Test {
         }
     }
 
+    @Test
+    public void lookupByEMailSupported() throws IOException, SlackApiException {
+        String token = System.getenv("SLACK_BOT_TEST_API_TOKEN");
+        UsersListResponse usersListResponse = slack.methods().usersList(UsersListRequest.builder().token(token).presence(1).build());
+        List<User> users = usersListResponse.getMembers();
+        User randomUser = users.get(0);
+        String email = randomUser.getProfile().getEmail();
+
+        UsersLookupByEmailResponse response = slack.methods().usersLookupByEmail(UsersLookupByEmailRequest.builder().token(token).email(email).build());
+
+        Assert.assertTrue(response.isOk());
+        Assert.assertEquals(randomUser.getId(), response.getUser().getId());
+    }
 }


### PR DESCRIPTION
details for both endpoints to be found below. I added a test for users.lookupByEmail, but chat.postEphemeral was very hard (requires to specify an existing user and post to an existing channel. Didn't know what the CI setup is, so I found that this had too many assumptions)

* https://api.slack.com/methods/users.lookupByEmail
* https://api.slack.com/methods/chat.postEphemeral