### PR TITLE
Adds Block Kit support

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatPostMessageRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatPostMessageRequest.java
@@ -2,6 +2,8 @@ package com.github.seratch.jslack.api.methods.request.chat;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+
 import lombok.*;
 
 import java.util.List;
@@ -50,6 +52,11 @@ public class ChatPostMessageRequest implements SlackApiRequest {
      * Find and link channel names and usernames.
      */
     private boolean linkNames;
+
+    /**
+     * A JSON-based array of structured blocks, presented as a URL-encoded string.
+     */
+    private List<LayoutBlock> blocks;
 
     /**
      * A JSON-based array of structured attachments, presented as a URL-encoded string.

--- a/src/main/java/com/github/seratch/jslack/api/model/block/ActionsBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/ActionsBlock.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.api.model.block;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.seratch.jslack.api.model.block.element.BlockElement;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#actions
+ */
+@Data
+@Builder
+public class ActionsBlock implements LayoutBlock {
+    private final String type = "actions";
+    @Builder.Default
+    private List<BlockElement> elements = new ArrayList<>();
+    private String blockId;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/ContextBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/ContextBlock.java
@@ -1,0 +1,20 @@
+package com.github.seratch.jslack.api.model.block;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#context
+ */
+@Data
+@Builder
+public class ContextBlock implements LayoutBlock {
+    private final String type = "context";
+    @Builder.Default
+    private List<ContextBlockElement> elements = new ArrayList<>();
+    private String blockId;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/ContextBlockElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/ContextBlockElement.java
@@ -1,0 +1,12 @@
+package com.github.seratch.jslack.api.model.block;
+
+import com.github.seratch.jslack.api.model.block.composition.TextObject;
+import com.github.seratch.jslack.api.model.block.element.ImageElement;
+
+/**
+ * Specific interface to make context layout blocks' {@link ContextBlock
+ * elements} type-safe, because ContextBlock can only contain
+ * {@link ImageElement} and {@link TextObject} elements
+ */
+public interface ContextBlockElement {
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/DividerBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/DividerBlock.java
@@ -1,0 +1,14 @@
+package com.github.seratch.jslack.api.model.block;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#divider
+ */
+@Data
+@Builder
+public class DividerBlock implements LayoutBlock {
+    private final String type = "divider";
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/ImageBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/ImageBlock.java
@@ -1,0 +1,20 @@
+package com.github.seratch.jslack.api.model.block;
+
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#image
+ */
+@Data
+@Builder
+public class ImageBlock implements LayoutBlock {
+    private final String type = "image";
+    private String imageUrl;
+    private String altText;
+    private PlainTextObject title;
+    private String blockId;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/LayoutBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/LayoutBlock.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.api.model.block;
+
+/**
+ * Block Kit is a new UI framework that offers you more control and flexibility
+ * when building messages for Slack. Comprised of "blocks," stackable bits of
+ * message UI, you can customize the order and appearance of information
+ * delivered by your app in Slack.
+ * 
+ * @see <a href="https://api.slack.com/block-kit">Block Kit Guide</a>
+ * @see <a href="https://api.slack.com/reference/messaging/blocks">Block Kit Reference</a>
+ */
+public interface LayoutBlock {
+    /**
+     * Determines the type of layout block, e.g. section, divider, context, actions
+     * and image.
+     */
+    public String getType();
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/SectionBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/SectionBlock.java
@@ -1,0 +1,23 @@
+package com.github.seratch.jslack.api.model.block;
+
+import java.util.List;
+
+import com.github.seratch.jslack.api.model.block.composition.TextObject;
+import com.github.seratch.jslack.api.model.block.element.BlockElement;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#section
+ */
+@Data
+@Builder
+public class SectionBlock implements LayoutBlock {
+    private final String type = "section";
+    private TextObject text;
+    private String blockId;
+    private List<TextObject> fields;
+    private BlockElement accessory;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/ConfirmationDialogObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/ConfirmationDialogObject.java
@@ -1,0 +1,20 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#confirm
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfirmationDialogObject {
+    private PlainTextObject title;
+    private TextObject text;
+    private PlainTextObject confirm;
+    private PlainTextObject deny;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/MarkdownTextObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/MarkdownTextObject.java
@@ -1,0 +1,21 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#text
+ */
+@Data
+@Builder
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarkdownTextObject extends TextObject {
+    private final String type = "mrkdwn";
+    private String text;
+    private Boolean verbatim;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/OptionGroupObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/OptionGroupObject.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#option-group
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OptionGroupObject {
+	private PlainTextObject label;
+	private OptionObject[] options;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/OptionObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/OptionObject.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#option
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OptionObject {
+    private PlainTextObject text;
+    private String value;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/PlainTextObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/PlainTextObject.java
@@ -1,0 +1,21 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#text
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder(toBuilder=true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlainTextObject extends TextObject {
+    private final String type = "plain_text";
+    private String text;
+    private Boolean emoji;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/TextObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/TextObject.java
@@ -1,0 +1,9 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import com.github.seratch.jslack.api.model.block.ContextBlockElement;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#text
+ */
+public abstract class TextObject implements ContextBlockElement {
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/BlockElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/BlockElement.java
@@ -1,0 +1,9 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+/**
+ * Base block element for adding interactive components to Slack messages.
+ * 
+ * https://api.slack.com/reference/messaging/block-elements
+ */
+public abstract class BlockElement {
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ButtonElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ButtonElement.java
@@ -1,0 +1,27 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#button
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ButtonElement extends BlockElement {
+    private final String type = "button";
+    private PlainTextObject text;
+    private String actionId;
+    private String url;
+    private String value;
+    private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ChannelsSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ChannelsSelectElement.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#channels-select
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChannelsSelectElement extends BlockElement {
+    private final String type = "channels_select";
+    private PlainTextObject placeholder;
+    private String actionId;
+    private String initialChannel;
+    private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ConversationsSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ConversationsSelectElement.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#conversations-select
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConversationsSelectElement extends BlockElement {
+    private final String type = "conversations_select";
+    private PlainTextObject placeholder;
+    private String actionId;
+    private String initialConversation;
+    private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/DatePickerElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/DatePickerElement.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#datepicker
+ */
+@Data
+@EqualsAndHashCode(callSuper=true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DatePickerElement extends BlockElement {
+	private final String type = "datepicker";
+	private String actionId;
+	private PlainTextObject placeholder;
+	private String initialDate;
+	private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ExternalSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ExternalSelectElement.java
@@ -1,0 +1,28 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.OptionObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#external-select
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExternalSelectElement extends BlockElement {
+    private final String type = "external_select";
+    private PlainTextObject placeholder;
+    private String actionId;
+    private OptionObject initialOption;
+    private Integer minQueryLength;
+    private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ImageElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ImageElement.java
@@ -1,0 +1,23 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.ContextBlockElement;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#image
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageElement extends BlockElement implements ContextBlockElement {
+    private final String type = "image";
+    private String imageUrl;
+    private String altText;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/OverflowMenuElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/OverflowMenuElement.java
@@ -1,0 +1,25 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.OptionObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#overflow
+ */
+@Data
+@EqualsAndHashCode(callSuper=true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OverflowMenuElement extends BlockElement {
+	private final String type = "overflow";
+	private String actionId;
+	private OptionObject[] options;
+	private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/StaticSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/StaticSelectElement.java
@@ -1,0 +1,30 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.OptionGroupObject;
+import com.github.seratch.jslack.api.model.block.composition.OptionObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#static-select
+ */
+@Data
+@EqualsAndHashCode(callSuper=true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StaticSelectElement extends BlockElement {
+	private final String type = "static_select";
+	private PlainTextObject placeholder;
+	private String actionId;
+	private OptionObject[] options;
+	private OptionGroupObject[] optionGroups;
+	private OptionObject initialOption;
+	private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/UsersSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/UsersSelectElement.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#users-select
+ */
+@Data
+@EqualsAndHashCode(callSuper=true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsersSelectElement extends BlockElement {
+	private final String type = "users_select";
+	private PlainTextObject placeholder;
+	private String actionId;
+	private String initialUser;
+	private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/webhook/Payload.java
+++ b/src/main/java/com/github/seratch/jslack/api/webhook/Payload.java
@@ -1,14 +1,17 @@
 package com.github.seratch.jslack.api.webhook;
 
+import java.util.List;
+
 import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * https://api.slack.com/incoming-webhooks
+ * 
+ * Implementation of <a href="https://api.slack.com/reference/messaging/payload">Message Payloads</a>
  */
 @Data
 @Builder
@@ -44,9 +47,13 @@ public class Payload {
     private String iconEmoji;
 
     /**
-     * You can use Slack's standard message markup to add simple formatting to your messages.
-     * You can also use message attachments to display richly-formatted message blocks.
+     * An array of {@link LayoutBlock layout blocks} in the same format as described in the 
+     * <a href="https://api.slack.com/messaging/composing/layouts#getting-started">layout block guide</a>.
      */
-    private List<Attachment> attachments = new ArrayList<>();
-
+    private List<LayoutBlock> blocks;
+    
+    /**
+     * An array of legacy secondary attachments. We recommend you use {@link #blocks} instead.
+     */
+    private List<Attachment> attachments;
 }


### PR DESCRIPTION
This is my first code contribution to jslack. I expect that my first attempt
probably has some issues and that my choices may not be yours. You are
welcome to provide feedback, ask for modifications or modify the code.

I submit this patch under the same license as jslack (currently MIT) and
transfer ownership of the code to @seratch. 

The description of this pull request:

Slack has created a new (improved?) message format based on layout
blocks that allow for semi-advanced rich formatting called Block Kit:

https://api.slack.com/block-kit

This commit adds support for all elements, while retaining API
compatibility with the old API (which is discouraged by the Slack
documentation https://api.slack.com/messaging/composing/layouts#secondary-attachments)

The new BlockMessagePayload builder allows you to start crafting your
message using layout blocks.

The canonical example from the Block Kit Builder, built with the jslack
model:

```
BlockMessagePayload payload = BlockMessagePayload.builder()
	.blocks(Arrays.asList(
		SectionBlock.builder()
			.text(MarkdownTextObject.builder()
				.text("Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where you'd like to take the Paper Company investors to dinner tonight.\n\n *Please select a restaurant:*")
				.build())
			.build(),
		DividerBlock.builder().build(),
		SectionBlock.builder()
			.text(MarkdownTextObject.builder()
				.text("*Farmhouse Thai Cuisine*\n:star::star::star::star: 1528 reviews\n They do have some vegan options, like the roti and curry, plus they have a ton of salad stuff and noodles can be ordered without meat!! They have something for everyone here")
				.build())
			.accessory(ImageElement.builder()
				.imageUrl("https://s3-media3.fl.yelpcdn.com/bphoto/c7ed05m9lC2EmA3Aruue7A/o.jpg")
				.altText("alt text for image")
				.build())
			.build()
		))
	.channel("#test")
	.threadTs("1552173794.000500")
	.build();
```

Fixes #96