### PR TITLE
Make subclassing MethodsClientImpl easier

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
@@ -1421,7 +1421,7 @@ public class MethodsClientImpl implements MethodsClient {
         }
     }
 
-    private <T> T doPostForm(
+    protected <T> T doPostForm(
             FormBody.Builder form,
             String endpoint,
             Class<T> clazz) throws IOException, SlackApiException {
@@ -1429,7 +1429,7 @@ public class MethodsClientImpl implements MethodsClient {
         return SlackHttpClient.buildJsonResponse(response, clazz);
     }
 
-    private <T> T doPostFormWithToken(
+    protected <T> T doPostFormWithToken(
             FormBody.Builder form,
             String endpoint,
             String token,
@@ -1438,7 +1438,7 @@ public class MethodsClientImpl implements MethodsClient {
         return SlackHttpClient.buildJsonResponse(response, clazz);
     }
 
-    private <T> T doPostMultipart(
+    protected <T> T doPostMultipart(
             MultipartBody.Builder form,
             String endpoint,
             String token,


### PR DESCRIPTION
Changes the access modifiers on MethodsClientImpl's three private doPost methods to protected This makes it much easier to extend. The issue is fully described here #75.

Fixes #75