### PR TITLE
Removes specific workspace assumptions from tests

### DIFF
--- a/src/test/java/com/github/seratch/jslack/Slack_bots_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_bots_Test.java
@@ -2,11 +2,15 @@ package com.github.seratch.jslack;
 
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.request.bots.BotsInfoRequest;
+import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
 import com.github.seratch.jslack.api.methods.response.bots.BotsInfoResponse;
+import com.github.seratch.jslack.api.model.User;
+
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -19,10 +23,26 @@ public class Slack_bots_Test {
     @Test
     public void botsInfo() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        String bot = "B03E94MLG"; // hard coded
-        BotsInfoResponse response = slack.methods().botsInfo(BotsInfoRequest.builder().token(token).bot(bot).build());
+
+        List<User> users = slack.methods()
+            .usersList(UsersListRequest.builder()
+                .token(token)
+                .build())
+            .getMembers();
+        User user = users.stream()
+            .filter(u -> u.isBot() && !"USLACKBOT".equals(u.getId()))
+            .findFirst()
+            .get();
+        String bot = user.getProfile()
+            .getBotId();
+
+        BotsInfoResponse response = slack.methods()
+            .botsInfo(BotsInfoRequest.builder()
+                .token(token)
+                .bot(bot)
+                .build());
+        assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getBot(), is(notNullValue()));
     }
-
 }

--- a/src/test/java/com/github/seratch/jslack/Slack_conversations_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_conversations_Test.java
@@ -170,15 +170,18 @@ public class Slack_conversations_Test {
             assertThat(membersResponse.getMembers().isEmpty(), is(false));
             assertThat(membersResponse.getResponseMetadata(), is(notNullValue()));
 
-            UsersListResponse usersListResponse = slack.methods().usersList(
-                    UsersListRequest.builder().token(token).build());
-            String invitee = null;
-            for (User user : usersListResponse.getMembers()) {
-                if (!membersResponse.getMembers().contains(user.getId())) {
-                    invitee = user.getId();
-                    break;
-                }
-            }
+            UsersListResponse usersListResponse = slack.methods()
+                    .usersList(UsersListRequest.builder()
+                            .token(token)
+                            .build());
+            String invitee = usersListResponse.getMembers()
+                    .stream()
+                    .filter(u -> !"USLACKBOT".equals(u.getId())
+                            && !membersResponse.getMembers()
+                                    .contains(u.getId()))
+                    .findFirst()
+                    .map(User::getId)
+                    .get();
 
             ConversationsInviteResponse inviteResponse = slack.methods().conversationsInvite(
                     ConversationsInviteRequest.builder()

--- a/src/test/java/com/github/seratch/jslack/Slack_team_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_team_Test.java
@@ -11,11 +11,15 @@ import com.github.seratch.jslack.api.methods.response.team.TeamBillableInfoRespo
 import com.github.seratch.jslack.api.methods.response.team.TeamInfoResponse;
 import com.github.seratch.jslack.api.methods.response.team.TeamIntegrationLogsResponse;
 import com.github.seratch.jslack.api.methods.response.team.profile.TeamProfileGetResponse;
+import com.github.seratch.jslack.api.model.User;
+
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+
+import java.util.List;
 
 @Slf4j
 public class Slack_team_Test {
@@ -41,11 +45,14 @@ public class Slack_team_Test {
 
     @Test
     public void teamBillableInfo() throws Exception {
-        String user = slack.methods().usersList(UsersListRequest.builder().token(token).build()).getMembers().get(0).getId();
+        List<User> users = slack.methods().usersList(UsersListRequest.builder().token(token).build()).getMembers();
+        User user = users.stream().filter(u -> !u.isBot() && !"USLACKBOT".equals(u.getId())).findFirst().get();
+        String userId = user.getId();
         TeamBillableInfoResponse response = slack.methods().teamBillableInfo(TeamBillableInfoRequest.builder()
                 .token(token)
-                .user(user)
+                .user(userId)
                 .build());
+        assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 


### PR DESCRIPTION
Some tests failed because the slackbot user was selected instead of an
actual user or bot. These tests have been fixed by looking up an actual
user or bot and using that for the test case.

Fixes #100