### PR TITLE
Fixes #88 - Message misses "edited" field

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/model/Message.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Message.java
@@ -26,6 +26,7 @@ public class Message {
     private Icon icons;
     private File file;
 
+    // field exists only if the message was edited
     private Edited edited;
 
     // https://api.slack.com/docs/message-link-unfurling
@@ -38,14 +39,15 @@ public class Message {
     // this field exists only when posting the message with "reply_broadcast": true
     private MessageRoot root;
 
-    /**
-     * The root message information of a "thread_broadcast" message.
-     */
     @Data
     public static class Edited {
         private String user;
         private String ts;
     }
+
+    /**
+     * The root message information of a "thread_broadcast" message.
+     */
 
     @Data
     public static class MessageRoot {

--- a/src/main/java/com/github/seratch/jslack/api/model/Message.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Message.java
@@ -48,7 +48,6 @@ public class Message {
     /**
      * The root message information of a "thread_broadcast" message.
      */
-
     @Data
     public static class MessageRoot {
         private String text;

--- a/src/main/java/com/github/seratch/jslack/api/model/Message.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Message.java
@@ -26,6 +26,8 @@ public class Message {
     private Icon icons;
     private File file;
 
+    private Edited edited;
+
     // https://api.slack.com/docs/message-link-unfurling
     private boolean unfurlLinks;
     private boolean unfurlMedia;
@@ -39,6 +41,12 @@ public class Message {
     /**
      * The root message information of a "thread_broadcast" message.
      */
+    @Data
+    public static class Edited {
+        private String user;
+        private String ts;
+    }
+
     @Data
     public static class MessageRoot {
         private String text;

--- a/src/test/java/com/github/seratch/jslack/Slack_channels_chat_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_channels_chat_Test.java
@@ -258,6 +258,35 @@ public class Slack_channels_chat_Test {
             assertThat(response.isOk(), is(true));
         }
 
+        //--------------Edited test---------
+        Message lastMessage = slack.methods().conversationsHistory(
+                ConversationsHistoryRequest.builder()
+                        .token(token)
+                        .channel(channel.getId())
+                        .limit(1)
+                        .build()
+        ).getMessages().get(0);
+
+        ChatUpdateResponse updateMessage = slack.methods().chatUpdate(ChatUpdateRequest.builder()
+                .channel(channel.getId())
+                .token(token)
+                .ts(lastMessage.getTs())
+                .text("Updated text" + lastMessage.getText())
+                .build());
+        assertThat(updateMessage.isOk(), is(true));
+
+        ConversationsHistoryResponse conversationsHistoryResponse = slack.methods().conversationsHistory(
+                ConversationsHistoryRequest.builder()
+                        .token(token)
+                        .channel(channel.getId())
+                        .limit(1)
+                        .build()
+        );
+        assertFalse(conversationsHistoryResponse.getMessages().isEmpty());
+        assertNotNull(conversationsHistoryResponse.getMessages().get(0).getEdited());
+        assertNotEquals(conversationsHistoryResponse.getMessages().get(0).getEdited().getTs(), lastMessage.getTs());
+        //--------------------
+
         {
             ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
                     .channel(channel.getId())


### PR DESCRIPTION
Fixes #88 - Message misses "edited" field

• add "edited" field to Message
• add test