### PR TITLE
fix some build warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jdk:
   - oraclejdk9
   - oraclejdk10
 install: echo 'skipped'
-script: ./mvnw test-compile
+script: ./mvnw test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jdk:
   - oraclejdk9
   - oraclejdk10
 install: echo 'skipped'
-script: ./mvnw test
+script: ./mvnw test-compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,9 @@ jdk:
   - oraclejdk8
   - oraclejdk9
   - oraclejdk10
+cache:
+  directories:
+  # cache maven directory for faster and more reliable build
+  - $HOME/.m2
 install: echo 'skipped'
 script: ./mvnw test-compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
+#  - oraclejdk9
+#  - oraclejdk10
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ jdk:
   - oraclejdk10
 cache:
   directories:
-  # cache maven directory for faster and more reliable build
   - $HOME/.m2
 install: echo 'skipped'
 script: ./mvnw test-compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-#  - oraclejdk9
+  - oraclejdk9
 #  - oraclejdk10
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>
                     <execution>
@@ -110,7 +109,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkMode>pertest</forkMode>
@@ -133,7 +131,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
@@ -145,14 +142,13 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.1</version>
                 <configuration>
                     <goals>deploy,site-deploy</goals>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -110,6 +111,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.12.4</version>
                 <configuration>
                     <forkMode>pertest</forkMode>
                     <argLine>-Xms64m -Xmx128m</argLine>
@@ -118,6 +120,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -126,12 +129,14 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>2.6</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
- remove default plugin **groupId** for default plugins
- set fixed plugin versions for more stable build, otherwise using "current plugin version" may break over time.