### PR TITLE
Update Message object to be compatible with the latest spec

### DIFF
--- a/src/main/java/com/github/seratch/jslack/api/model/Message.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Message.java
@@ -10,8 +10,10 @@ import java.util.List;
 public class Message {
 
     private String type;
+    private String subtype;
     private String channel;
     private String user;
+    private String username;
     private String text;
     private List<LayoutBlock> blocks;
     private List<Attachment> attachments;
@@ -22,8 +24,6 @@ public class Message {
     private boolean wibblr;
     private List<String> pinnedTo;
     private List<Reaction> reactions;
-    private String username;
-    private String subtype;
     private String botId;
     private Icons icons;
     private File file;
@@ -37,6 +37,23 @@ public class Message {
 
     @SerializedName("is_thread_broadcast")
     private boolean threadBroadcast;
+
+    // https://api.slack.com/messaging/retrieving#threading
+    // Parent messages in a thread will no longer explicitly list their replies.
+    // Instead of a large replies array containing threaded message replies,
+    // we'll provide a lighter-weight list of reply_users,
+    // plus a reply_users_count and the latest_reply message.
+    // These new fields are already available. We'll remove the replies array on October 18, 2019.
+    @Deprecated
+    private List<MessageRootReply> replies;
+    private Integer replyCount;
+
+    private List<String> replyUsers;
+    private Integer replyUsersCount;
+
+    private String latestReply; // ts
+
+    private boolean subscribed;
 
     // this field exists only when posting the message with "reply_broadcast": true
     private MessageRoot root;
@@ -59,8 +76,18 @@ public class Message {
         private String type;
         private String subtype;
         private String threadTs;
-        private Integer replyCount;
+
+        // https://api.slack.com/messaging/retrieving#threading
+        // Parent messages in a thread will no longer explicitly list their replies.
+        // Instead of a large replies array containing threaded message replies,
+        // we'll provide a lighter-weight list of reply_users,
+        // plus a reply_users_count and the latest_reply message.
+        // These new fields are already available. We'll remove the replies array on October 18, 2019.
+        @Deprecated
         private List<MessageRootReply> replies;
+        private Integer replyCount;
+        private List<String> replyUsers;
+        private Integer replyUsersCount;
         private boolean subscribed;
         private Integer unreadCount;
         private String ts;


### PR DESCRIPTION
https://api.slack.com/changelog.rss

>Important notice: An update about an API or feature

>Parent messages in a thread will no longer explicitly list their replies. Instead of a large replies array containing threaded message replies, we'll provide a lighter-weight list of reply_users, plus a reply_users_count and the latest_reply message. These new fields are already available. We'll remove the replies array on October 18, 2019.