### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.11.0</version>
+            <version>3.13.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
+            <version>1.18.6</version>
             <scope>provided</scope>
         </dependency>
 
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.glassfish.tyrus.bundles</groupId>
             <artifactId>tyrus-standalone-client</artifactId>
-            <version>1.14</version>
+            <version>1.15</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
```
[INFO]   ch.qos.logback:logback-classic ................. 1.2.3 -> 1.3.0-alpha4
[INFO]   com.squareup.okhttp3:okhttp ......................... 3.11.0 -> 3.13.1
[INFO]   junit:junit ...................................... 4.12 -> 4.13-beta-2
[INFO]   org.glassfish.tyrus.bundles:tyrus-standalone-client ..... 1.14 -> 1.15
[INFO]   org.projectlombok:lombok ............................ 1.18.2 -> 1.18.6
[INFO]   org.slf4j:slf4j-api ............................ 1.7.25 -> 1.8.0-beta2
```