### PR TITLE
Enable using subclasses of RTMEventHandler

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/rtm/RTMEventHandler.java
+++ b/src/main/java/com/github/seratch/jslack/api/rtm/RTMEventHandler.java
@@ -40,14 +40,18 @@ public abstract class RTMEventHandler<E extends Event> {
         if (cachedClazz != null) {
             return cachedClazz;
         }
-        Type mySuperclass = this.getClass().getGenericSuperclass();
-        Type tType = ((ParameterizedType)mySuperclass).getActualTypeArguments()[0];
-        try {
-            cachedClazz = (Class<E>) Class.forName(tType.getTypeName());
-            return cachedClazz;
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to load event class - " + e.getMessage());
+        Class<?> clazz = this.getClass();
+        while (clazz != Object.class) {
+            try {
+                Type mySuperclass = clazz.getGenericSuperclass();
+                Type tType = ((ParameterizedType)mySuperclass).getActualTypeArguments()[0];
+                cachedClazz = (Class<E>) Class.forName(tType.getTypeName());
+                return cachedClazz;
+            } catch (Exception e) {
+            }
+            clazz = clazz.getSuperclass();
         }
+        throw new IllegalStateException("Failed to load event class - " + this.getClass().getCanonicalName());
     }
 
     /**

--- a/src/test/java/com/github/seratch/jslack/Slack_rtm_typesafe_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_rtm_typesafe_Test.java
@@ -24,6 +24,9 @@ public class Slack_rtm_typesafe_Test {
         }
     }
 
+    public static class SubHelloHandler extends HelloHandler {
+    }
+
     @Test
     public void test() throws Exception {
 
@@ -39,11 +42,41 @@ public class Slack_rtm_typesafe_Test {
             rtm.addMessageHandler(dispatcher.toMessageHandler());
 
             rtm.connect();
-            Thread.sleep(2000L);
+            Thread.sleep(300L);
             assertThat(hello.counter.get(), is(1));
 
             rtm.reconnect();
-            Thread.sleep(2000L);
+            Thread.sleep(300L);
+            assertThat(hello.counter.get(), is(2));
+
+            dispatcher.deregister(hello);
+
+            rtm.reconnect();
+            Thread.sleep(300L);
+            assertThat(hello.counter.get(), is(2)); // should not be incremented
+        }
+    }
+
+    @Test
+    public void test_with_subclass() throws Exception {
+
+        Slack slack = Slack.getInstance();
+
+        String botToken = System.getenv(Constants.SLACK_BOT_USER_TEST_OAUTH_ACCESS_TOKEN);
+
+        RTMEventsDispatcher dispatcher = RTMEventsDispatcherFactory.getInstance();
+        SubHelloHandler hello = new SubHelloHandler();
+        dispatcher.register(hello);
+
+        try (RTMClient rtm = slack.rtmStart(botToken)) {
+            rtm.addMessageHandler(dispatcher.toMessageHandler());
+
+            rtm.connect();
+            Thread.sleep(300L);
+            assertThat(hello.counter.get(), is(1));
+
+            rtm.reconnect();
+            Thread.sleep(300L);
             assertThat(hello.counter.get(), is(2));
         }
     }


### PR DESCRIPTION
This pull request enables library users to have subclasses of `RTMEventHander` as with `com.github.seratch.jslack.api.events.EventHandler`.