### PR TITLE
Log errors, provide interfaces for custom close and error handlers

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/rtm/RTMClient.java
+++ b/src/main/java/com/github/seratch/jslack/api/rtm/RTMClient.java
@@ -18,6 +18,7 @@ public class RTMClient implements Closeable {
     private Session currentSession = null;
 
     private final List<RTMMessageHandler> messageHandlers = new ArrayList<>();
+    private final List<RTMErrorHandler> errorHandlers = new ArrayList<>();
 
     public RTMClient(String wssUrl) throws URISyntaxException {
         if (wssUrl == null) {
@@ -59,6 +60,10 @@ public class RTMClient implements Closeable {
     public void onError(Session session, Throwable reason) {
         log.error("session errored, exception is below", reason);
         this.currentSession = null;
+
+        errorHandlers.forEach(errorHandler -> {
+            errorHandler.handle(reason);
+        });
     }
 
     @OnMessage
@@ -75,6 +80,14 @@ public class RTMClient implements Closeable {
 
     public void removeMessageHandler(RTMMessageHandler messageHandler) {
         messageHandlers.remove(messageHandler);
+    }
+
+    public void addErrorHandler(RTMErrorHandler errorHandler) {
+        errorHandlers.add(errorHandler);
+    }
+
+    public void removeErrorHandler(RTMErrorHandler errorHandler) {
+        errorHandlers.remove(errorHandler);
     }
 
     public void sendMessage(String message) {

--- a/src/main/java/com/github/seratch/jslack/api/rtm/RTMClient.java
+++ b/src/main/java/com/github/seratch/jslack/api/rtm/RTMClient.java
@@ -19,6 +19,7 @@ public class RTMClient implements Closeable {
 
     private final List<RTMMessageHandler> messageHandlers = new ArrayList<>();
     private final List<RTMErrorHandler> errorHandlers = new ArrayList<>();
+    private final List<RTMCloseHandler> closeHandlers = new ArrayList<>();
 
     public RTMClient(String wssUrl) throws URISyntaxException {
         if (wssUrl == null) {
@@ -54,6 +55,10 @@ public class RTMClient implements Closeable {
     public void onClose(Session session, CloseReason reason) {
         log.debug("session closed: {}, reason: {}", session.getId(), reason.getReasonPhrase());
         this.currentSession = null;
+
+        closeHandlers.forEach(closeHandler -> {
+            closeHandler.handle(reason);
+        });
     }
 
     @OnError
@@ -88,6 +93,14 @@ public class RTMClient implements Closeable {
 
     public void removeErrorHandler(RTMErrorHandler errorHandler) {
         errorHandlers.remove(errorHandler);
+    }
+
+    public void addCloseHandler(RTMCloseHandler closeHandler) {
+        closeHandlers.add(closeHandler);
+    }
+
+    public void removeCloseHandler(RTMCloseHandler closeHandler) {
+        closeHandlers.remove(closeHandler);
     }
 
     public void sendMessage(String message) {

--- a/src/main/java/com/github/seratch/jslack/api/rtm/RTMClient.java
+++ b/src/main/java/com/github/seratch/jslack/api/rtm/RTMClient.java
@@ -55,6 +55,12 @@ public class RTMClient implements Closeable {
         this.currentSession = null;
     }
 
+    @OnError
+    public void onError(Session session, Throwable reason) {
+        log.error("session errored, exception is below", reason);
+        this.currentSession = null;
+    }
+
     @OnMessage
     public void onMessage(String message) {
         log.debug("message: {}", message);

--- a/src/main/java/com/github/seratch/jslack/api/rtm/RTMCloseHandler.java
+++ b/src/main/java/com/github/seratch/jslack/api/rtm/RTMCloseHandler.java
@@ -1,0 +1,10 @@
+package com.github.seratch.jslack.api.rtm;
+
+import javax.websocket.CloseReason;
+
+@FunctionalInterface
+public interface RTMCloseHandler {
+
+    void handle(CloseReason reason);
+
+}

--- a/src/main/java/com/github/seratch/jslack/api/rtm/RTMErrorHandler.java
+++ b/src/main/java/com/github/seratch/jslack/api/rtm/RTMErrorHandler.java
@@ -1,0 +1,8 @@
+package com.github.seratch.jslack.api.rtm;
+
+@FunctionalInterface
+public interface RTMErrorHandler {
+
+    void handle(Throwable reason);
+
+}


### PR DESCRIPTION
Hi there!

While using jslack for a Slack bot, we noticed that the bot will periodically just "fall over" with no indication of why in the logs. Messages just stop arriving and it stops responding. Taking a look at the implementation of `RTMClient` we had relatively few hooks to determine what was going on. We also noticed that `RTMClient` didn't attach an `OnError` handler.

This PR:

* Adds an `OnError` handler to the `RTMClient`
* Provides for a `RTMErrorHandler` and `RTMCloseHandler` to be provided so that applications that depend on jslack have a clean interface to attach custom logic into the close / error pipelines.

Please let me know if there are any questions or concerns with this approach. :)