### PR TITLE
Adds Block Kit support

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
@@ -350,6 +350,10 @@ public class MethodsClientImpl implements MethodsClient {
         setIfNotNull("parse", req.getParse(), form);
         setIfNotNull("link_names", req.isLinkNames(), form);
         setIfNotNull("mrkdwn", req.isMrkdwn(), form);
+        if (req.getBlocks() != null) {
+            String json = GsonFactory.createSnakeCase().toJson(req.getBlocks());
+            form.add("blocks", json);
+        }
         if (req.getAttachments() != null) {
             String json = GsonFactory.createSnakeCase().toJson(req.getAttachments());
             form.add("attachments", json);

--- a/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatPostMessageRequest.java
+++ b/src/main/java/com/github/seratch/jslack/api/methods/request/chat/ChatPostMessageRequest.java
@@ -2,6 +2,8 @@ package com.github.seratch.jslack.api.methods.request.chat;
 
 import com.github.seratch.jslack.api.methods.SlackApiRequest;
 import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+
 import lombok.*;
 
 import java.util.List;
@@ -50,6 +52,11 @@ public class ChatPostMessageRequest implements SlackApiRequest {
      * Find and link channel names and usernames.
      */
     private boolean linkNames;
+
+    /**
+     * A JSON-based array of structured blocks, presented as a URL-encoded string.
+     */
+    private List<LayoutBlock> blocks;
 
     /**
      * A JSON-based array of structured attachments, presented as a URL-encoded string.

--- a/src/main/java/com/github/seratch/jslack/api/model/Message.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Message.java
@@ -1,9 +1,11 @@
 package com.github.seratch.jslack.api.model;
 
-import com.google.gson.annotations.SerializedName;
-import lombok.Data;
-
 import java.util.List;
+
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Data;
 
 @Data
 public class Message {
@@ -12,6 +14,7 @@ public class Message {
     private String channel;
     private String user;
     private String text;
+    private List<LayoutBlock> blocks;
     private List<Attachment> attachments;
     private String ts;
     private String threadTs;

--- a/src/main/java/com/github/seratch/jslack/api/model/block/ActionsBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/ActionsBlock.java
@@ -1,0 +1,25 @@
+package com.github.seratch.jslack.api.model.block;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.seratch.jslack.api.model.block.element.BlockElement;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#actions
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActionsBlock implements LayoutBlock {
+    private final String type = "actions";
+    @Builder.Default
+    private List<BlockElement> elements = new ArrayList<>();
+    private String blockId;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/ContextBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/ContextBlock.java
@@ -1,0 +1,23 @@
+package com.github.seratch.jslack.api.model.block;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#context
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContextBlock implements LayoutBlock {
+    private final String type = "context";
+    @Builder.Default
+    private List<ContextBlockElement> elements = new ArrayList<>();
+    private String blockId;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/ContextBlockElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/ContextBlockElement.java
@@ -1,0 +1,16 @@
+package com.github.seratch.jslack.api.model.block;
+
+import com.github.seratch.jslack.api.model.block.composition.TextObject;
+import com.github.seratch.jslack.api.model.block.element.ImageElement;
+
+/**
+ * Specific interface to make context layout blocks' {@link ContextBlock
+ * elements} type-safe, because ContextBlock can only contain
+ * {@link ImageElement} and {@link TextObject} elements.
+ * 
+ * @see Slack Block Kit Reference: <a href=
+ *      "https://api.slack.com/reference/messaging/blocks#context">Context
+ *      Block's elements</a>
+ */
+public interface ContextBlockElement {
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/DividerBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/DividerBlock.java
@@ -1,0 +1,15 @@
+package com.github.seratch.jslack.api.model.block;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#divider
+ */
+@Data
+@Builder
+@NoArgsConstructor
+public class DividerBlock implements LayoutBlock {
+    private final String type = "divider";
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/ImageBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/ImageBlock.java
@@ -1,0 +1,23 @@
+package com.github.seratch.jslack.api.model.block;
+
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#image
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageBlock implements LayoutBlock {
+    private final String type = "image";
+    private String imageUrl;
+    private String altText;
+    private PlainTextObject title;
+    private String blockId;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/LayoutBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/LayoutBlock.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.api.model.block;
+
+/**
+ * Block Kit is a new UI framework that offers you more control and flexibility
+ * when building messages for Slack. Comprised of "blocks," stackable bits of
+ * message UI, you can customize the order and appearance of information
+ * delivered by your app in Slack.
+ * 
+ * @see <a href="https://api.slack.com/block-kit">Block Kit Guide</a>
+ * @see <a href="https://api.slack.com/reference/messaging/blocks">Block Kit Reference</a>
+ */
+public interface LayoutBlock {
+    /**
+     * Determines the type of layout block, e.g. section, divider, context, actions
+     * and image.
+     */
+    public String getType();
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/SectionBlock.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/SectionBlock.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.block;
+
+import java.util.List;
+
+import com.github.seratch.jslack.api.model.block.composition.TextObject;
+import com.github.seratch.jslack.api.model.block.element.BlockElement;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#section
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SectionBlock implements LayoutBlock {
+    private final String type = "section";
+    private TextObject text;
+    private String blockId;
+    private List<TextObject> fields;
+    private BlockElement accessory;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/ConfirmationDialogObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/ConfirmationDialogObject.java
@@ -1,0 +1,20 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#confirm
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfirmationDialogObject {
+    private PlainTextObject title;
+    private TextObject text;
+    private PlainTextObject confirm;
+    private PlainTextObject deny;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/MarkdownTextObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/MarkdownTextObject.java
@@ -1,0 +1,21 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#text
+ */
+@Data
+@Builder
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarkdownTextObject extends TextObject {
+    private final String type = "mrkdwn";
+    private String text;
+    private Boolean verbatim;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/OptionGroupObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/OptionGroupObject.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#option-group
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OptionGroupObject {
+	private PlainTextObject label;
+	private OptionObject[] options;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/OptionObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/OptionObject.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#option
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OptionObject {
+    private PlainTextObject text;
+    private String value;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/PlainTextObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/PlainTextObject.java
@@ -1,0 +1,21 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#text
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder(toBuilder=true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlainTextObject extends TextObject {
+    private final String type = "plain_text";
+    private String text;
+    private Boolean emoji;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/composition/TextObject.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/composition/TextObject.java
@@ -1,0 +1,9 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import com.github.seratch.jslack.api.model.block.ContextBlockElement;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#text
+ */
+public abstract class TextObject implements ContextBlockElement {
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/BlockElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/BlockElement.java
@@ -1,0 +1,9 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+/**
+ * Base block element for adding interactive components to Slack messages.
+ * 
+ * https://api.slack.com/reference/messaging/block-elements
+ */
+public abstract class BlockElement {
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ButtonElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ButtonElement.java
@@ -1,0 +1,27 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#button
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ButtonElement extends BlockElement {
+    private final String type = "button";
+    private PlainTextObject text;
+    private String actionId;
+    private String url;
+    private String value;
+    private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ChannelsSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ChannelsSelectElement.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#channels-select
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChannelsSelectElement extends BlockElement {
+    private final String type = "channels_select";
+    private PlainTextObject placeholder;
+    private String actionId;
+    private String initialChannel;
+    private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ConversationsSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ConversationsSelectElement.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#conversations-select
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConversationsSelectElement extends BlockElement {
+    private final String type = "conversations_select";
+    private PlainTextObject placeholder;
+    private String actionId;
+    private String initialConversation;
+    private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/DatePickerElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/DatePickerElement.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#datepicker
+ */
+@Data
+@EqualsAndHashCode(callSuper=true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DatePickerElement extends BlockElement {
+	private final String type = "datepicker";
+	private String actionId;
+	private PlainTextObject placeholder;
+	private String initialDate;
+	private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ExternalSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ExternalSelectElement.java
@@ -1,0 +1,28 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.OptionObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#external-select
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExternalSelectElement extends BlockElement {
+    private final String type = "external_select";
+    private PlainTextObject placeholder;
+    private String actionId;
+    private OptionObject initialOption;
+    private Integer minQueryLength;
+    private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/ImageElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/ImageElement.java
@@ -1,0 +1,23 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.ContextBlockElement;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#image
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageElement extends BlockElement implements ContextBlockElement {
+    private final String type = "image";
+    private String imageUrl;
+    private String altText;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/OverflowMenuElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/OverflowMenuElement.java
@@ -1,0 +1,25 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.OptionObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#overflow
+ */
+@Data
+@EqualsAndHashCode(callSuper=true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OverflowMenuElement extends BlockElement {
+	private final String type = "overflow";
+	private String actionId;
+	private OptionObject[] options;
+	private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/StaticSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/StaticSelectElement.java
@@ -1,0 +1,30 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.OptionGroupObject;
+import com.github.seratch.jslack.api.model.block.composition.OptionObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#static-select
+ */
+@Data
+@EqualsAndHashCode(callSuper=true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StaticSelectElement extends BlockElement {
+	private final String type = "static_select";
+	private PlainTextObject placeholder;
+	private String actionId;
+	private OptionObject[] options;
+	private OptionGroupObject[] optionGroups;
+	private OptionObject initialOption;
+	private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/block/element/UsersSelectElement.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/block/element/UsersSelectElement.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import com.github.seratch.jslack.api.model.block.composition.ConfirmationDialogObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/block-elements#users-select
+ */
+@Data
+@EqualsAndHashCode(callSuper=true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsersSelectElement extends BlockElement {
+	private final String type = "users_select";
+	private PlainTextObject placeholder;
+	private String actionId;
+	private String initialUser;
+	private ConfirmationDialogObject confirm;
+}

--- a/src/main/java/com/github/seratch/jslack/api/webhook/Payload.java
+++ b/src/main/java/com/github/seratch/jslack/api/webhook/Payload.java
@@ -1,14 +1,17 @@
 package com.github.seratch.jslack.api.webhook;
 
+import java.util.List;
+
 import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * https://api.slack.com/incoming-webhooks
+ * 
+ * Implementation of <a href="https://api.slack.com/reference/messaging/payload">Message Payloads</a>
  */
 @Data
 @Builder
@@ -44,9 +47,13 @@ public class Payload {
     private String iconEmoji;
 
     /**
-     * You can use Slack's standard message markup to add simple formatting to your messages.
-     * You can also use message attachments to display richly-formatted message blocks.
+     * An array of {@link LayoutBlock layout blocks} in the same format as described in the 
+     * <a href="https://api.slack.com/messaging/composing/layouts#getting-started">layout block guide</a>.
      */
-    private List<Attachment> attachments = new ArrayList<>();
-
+    private List<LayoutBlock> blocks;
+    
+    /**
+     * An array of legacy secondary attachments. We recommend you use {@link #blocks} instead.
+     */
+    private List<Attachment> attachments;
 }

--- a/src/main/java/com/github/seratch/jslack/common/json/GsonBlockElementFactory.java
+++ b/src/main/java/com/github/seratch/jslack/common/json/GsonBlockElementFactory.java
@@ -1,0 +1,73 @@
+package com.github.seratch.jslack.common.json;
+
+import java.lang.reflect.Type;
+
+import com.github.seratch.jslack.api.model.block.element.BlockElement;
+import com.github.seratch.jslack.api.model.block.element.ButtonElement;
+import com.github.seratch.jslack.api.model.block.element.ChannelsSelectElement;
+import com.github.seratch.jslack.api.model.block.element.ConversationsSelectElement;
+import com.github.seratch.jslack.api.model.block.element.DatePickerElement;
+import com.github.seratch.jslack.api.model.block.element.ExternalSelectElement;
+import com.github.seratch.jslack.api.model.block.element.ImageElement;
+import com.github.seratch.jslack.api.model.block.element.OverflowMenuElement;
+import com.github.seratch.jslack.api.model.block.element.StaticSelectElement;
+import com.github.seratch.jslack.api.model.block.element.UsersSelectElement;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Factory for deserializing BlockKit 'block elements' (buttons, selects,
+ * images, menus) from a {@link com.github.seratch.jslack.api.model.Message chat
+ * message response}.
+ * 
+ * @see <a href=
+ *      "https://api.slack.com/reference/messaging/block-elements">Block
+ *      Elements documentation</a>
+ */
+public class GsonBlockElementFactory implements JsonDeserializer<BlockElement>, JsonSerializer<BlockElement> {
+    @Override
+    public BlockElement deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        final JsonObject jsonObject = json.getAsJsonObject();
+        final JsonPrimitive prim = (JsonPrimitive) jsonObject.get("type");
+        final String className = prim.getAsString();
+        final Class<? extends BlockElement> clazz = getContextBlockElementClassInstance(className);
+        return context.deserialize(jsonObject, clazz);
+    }
+
+    @Override
+    public JsonElement serialize(BlockElement src, Type typeOfSrc, JsonSerializationContext context) {
+        return context.serialize(src);
+    }
+
+    private Class<? extends BlockElement> getContextBlockElementClassInstance(String className) {
+        switch (className) {
+        case "button":
+            return ButtonElement.class;
+        case "image":
+            return ImageElement.class;
+        case "channels_select":
+            return ChannelsSelectElement.class;
+        case "users_select":
+            return UsersSelectElement.class;
+        case "external_select":
+            return ExternalSelectElement.class;
+        case "conversations_select":
+            return ConversationsSelectElement.class;
+        case "static_select":
+            return StaticSelectElement.class;
+        case "overflow":
+            return OverflowMenuElement.class;
+        case "datepicker":
+            return DatePickerElement.class;
+        default:
+            throw new JsonParseException("Unknown context block element type: " + className);
+        }
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/common/json/GsonContextBlockElementFactory.java
+++ b/src/main/java/com/github/seratch/jslack/common/json/GsonContextBlockElementFactory.java
@@ -1,0 +1,59 @@
+package com.github.seratch.jslack.common.json;
+
+import java.lang.reflect.Type;
+
+import com.github.seratch.jslack.api.model.block.ContextBlockElement;
+import com.github.seratch.jslack.api.model.block.composition.MarkdownTextObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+import com.github.seratch.jslack.api.model.block.element.ImageElement;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Factory for deserializing BlockKit 'context block' elements from a
+ * {@link com.github.seratch.jslack.api.model.Message chat message response}.
+ * 
+ * @see <a href=
+ *      "https://api.slack.com/reference/messaging/blocks#context">Context Block
+ *      documentation</a>
+ */
+public class GsonContextBlockElementFactory implements JsonDeserializer<ContextBlockElement> , JsonSerializer<ContextBlockElement>{
+    @Override
+    public ContextBlockElement deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        final JsonObject jsonObject = json.getAsJsonObject();
+        final JsonPrimitive prim = (JsonPrimitive) jsonObject.get("type");
+        final String className = prim.getAsString();
+        final Class<? extends ContextBlockElement> clazz = getContextBlockElementClassInstance(className);
+        return context.deserialize(jsonObject, clazz);
+    }
+
+    @Override
+    public JsonElement serialize(ContextBlockElement src, Type typeOfSrc, JsonSerializationContext context) {
+        return context.serialize(src);
+    }
+
+    private Class<? extends ContextBlockElement> getContextBlockElementClassInstance(String className) {
+        switch (className) {
+        case "image":
+            return ImageElement.class;
+
+        // does not defer to GsonTextObjectFactory as not to loose the specific context
+        // in which the
+        // type needs to be parsed (gives a better error message to the consumer).
+
+        case "plain_text":
+            return PlainTextObject.class;
+        case "mrkdwn":
+            return MarkdownTextObject.class;
+        default:
+            throw new JsonParseException("Unknown context block element type: " + className);
+        }
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/common/json/GsonFactory.java
+++ b/src/main/java/com/github/seratch/jslack/common/json/GsonFactory.java
@@ -1,18 +1,24 @@
 package com.github.seratch.jslack.common.json;
 
+import com.github.seratch.jslack.api.model.block.ContextBlockElement;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import com.github.seratch.jslack.api.model.block.composition.TextObject;
+import com.github.seratch.jslack.api.model.block.element.BlockElement;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 public class GsonFactory {
-
     private GsonFactory() {
     }
 
     public static Gson createSnakeCase() {
         return new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory())
+                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory())
+                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory())
+                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory())
                 .create();
     }
-
 }

--- a/src/main/java/com/github/seratch/jslack/common/json/GsonLayoutBlockFactory.java
+++ b/src/main/java/com/github/seratch/jslack/common/json/GsonLayoutBlockFactory.java
@@ -1,0 +1,56 @@
+package com.github.seratch.jslack.common.json;
+
+import java.lang.reflect.Type;
+
+import com.github.seratch.jslack.api.model.block.ActionsBlock;
+import com.github.seratch.jslack.api.model.block.ContextBlock;
+import com.github.seratch.jslack.api.model.block.DividerBlock;
+import com.github.seratch.jslack.api.model.block.ImageBlock;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import com.github.seratch.jslack.api.model.block.SectionBlock;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Factory for deserializing BlockKit elements from a
+ * {@link com.github.seratch.jslack.api.model.Message chat message response}.
+ */
+public class GsonLayoutBlockFactory implements JsonDeserializer<LayoutBlock>, JsonSerializer<LayoutBlock> {
+    @Override
+    public LayoutBlock deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        final JsonObject jsonObject = json.getAsJsonObject();
+        final JsonPrimitive prim = (JsonPrimitive) jsonObject.get("type");
+        final String className = prim.getAsString();
+        final Class<? extends LayoutBlock> clazz = getLayoutClassInstance(className);
+        return context.deserialize(jsonObject, clazz);
+    }
+
+    private Class<? extends LayoutBlock> getLayoutClassInstance(String className) {
+        switch (className) {
+        case "section":
+            return SectionBlock.class;
+        case "divider":
+            return DividerBlock.class;
+        case "image":
+            return ImageBlock.class;
+        case "context":
+            return ContextBlock.class;
+        case "actions":
+            return ActionsBlock.class;
+        default:
+            throw new JsonParseException("Unsupported layout block type: " + className);
+        }
+    }
+
+    @Override
+    public JsonElement serialize(LayoutBlock src, Type typeOfSrc, JsonSerializationContext context) {
+        return context.serialize(src);
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/common/json/GsonTextObjectFactory.java
+++ b/src/main/java/com/github/seratch/jslack/common/json/GsonTextObjectFactory.java
@@ -1,0 +1,51 @@
+package com.github.seratch.jslack.common.json;
+
+import java.lang.reflect.Type;
+
+import com.github.seratch.jslack.api.model.block.composition.MarkdownTextObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+import com.github.seratch.jslack.api.model.block.composition.TextObject;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Factory for deserializing BlockKit 'text object' elements from a
+ * {@link com.github.seratch.jslack.api.model.Message chat message response}.
+ * 
+ * @see <a href=
+ *      "https://api.slack.com/reference/messaging/composition-objects#text">Text
+ *      Composition Objects documentation</a>
+ */
+public class GsonTextObjectFactory implements JsonDeserializer<TextObject>, JsonSerializer<TextObject> {
+    @Override
+    public TextObject deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        final JsonObject jsonObject = json.getAsJsonObject();
+        final JsonPrimitive prim = (JsonPrimitive) jsonObject.get("type");
+        final String className = prim.getAsString();
+        final Class<? extends TextObject> clazz = getTextObjectClassInstance(className);
+        return context.deserialize(jsonObject, clazz);
+    }
+
+    @Override
+    public JsonElement serialize(TextObject src, Type typeOfSrc, JsonSerializationContext context) {
+        return context.serialize(src);
+    }
+
+    private Class<? extends TextObject> getTextObjectClassInstance(String className) {
+        switch (className) {
+        case "plain_text":
+            return PlainTextObject.class;
+        case "mrkdwn":
+            return MarkdownTextObject.class;
+        default:
+            throw new JsonParseException("Unknown text object type: " + className);
+        }
+    }
+}

--- a/src/test/java/com/github/seratch/jslack/Slack_blockkit_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_blockkit_Test.java
@@ -1,0 +1,101 @@
+package com.github.seratch.jslack;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
+import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
+import com.github.seratch.jslack.api.model.block.ActionsBlock;
+import com.github.seratch.jslack.api.model.block.DividerBlock;
+import com.github.seratch.jslack.api.model.block.SectionBlock;
+import com.github.seratch.jslack.api.model.block.composition.MarkdownTextObject;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+import com.github.seratch.jslack.api.model.block.element.ButtonElement;
+import com.github.seratch.jslack.api.model.block.element.ImageElement;
+
+public class Slack_blockkit_Test {
+    Slack slack = Slack.getInstance();
+    String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+
+    @Test
+    public void example() throws IOException, SlackApiException {
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .channel("general")
+                .token(token)
+                .text("Example message")
+                .blocks(Arrays.asList(SectionBlock.builder()
+                        .text(MarkdownTextObject.builder()
+                                .text("Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where you'd like to take the Paper Company investors to dinner tonight.\n\n*Please select a restaurant:*")
+                                .build())
+                        .build(),
+                        new DividerBlock(),
+                        SectionBlock.builder()
+                                .text(MarkdownTextObject.builder()
+                                        .text("*Farmhouse Thai Cuisine*\n:star::star::star::star: 1528 reviews\n They do have some vegan options, like the roti and curry, plus they have a ton of salad stuff and noodles can be ordered without meat!! They have something for everyone here")
+                                        .build())
+                                .accessory(ImageElement.builder()
+                                        .imageUrl(
+                                                "https://s3-media3.fl.yelpcdn.com/bphoto/c7ed05m9lC2EmA3Aruue7A/o.jpg")
+                                        .altText("alt text for image")
+                                        .build())
+                                .build(),
+                        SectionBlock.builder()
+                                .text(MarkdownTextObject.builder()
+                                        .text("*Kin Khao*\n:star::star::star::star: 1638 reviews\n The sticky rice also goes wonderfully with the caramelized pork belly, which is absolutely melt-in-your-mouth and so soft.")
+                                        .build())
+                                .accessory(ImageElement.builder()
+                                        .imageUrl(
+                                                "https://s3-media2.fl.yelpcdn.com/bphoto/korel-1YjNtFtJlMTaC26A/o.jpg")
+                                        .altText("alt text for image")
+                                        .build())
+                                .build(),
+                        SectionBlock.builder()
+                                .text(MarkdownTextObject.builder()
+                                        .text("*Ler Ros*\n:star::star::star::star: 2082 reviews\n I would really recommend the  Yum Koh Moo Yang - Spicy lime dressing and roasted quick marinated pork shoulder, basil leaves, chili & rice powder.")
+                                        .build())
+                                .accessory(ImageElement.builder()
+                                        .imageUrl(
+                                                "https://s3-media2.fl.yelpcdn.com/bphoto/DawwNigKJ2ckPeDeDM7jAg/o.jpg")
+                                        .altText("alt text for image")
+                                        .build())
+                                .build(),
+                        new DividerBlock(),
+                        ActionsBlock.builder()
+                                .elements(Arrays.asList(ButtonElement.builder()
+                                        .text(PlainTextObject.builder()
+                                                .emoji(true)
+                                                .text("Farmhouse")
+                                                .build())
+                                        .value("click_me_123")
+                                        .build(),
+                                        ButtonElement.builder()
+                                                .text(PlainTextObject.builder()
+                                                        .emoji(true)
+                                                        .text("Kin Khao")
+                                                        .build())
+                                                .value("click_me_123")
+                                                .build(),
+                                        ButtonElement.builder()
+                                                .text(PlainTextObject.builder()
+                                                        .emoji(true)
+                                                        .text("Ler Ros")
+                                                        .build())
+                                                .value("click_me_123")
+                                                .build()))
+                                .build()))
+                .build();
+
+        ChatPostMessageResponse response = slack.methods()
+                .chatPostMessage(request);
+        Assert.assertThat(response.getError(), is(nullValue()));
+        Assert.assertThat(response.isOk(), is(true));
+        Assert.assertThat(response.getMessage().getBlocks().size(), is(7));
+    }
+}

--- a/src/test/java/com/github/seratch/jslack/Slack_incomingWebhooks_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_incomingWebhooks_Test.java
@@ -2,13 +2,22 @@ package com.github.seratch.jslack;
 
 import com.github.seratch.jslack.api.model.Attachment;
 import com.github.seratch.jslack.api.model.Field;
+import com.github.seratch.jslack.api.model.block.ActionsBlock;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
+import com.github.seratch.jslack.api.model.block.element.ButtonElement;
 import com.github.seratch.jslack.api.webhook.Payload;
 import com.github.seratch.jslack.api.webhook.WebhookResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 @Slf4j
 public class Slack_incomingWebhooks_Test {
@@ -65,6 +74,39 @@ public class Slack_incomingWebhooks_Test {
 
         WebhookResponse response = slack.send(url, payload);
         log.info(response.toString());
+
+        assertThat(response.getCode(), is(200));
+    }
+
+    @Test
+    public void incomingWebhook_BlockKit() throws IOException {
+        // String url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX";
+        String url = System.getenv("SLACK_WEBHOOK_TEST_URL");
+        if (url == null) {
+            throw new IllegalStateException("Environment variable SLACK_WEBHOOK_TEST_URL must be defined");
+        }
+
+        Payload payload = Payload.builder()
+                .channel("#random")
+                .text("Hello World!")
+                .iconEmoji(":smile_cat:")
+                .username("jSlack")
+                .blocks(new ArrayList<>())
+                .build();
+
+        ButtonElement button = ButtonElement.builder()
+                .text(PlainTextObject.builder().emoji(true).text("Farmhouse").build())
+                .value("click_me_123")
+                .build();
+
+        LayoutBlock block = ActionsBlock.builder().elements(Arrays.asList(button)).build();
+
+        payload.getBlocks().add(block);
+
+        WebhookResponse response = slack.send(url, payload);
+        log.info(response.toString());
+
+        assertThat(response.getCode(), is(200));
     }
 
 }


### PR DESCRIPTION
This is a new pull request for issue #96, and it replaces pull request #99.

New:
- adds `@NoArgsConstructor` and `@AllArgsConstructor` annotations to model classes
- adds unit test
- adds support for deserialization of the api.model.block objects
- adds serialization/deserialization TypeAdapters for Gson

The code in this patch is licensed under the MIT license.

Slack has created a new (improved?) message format based on layout
blocks that allow for semi-advanced rich formatting called Block Kit:

https://api.slack.com/block-kit

This commit adds support for all elements, while retaining API
compatibility with the old API (which is discouraged by the Slack
documentation https://api.slack.com/messaging/composing/layouts#secondary-attachments)

The canonical example from the Block Kit Builder, built with the jslack
model:

```
Payload payload = Payload.builder()
	.blocks(Arrays.asList(
		SectionBlock.builder()
			.text(MarkdownTextObject.builder()
				.text("Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where you'd like to take the Paper Company investors to dinner tonight.\n\n *Please select a restaurant:*")
				.build())
			.build(),
		DividerBlock.builder().build(),
		SectionBlock.builder()
			.text(MarkdownTextObject.builder()
				.text("*Farmhouse Thai Cuisine*\n:star::star::star::star: 1528 reviews\n They do have some vegan options, like the roti and curry, plus they have a ton of salad stuff and noodles can be ordered without meat!! They have something for everyone here")
				.build())
			.accessory(ImageElement.builder()
				.imageUrl("https://s3-media3.fl.yelpcdn.com/bphoto/c7ed05m9lC2EmA3Aruue7A/o.jpg")
				.altText("alt text for image")
				.build())
			.build()
		))
	.channel("#test")
	.threadTs("1552173794.000500")
	.build();
```

Fixes #96 
