### PR TITLE
Add the initial version of Slack App backend support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
             <version>9.2.27.v20190403</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.27.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/seratch/jslack/Slack.java
+++ b/src/main/java/com/github/seratch/jslack/Slack.java
@@ -51,11 +51,15 @@ public class Slack {
         return new Slack(httpClient);
     }
 
+    public SlackHttpClient getHttpClient() {
+        return  this.httpClient;
+    }
+
     /**
      * Send a data to Incoming Webhook endpoint.
      */
     public WebhookResponse send(String url, Payload payload) throws IOException {
-        Response httpResponse = this.httpClient.postJsonPostRequest(url, payload);
+        Response httpResponse = getHttpClient().postJsonPostRequest(url, payload);
         String body = httpResponse.body().string();
         SlackHttpClient.debugLog(httpResponse, body);
 

--- a/src/main/java/com/github/seratch/jslack/api/events/EventHandler.java
+++ b/src/main/java/com/github/seratch/jslack/api/events/EventHandler.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Type;
 
 /**
  * Events API handler base class.
+ *
  * @param <E> The type of an events API Payload
  */
 public abstract class EventHandler<E extends EventsApiPayload<?>> {
@@ -29,7 +30,7 @@ public abstract class EventHandler<E extends EventsApiPayload<?>> {
         while (clazz != Object.class) {
             try {
                 Type mySuperclass = clazz.getGenericSuperclass();
-                Type tType = ((ParameterizedType)mySuperclass).getActualTypeArguments()[0];
+                Type tType = ((ParameterizedType) mySuperclass).getActualTypeArguments()[0];
                 cachedPayloadClazz = (Class<E>) Class.forName(tType.getTypeName());
                 return cachedPayloadClazz;
             } catch (Exception e) {
@@ -41,12 +42,14 @@ public abstract class EventHandler<E extends EventsApiPayload<?>> {
 
     /**
      * Implement your logic in this method.
+     *
      * @param payload Events API payload
      */
     public abstract void handle(E payload);
 
     /**
      * Used only internally.
+     *
      * @param payload Events API payload
      */
     public void acceptUntypedObject(Object payload) {

--- a/src/main/java/com/github/seratch/jslack/api/rtm/RTMEventHandler.java
+++ b/src/main/java/com/github/seratch/jslack/api/rtm/RTMEventHandler.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Type;
 
 /**
  * Real Time Messaging API event handler base class.
+ *
  * @param <E> The type of an events API Payload
  */
 public abstract class RTMEventHandler<E extends Event> {
@@ -44,7 +45,7 @@ public abstract class RTMEventHandler<E extends Event> {
         while (clazz != Object.class) {
             try {
                 Type mySuperclass = clazz.getGenericSuperclass();
-                Type tType = ((ParameterizedType)mySuperclass).getActualTypeArguments()[0];
+                Type tType = ((ParameterizedType) mySuperclass).getActualTypeArguments()[0];
                 cachedClazz = (Class<E>) Class.forName(tType.getTypeName());
                 return cachedClazz;
             } catch (Exception e) {
@@ -56,12 +57,14 @@ public abstract class RTMEventHandler<E extends Event> {
 
     /**
      * Implement your logic in this method.
+     *
      * @param event event data
      */
     public abstract void handle(E event);
 
     /**
      * Used only internally.
+     *
      * @param event event data
      */
     public void acceptUntypedObject(Object event) {

--- a/src/main/java/com/github/seratch/jslack/app_backend/config/SlackAppConfig.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/config/SlackAppConfig.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.app_backend.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/apps
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SlackAppConfig {
+    // https://api.slack.com/docs/oauth
+    private String clientId;
+    // https://api.slack.com/docs/oauth
+    private String clientSecret;
+    // https://api.slack.com/docs/oauth
+    private String redirectUri;
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/ResponseSender.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/ResponseSender.java
@@ -1,0 +1,30 @@
+package com.github.seratch.jslack.app_backend.interactive_messages;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.api.webhook.WebhookResponse;
+import com.github.seratch.jslack.app_backend.interactive_messages.response.ActionResponse;
+import com.github.seratch.jslack.common.http.SlackHttpClient;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+public class ResponseSender {
+
+    private final Slack slack;
+
+    public ResponseSender(Slack slack) {
+        this.slack = slack;
+    }
+
+    public WebhookResponse send(String responseUrl, ActionResponse response) throws IOException {
+        Response httpResponse = slack.getHttpClient().postJsonPostRequest(responseUrl, response);
+        String body = httpResponse.body().string();
+        SlackHttpClient.debugLog(httpResponse, body);
+
+        return WebhookResponse.builder()
+                .code(httpResponse.code())
+                .message(httpResponse.message())
+                .body(body)
+                .build();
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/AttachmentActionPayload.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/AttachmentActionPayload.java
@@ -1,0 +1,104 @@
+package com.github.seratch.jslack.app_backend.interactive_messages.payload;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Interactive messages are much like other messages, only they contain buttons, a variety of menus types,
+ * or they have some custom actions available.
+ * Rather than remaining mostly static, interactive messages evolve over time.
+ * <p>
+ * see https://api.slack.com/interactive-messages
+ */
+@Data
+public class AttachmentActionPayload {
+
+    public static final String TYPE = "interactive_message";
+
+    private final String type = TYPE;
+    private List<Action> actions;
+    private String callbackId;
+    private Team team;
+    private Channel channel;
+    private User user;
+    private String actionTs;
+    private String messageTs;
+    private String attachmentId;
+    private String token;
+    @SerializedName("is_app_unfurl")
+    private boolean appUnfurl;
+    private OriginalMessage originalMessage;
+    private String responseUrl;
+    private String triggerId;
+
+    @Data
+    public static class Action {
+        private String name;
+        private String type;
+        private String value;
+    }
+
+    @Data
+    public static class Team {
+        private String id;
+        private String domain;
+    }
+
+    @Data
+    public static class Channel {
+        private String id;
+        private String name;
+    }
+
+    @Data
+    public static class User {
+        private String id;
+        private String name;
+    }
+
+    @Data
+    public static class OriginalMessage {
+        private String text;
+        private String username;
+        private String botId;
+        private List<Attachment> attachments;
+        private String type;
+        private String subtype;
+        private String ts;
+    }
+
+    @Data
+    public static class Attachment {
+        private Integer id;
+        private String callbackId;
+        private String title;
+        private String text;
+        private String fallback;
+        private String color;
+        private String attachmentType;
+        private List<AttachmentAction> actions;
+        private List<AttachmentFiled> fields;
+        private String authorName;
+        private String authorIcon;
+        private String imageUrl;
+    }
+
+    @Data
+    public static class AttachmentFiled {
+        private String title;
+        private String value;
+        @SerializedName("short")
+        private boolean shortField;
+    }
+
+    @Data
+    public static class AttachmentAction {
+        private String name;
+        private String text;
+        private String type;
+        private String value;
+    }
+
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/BlockActionPayload.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/BlockActionPayload.java
@@ -1,0 +1,80 @@
+package com.github.seratch.jslack.app_backend.interactive_messages.payload;
+
+import com.github.seratch.jslack.api.model.Message;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ *
+ * https://api.slack.com/messaging/interactivity/enabling
+ */
+@Data
+public class BlockActionPayload {
+
+    public static final String TYPE = "block_actions";
+
+    private final String type = TYPE;
+    private Team team;
+    private User user;
+    private String apiAppId;
+    private String token;
+    private Container container;
+    private String triggerId;
+    private Channel channel;
+    private Message message;
+    private String responseUrl;
+    private List<Action> actions;
+
+    @Data
+    public static class Team {
+        private String id;
+        private String domain;
+    }
+
+    @Data
+    public static class User {
+        private String id;
+        private String username;
+        private String name;
+        private String teamId;
+    }
+
+    @Data
+    public static class Container {
+        private String type;
+        private String messageTs;
+        private Integer attachmentId;
+        private String channelId;
+        private String text;
+        @SerializedName("is_ephemeral")
+        private boolean ephemeral;
+        @SerializedName("is_app_unfurl")
+        private boolean app_unfurl;
+    }
+
+    @Data
+    public static class Channel {
+        private String id;
+        private String name;
+    }
+
+    @Data
+    public static class Action {
+        private String actionId;
+        private String blockId;
+        private Text text;
+        private String value;
+        private String type;
+        private String actionTs;
+
+        @Data
+        public static class Text {
+            private String type;
+            private String text;
+            private boolean emoji;
+        }
+    }
+
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/PayloadTypeDetector.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/PayloadTypeDetector.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.app_backend.interactive_messages.payload;
+
+import com.github.seratch.jslack.common.json.GsonFactory;
+import lombok.Data;
+
+public class PayloadTypeDetector {
+
+    @Data
+    public static class Payload {
+        private String type;
+    }
+
+    public String detectType(String json) {
+        Payload payload = GsonFactory.createSnakeCase().fromJson(json, Payload.class);
+        return payload.getType();
+    }
+
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/response/ActionResponse.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/response/ActionResponse.java
@@ -1,0 +1,17 @@
+package com.github.seratch.jslack.app_backend.interactive_messages.response;
+
+import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ActionResponse {
+    private String responseType; // ephemeral, in_channel
+    private String text;
+    private boolean replaceOriginal;
+    private boolean deleteOriginal;
+    private List<Attachment> attachments;
+    private List<LayoutBlock> blocks;
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/oauth/OAuthFlowOperator.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/oauth/OAuthFlowOperator.java
@@ -1,0 +1,31 @@
+package com.github.seratch.jslack.app_backend.oauth;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.methods.request.oauth.OAuthAccessRequest;
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
+import com.github.seratch.jslack.app_backend.config.SlackAppConfig;
+import com.github.seratch.jslack.app_backend.oauth.payload.VerificationCodePayload;
+
+import java.io.IOException;
+
+public class OAuthFlowOperator {
+
+    private final Slack slack;
+    private final SlackAppConfig config;
+
+    public OAuthFlowOperator(Slack slack, SlackAppConfig config) {
+        this.slack = slack;
+        this.config = config;
+    }
+
+    public OAuthAccessResponse callOAuthAccessMethod(VerificationCodePayload payload) throws IOException, SlackApiException {
+        return slack.methods().oauthAccess(OAuthAccessRequest.builder()
+                .clientId(config.getClientId())
+                .clientSecret(config.getClientSecret())
+                .code(payload.getCode())
+                .redirectUri(config.getRedirectUri())
+                .build());
+    }
+
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/oauth/payload/VerificationCodePayload.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/oauth/payload/VerificationCodePayload.java
@@ -1,0 +1,24 @@
+package com.github.seratch.jslack.app_backend.oauth.payload;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class VerificationCodePayload {
+
+    private String code;
+    private String state;
+
+    /**
+     * Extracts code and state from Map object. This method is supposed to be used in AWS lambda functions.
+     * See also {@link com.github.seratch.jslack.app_backend.vendor.aws.lambda.request.ApiGatewayRequest}
+     */
+    public static VerificationCodePayload from(Map<String, String> queryStringParameters) {
+        VerificationCodePayload payload = new VerificationCodePayload();
+        payload.setCode(queryStringParameters.get("code"));
+        payload.setState(queryStringParameters.get("state"));
+        return payload;
+    }
+
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/DelayedResponseSender.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/DelayedResponseSender.java
@@ -1,0 +1,34 @@
+package com.github.seratch.jslack.app_backend.slash_commands;
+
+import com.github.seratch.jslack.api.webhook.WebhookResponse;
+import com.github.seratch.jslack.app_backend.slash_commands.payload.SlashCommandPayload;
+import com.github.seratch.jslack.app_backend.slash_commands.response.SlashCommandResponse;
+import com.github.seratch.jslack.common.http.SlackHttpClient;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+public class DelayedResponseSender {
+
+    private final SlackHttpClient httpClient;
+
+    public DelayedResponseSender() {
+        this(new SlackHttpClient());
+    }
+
+    public DelayedResponseSender(SlackHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public WebhookResponse send(SlashCommandPayload payload, SlashCommandResponse response) throws IOException {
+        Response httpResponse = httpClient.postJsonPostRequest(payload.getResponseUrl(), response);
+        String body = httpResponse.body().string();
+        SlackHttpClient.debugLog(httpResponse, body);
+
+        return WebhookResponse.builder()
+                .code(httpResponse.code())
+                .message(httpResponse.message())
+                .body(body)
+                .build();
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/payload/SlashCommandPayload.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/payload/SlashCommandPayload.java
@@ -1,0 +1,20 @@
+package com.github.seratch.jslack.app_backend.slash_commands.payload;
+
+import lombok.Data;
+
+@Data
+public class SlashCommandPayload {
+    private String token;
+    private String teamId;
+    private String teamDomain;
+    private String enterpriseId;
+    private String enterpriseName;
+    private String channelId;
+    private String channelName;
+    private String userId;
+    private String userName;
+    private String command;
+    private String text;
+    private String responseUrl;
+    private String triggerId;
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/payload/SlashCommandPayloadParser.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/payload/SlashCommandPayloadParser.java
@@ -1,0 +1,72 @@
+package com.github.seratch.jslack.app_backend.slash_commands.payload;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+@Slf4j
+public class SlashCommandPayloadParser {
+
+    public SlashCommandPayload parse(String requestBody) {
+        if (requestBody == null) {
+            return null;
+        }
+        SlashCommandPayload payload = new SlashCommandPayload();
+        String[] pairs = requestBody.split("\\&");
+        for (String pair : pairs) {
+            String[] fields = pair.split("=");
+            if (fields.length == 2) {
+                try {
+                    String name = URLDecoder.decode(fields[0].trim().replaceAll("\\n+", ""), "UTF-8");
+                    String value = URLDecoder.decode(fields[1], "UTF-8");
+                    switch (name) {
+                        case "token":
+                            payload.setToken(value);
+                            break;
+                        case "team_id":
+                            payload.setTeamId(value);
+                            break;
+                        case "team_domain":
+                            payload.setTeamDomain(value);
+                            break;
+                        case "enterprise_id":
+                            payload.setEnterpriseId(value);
+                            break;
+                        case "enterprise_name":
+                            payload.setEnterpriseName(value);
+                            break;
+                        case "channel_id":
+                            payload.setChannelId(value);
+                            break;
+                        case "channel_name":
+                            payload.setChannelName(value);
+                            break;
+                        case "user_id":
+                            payload.setUserId(value);
+                            break;
+                        case "user_name":
+                            payload.setUserName(value);
+                            break;
+                        case "command":
+                            payload.setCommand(value);
+                            break;
+                        case "text":
+                            payload.setText(value);
+                            break;
+                        case "response_url":
+                            payload.setResponseUrl(value);
+                            break;
+                        case "trigger_id":
+                            payload.setTriggerId(value);
+                            break;
+                        default:
+                    }
+                } catch (UnsupportedEncodingException e) {
+                    log.error("Failed to decode URL-encoded string values - {}", e.getMessage(), e);
+                }
+            }
+        }
+        return payload;
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/response/SlashCommandResponse.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/response/SlashCommandResponse.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.app_backend.slash_commands.response;
+
+import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/docs/interactive-message-field-guide
+ */
+@Data
+public class SlashCommandResponse {
+    private String responseType; // ephemeral, in_channel
+    private String text;
+    private List<Attachment> attachments;
+    private List<LayoutBlock> blocks;
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/util/RequestTokenVerifier.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/util/RequestTokenVerifier.java
@@ -1,0 +1,41 @@
+package com.github.seratch.jslack.app_backend.util;
+
+import com.github.seratch.jslack.app_backend.interactive_messages.payload.AttachmentActionPayload;
+import com.github.seratch.jslack.app_backend.interactive_messages.payload.BlockActionPayload;
+import com.github.seratch.jslack.app_backend.slash_commands.payload.SlashCommandPayload;
+
+public class RequestTokenVerifier {
+
+    // https://api.slack.com/apps/{apiAppId}
+    // App Credentials > Verification Token
+    public static final String ENV_VARIABLE_NAME = "SLACK_VERIFICATION_TOKEN";
+
+    private final String verificationToken;
+
+    public RequestTokenVerifier() {
+        this.verificationToken = System.getenv(RequestTokenVerifier.ENV_VARIABLE_NAME);
+    }
+
+    public RequestTokenVerifier(String verificationToken) {
+        this.verificationToken = verificationToken;
+    }
+
+    public boolean isValid(AttachmentActionPayload payload) {
+        return payload != null && isValid(payload.getToken());
+    }
+
+    public boolean isValid(BlockActionPayload payload) {
+        return payload != null && isValid(payload.getToken());
+    }
+
+    public boolean isValid(SlashCommandPayload payload) {
+        return payload != null && isValid(payload.getToken());
+    }
+
+    public boolean isValid(String actualToken) {
+        if (actualToken == null) {
+            return false;
+        }
+        return actualToken.equals(this.verificationToken);
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/request/ApiGatewayRequest.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/request/ApiGatewayRequest.java
@@ -1,0 +1,21 @@
+package com.github.seratch.jslack.app_backend.vendor.aws.lambda.request;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class ApiGatewayRequest {
+
+    private String resource;
+    private String path;
+    private String httpMethod;
+    private Map<String, String> headers;
+    private Map<String, String> queryStringParameters;
+    private Map<String, String> pathParameters;
+    private Map<String, String> stageVariables;
+    private RequestContext requestContext;
+    private String body;
+    private boolean isBase64Encoded;
+
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/request/Identity.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/request/Identity.java
@@ -1,0 +1,19 @@
+package com.github.seratch.jslack.app_backend.vendor.aws.lambda.request;
+
+import lombok.Data;
+
+@Data
+public class Identity {
+
+    private String cognitoIdentityPoolId;
+    private String accountId;
+    private String cognitoIdentityId;
+    private String caller;
+    private String apiKey;
+    private String sourceIp;
+    private String cognitoAuthenticationType;
+    private String cognitoAuthenticationProvider;
+    private String userArn;
+    private String userAgent;
+    private String user;
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/request/RequestContext.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/request/RequestContext.java
@@ -1,0 +1,15 @@
+package com.github.seratch.jslack.app_backend.vendor.aws.lambda.request;
+
+import lombok.Data;
+
+@Data
+public class RequestContext {
+    private String accountId;
+    private String resourceId;
+    private String stage;
+    private String requestId;
+    private Identity identity;
+    private String resourcePath;
+    private String httpMethod;
+    private String apiId;
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/response/ApiGatewayResponse.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/response/ApiGatewayResponse.java
@@ -1,0 +1,136 @@
+package com.github.seratch.jslack.app_backend.vendor.aws.lambda.response;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class ApiGatewayResponse {
+
+    private static final Gson GSON = new GsonBuilder().create();
+
+    private final int statusCode;
+    private final String body;
+    private final Map<String, String> headers;
+    private final boolean isBase64Encoded;
+
+    public ApiGatewayResponse(int statusCode, String body, Map<String, String> headers, boolean isBase64Encoded) {
+        this.statusCode = statusCode;
+        this.body = body;
+        this.headers = headers;
+        this.isBase64Encoded = isBase64Encoded;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    // API Gateway expects the property to be called "isBase64Encoded" => isIs
+    public boolean isIsBase64Encoded() {
+        return isBase64Encoded;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private int statusCode = 200;
+        private Map<String, String> headers = Collections.emptyMap();
+        private String rawBody;
+        private Object objectBody;
+        private byte[] binaryBody;
+        private boolean base64Encoded;
+
+        public Builder setStatusCode(int statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public Builder setHeaders(Map<String, String> headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        /**
+         * Builds the {@link ApiGatewayResponse} using the passed raw body string.
+         */
+        public Builder setRawBody(String rawBody) {
+            this.rawBody = rawBody;
+            return this;
+        }
+
+        /**
+         * Builds the {@link ApiGatewayResponse} using the passed object body
+         * converted to JSON.
+         */
+        public Builder setObjectBody(Object objectBody) {
+            this.objectBody = objectBody;
+            return this;
+        }
+
+        /**
+         * Builds the {@link ApiGatewayResponse} using the passed binary body
+         * encoded as base64. {@link #setBase64Encoded(boolean)
+         * setBase64Encoded(true)} will be in invoked automatically.
+         */
+        public Builder setBinaryBody(byte[] binaryBody) {
+            this.binaryBody = binaryBody;
+            setBase64Encoded(true);
+            return this;
+        }
+
+        /**
+         * A binary or rather a base64encoded responses requires
+         * <ol>
+         * <li>"Binary Media Types" to be configured in API Gateway
+         * <li>a request with an "Accept" header set to one of the "Binary Media
+         * Types"
+         * </ol>
+         */
+        public Builder setBase64Encoded(boolean base64Encoded) {
+            this.base64Encoded = base64Encoded;
+            return this;
+        }
+
+        public ApiGatewayResponse build() {
+            String body = null;
+            if (rawBody != null) {
+                body = rawBody;
+            } else if (objectBody != null) {
+                body = GSON.toJson(objectBody);
+            } else if (binaryBody != null) {
+                body = new String(Base64.getEncoder().encode(binaryBody), StandardCharsets.UTF_8);
+            }
+            log.debug("body: {}", body);
+            return new ApiGatewayResponse(statusCode, body, headers, base64Encoded);
+        }
+    }
+
+    // ----------------------
+
+    public static ApiGatewayResponse build302Response(String location) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Location", location);
+        return ApiGatewayResponse.builder()
+                .setStatusCode(302)
+                .setHeaders(headers)
+                .build();
+    }
+
+}

--- a/src/test/java/com/github/seratch/jslack/Slack_rtm_typesafe_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_rtm_typesafe_Test.java
@@ -19,6 +19,7 @@ public class Slack_rtm_typesafe_Test {
     @Slf4j
     public static class HelloHandler extends RTMEventHandler<HelloEvent> {
         public final AtomicInteger counter = new AtomicInteger(0);
+
         @Override
         public void handle(HelloEvent event) {
             counter.incrementAndGet();

--- a/src/test/java/com/github/seratch/jslack/app_backend/config/SlackAppConfigTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/config/SlackAppConfigTest.java
@@ -1,0 +1,37 @@
+package com.github.seratch.jslack.app_backend.config;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.*;
+
+public class SlackAppConfigTest {
+
+    @Test
+    public void instantiation() {
+        SlackAppConfig config = new SlackAppConfig();
+        config.setClientId("a");
+        config.setClientSecret("b");
+        config.setRedirectUri("https://example.com/");
+
+        assertThat(config, is(notNullValue()));
+        assertThat(config.getClientId(), is("a"));
+        assertThat(config.getClientSecret(), is("b"));
+        assertThat(config.getRedirectUri(), is("https://example.com/"));
+    }
+
+    @Test
+    public void builder() {
+        SlackAppConfig config = SlackAppConfig.builder()
+                .clientId("a")
+                .clientSecret("b")
+                .redirectUri("https://example.com/")
+                .build();
+
+        assertThat(config, is(notNullValue()));
+        assertThat(config.getClientId(), is("a"));
+        assertThat(config.getClientSecret(), is("b"));
+        assertThat(config.getRedirectUri(), is("https://example.com/"));
+    }
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/AttachmentActionPayloadTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/AttachmentActionPayloadTest.java
@@ -1,0 +1,81 @@
+package com.github.seratch.jslack.app_backend.interactive_messages.payload;
+
+import com.github.seratch.jslack.common.json.GsonFactory;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.*;
+
+public class AttachmentActionPayloadTest {
+
+    // https://api.slack.com/interactive-messages
+    String json = "{\n" +
+            "  \"type\": \"interactive_message\",\n" +
+            "  \"actions\": [\n" +
+            "    {\n" +
+            "      \"name\": \"channel_list\",\n" +
+            "      \"type\": \"select\",\n" +
+            "      \"selected_options\":[\n" +
+            "        {\n" +
+            "          \"value\": \"C24BTKDQW\"\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"callback_id\": \"pick_channel_for_fun\",\n" +
+            "  \"team\": {\n" +
+            "    \"id\": \"T1ABCD2E12\",\n" +
+            "    \"domain\": \"hooli-hq\"\n" +
+            "  },\n" +
+            "  \"channel\": {\n" +
+            "    \"id\": \"C9C2VHR7D\",\n" +
+            "    \"name\": \"triage-random\"\n" +
+            "  },\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"U900MV5U7\",\n" +
+            "    \"name\": \"gbelson\"\n" +
+            "  },\n" +
+            "  \"action_ts\": \"1520966872.245369\",\n" +
+            "  \"message_ts\": \"1520965348.000538\",\n" +
+            "  \"attachment_id\": \"1\",\n" +
+            "  \"token\": \"lbAZE0ckwoSNJcsGWE7sqX5j\",\n" +
+            "  \"is_app_unfurl\": false,\n" +
+            "  \"original_message\": {\n" +
+            "    \"text\": \"\",\n" +
+            "    \"username\": \"Belson Bot\",\n" +
+            "    \"bot_id\": \"B9DKHFZ1E\",\n" +
+            "    \"attachments\":[\n" +
+            "      {\n" +
+            "        \"callback_id\": \"pick_channel_for_fun\",\n" +
+            "        \"text\": \"Choose a channel\",\n" +
+            "        \"id\": 1,\n" +
+            "        \"color\": \"2b72cb\",\n" +
+            "        \"actions\": [\n" +
+            "          {\n" +
+            "            \"id\": \"1\",\n" +
+            "            \"name\": \"channel_list\",\n" +
+            "            \"text\": \"Public channels\",\n" +
+            "            \"type\": \"select\",\n" +
+            "            \"data_source\": \"channels\"\n" +
+            "          }\n" +
+            "        ],\n" +
+            "        \"fallback\":\"Choose a channel\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"type\": \"message\",\n" +
+            "    \"subtype\": \"bot_message\",\n" +
+            "    \"ts\": \"1520965348.000538\"\n" +
+            "  },\n" +
+            "  \"response_url\": \"https://hooks.slack.com/actions/T1ABCD2E12/330361579271/0dAEyLY19ofpLwxqozy3firz\",\n" +
+            "  \"trigger_id\": \"328654886736.72393107734.9a0f78bccc3c64093f4b12fe82ccd51e\"\n" +
+            "}";
+
+    @Test
+    public void deserialize() {
+        AttachmentActionPayload payload = GsonFactory.createSnakeCase().fromJson(json, AttachmentActionPayload.class);
+        assertThat(payload.getType(), is("interactive_message"));
+        assertThat(payload.getOriginalMessage(), is(notNullValue()));
+        assertThat(payload.getResponseUrl(), is("https://hooks.slack.com/actions/T1ABCD2E12/330361579271/0dAEyLY19ofpLwxqozy3firz"));
+    }
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/BlockActionPayloadTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/BlockActionPayloadTest.java
@@ -1,0 +1,75 @@
+package com.github.seratch.jslack.app_backend.interactive_messages.payload;
+
+import com.github.seratch.jslack.common.json.GsonFactory;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.*;
+
+public class BlockActionPayloadTest {
+
+    // https://api.slack.com/messaging/interactivity/enabling
+    String json = "{\n" +
+            "  \"type\": \"block_actions\",\n" +
+            "  \"team\": { \n" +
+            "    \"id\": \"T9TK3CUKW\", \n" +
+            "    \"domain\": \"example\" \n" +
+            "  },\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"UA8RXUSPL\",\n" +
+            "    \"username\": \"jtorrance\",\n" +
+            "    \"team_id\": \"T9TK3CUKW\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"AABA1ABCD\",\n" +
+            "  \"token\": \"9s8d9as89d8as9d8as989\",\n" +
+            "  \"container\": {\n" +
+            "    \"type\": \"message_attachment\",\n" +
+            "    \"message_ts\": \"1548261231.000200\",\n" +
+            "    \"attachment_id\": 1,\n" +
+            "    \"channel_id\": \"CBR2V3XEX\",\n" +
+            "    \"is_ephemeral\": false,\n" +
+            "    \"is_app_unfurl\": false\n" +
+            "  },\n" +
+            "  \"trigger_id\": \"12321423423.333649436676.d8c1bb837935619ccad0f624c448ffb3\",\n" +
+            "  \"channel\": { \n" +
+            "    \"id\": \"CBR2V3XEX\", \n" +
+            "    \"name\": \"review-updates\" \n" +
+            "  },\n" +
+            "  \"message\": {\n" +
+            "    \"bot_id\": \"BAH5CA16Z\",\n" +
+            "    \"type\": \"message\",\n" +
+            "    \"text\": \"This content can't be displayed.\",\n" +
+            "    \"user\": \"UAJ2RU415\",\n" +
+            "    \"ts\": \"1548261231.000200\"\n" +
+            "  },\n" +
+            "  \"response_url\": \"https://hooks.slack.com/actions/AABA1ABCD/1232321423432/D09sSasdasdAS9091209\",\n" +
+            "  \"actions\": [\n" +
+            "    {\n" +
+            "      \"action_id\": \"WaXA\",\n" +
+            "      \"block_id\": \"=qXel\",\n" +
+            "      \"text\": { \n" +
+            "        \"type\": \"plain_text\", \n" +
+            "        \"text\": \"View\", \n" +
+            "        \"emoji\": true \n" +
+            "      },\n" +
+            "      \"value\": \"click_me_123\",\n" +
+            "      \"type\": \"button\",\n" +
+            "      \"action_ts\": \"1548426417.840180\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    @Test
+    public void deserialize() {
+        BlockActionPayload payload = GsonFactory.createSnakeCase().fromJson(json, BlockActionPayload.class);
+        assertThat(payload.getType(), is("block_actions"));
+        assertThat(payload.getToken(), is("9s8d9as89d8as9d8as989"));
+        assertThat(payload.getUser(), is(notNullValue()));
+        assertThat(payload.getTeam(), is(notNullValue()));
+        assertThat(payload.getContainer(), is(notNullValue()));
+        assertThat(payload.getChannel(), is(notNullValue()));
+        assertThat(payload.getResponseUrl(), is("https://hooks.slack.com/actions/AABA1ABCD/1232321423432/D09sSasdasdAS9091209"));
+        assertThat(payload.getActions().size(), is(1));
+    }
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/PayloadTypeDetectorTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/PayloadTypeDetectorTest.java
@@ -1,0 +1,142 @@
+package com.github.seratch.jslack.app_backend.interactive_messages.payload;
+
+import com.github.seratch.jslack.common.json.GsonFactory;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class PayloadTypeDetectorTest {
+
+    // https://api.slack.com/interactive-messages
+    String attachmentActionPayload = "{\n" +
+            "  \"type\": \"interactive_message\",\n" +
+            "  \"actions\": [\n" +
+            "    {\n" +
+            "      \"name\": \"channel_list\",\n" +
+            "      \"type\": \"select\",\n" +
+            "      \"selected_options\":[\n" +
+            "        {\n" +
+            "          \"value\": \"C24BTKDQW\"\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"callback_id\": \"pick_channel_for_fun\",\n" +
+            "  \"team\": {\n" +
+            "    \"id\": \"T1ABCD2E12\",\n" +
+            "    \"domain\": \"hooli-hq\"\n" +
+            "  },\n" +
+            "  \"channel\": {\n" +
+            "    \"id\": \"C9C2VHR7D\",\n" +
+            "    \"name\": \"triage-random\"\n" +
+            "  },\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"U900MV5U7\",\n" +
+            "    \"name\": \"gbelson\"\n" +
+            "  },\n" +
+            "  \"action_ts\": \"1520966872.245369\",\n" +
+            "  \"message_ts\": \"1520965348.000538\",\n" +
+            "  \"attachment_id\": \"1\",\n" +
+            "  \"token\": \"lbAZE0ckwoSNJcsGWE7sqX5j\",\n" +
+            "  \"is_app_unfurl\": false,\n" +
+            "  \"original_message\": {\n" +
+            "    \"text\": \"\",\n" +
+            "    \"username\": \"Belson Bot\",\n" +
+            "    \"bot_id\": \"B9DKHFZ1E\",\n" +
+            "    \"attachments\":[\n" +
+            "      {\n" +
+            "        \"callback_id\": \"pick_channel_for_fun\",\n" +
+            "        \"text\": \"Choose a channel\",\n" +
+            "        \"id\": 1,\n" +
+            "        \"color\": \"2b72cb\",\n" +
+            "        \"actions\": [\n" +
+            "          {\n" +
+            "            \"id\": \"1\",\n" +
+            "            \"name\": \"channel_list\",\n" +
+            "            \"text\": \"Public channels\",\n" +
+            "            \"type\": \"select\",\n" +
+            "            \"data_source\": \"channels\"\n" +
+            "          }\n" +
+            "        ],\n" +
+            "        \"fallback\":\"Choose a channel\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"type\": \"message\",\n" +
+            "    \"subtype\": \"bot_message\",\n" +
+            "    \"ts\": \"1520965348.000538\"\n" +
+            "  },\n" +
+            "  \"response_url\": \"https://hooks.slack.com/actions/T1ABCD2E12/330361579271/0dAEyLY19ofpLwxqozy3firz\",\n" +
+            "  \"trigger_id\": \"328654886736.72393107734.9a0f78bccc3c64093f4b12fe82ccd51e\"\n" +
+            "}";
+    @Test
+    public void interactive_message() throws UnsupportedEncodingException {
+        String encoded = URLEncoder.encode(attachmentActionPayload, "UTF-8");
+        PayloadTypeDetector detector = new PayloadTypeDetector();
+        String type = detector.detectType(URLDecoder.decode(encoded, "UTF-8"));
+        assertThat(type, is("interactive_message"));
+    }
+
+    // https://api.slack.com/messaging/interactivity/enabling
+    String blockActionJson = "{\n" +
+            "  \"type\": \"block_actions\",\n" +
+            "  \"team\": { \n" +
+            "    \"id\": \"T9TK3CUKW\", \n" +
+            "    \"domain\": \"example\" \n" +
+            "  },\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"UA8RXUSPL\",\n" +
+            "    \"username\": \"jtorrance\",\n" +
+            "    \"team_id\": \"T9TK3CUKW\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"AABA1ABCD\",\n" +
+            "  \"token\": \"9s8d9as89d8as9d8as989\",\n" +
+            "  \"container\": {\n" +
+            "    \"type\": \"message_attachment\",\n" +
+            "    \"message_ts\": \"1548261231.000200\",\n" +
+            "    \"attachment_id\": 1,\n" +
+            "    \"channel_id\": \"CBR2V3XEX\",\n" +
+            "    \"is_ephemeral\": false,\n" +
+            "    \"is_app_unfurl\": false\n" +
+            "  },\n" +
+            "  \"trigger_id\": \"12321423423.333649436676.d8c1bb837935619ccad0f624c448ffb3\",\n" +
+            "  \"channel\": { \n" +
+            "    \"id\": \"CBR2V3XEX\", \n" +
+            "    \"name\": \"review-updates\" \n" +
+            "  },\n" +
+            "  \"message\": {\n" +
+            "    \"bot_id\": \"BAH5CA16Z\",\n" +
+            "    \"type\": \"message\",\n" +
+            "    \"text\": \"This content can't be displayed.\",\n" +
+            "    \"user\": \"UAJ2RU415\",\n" +
+            "    \"ts\": \"1548261231.000200\"\n" +
+            "  },\n" +
+            "  \"response_url\": \"https://hooks.slack.com/actions/AABA1ABCD/1232321423432/D09sSasdasdAS9091209\",\n" +
+            "  \"actions\": [\n" +
+            "    {\n" +
+            "      \"action_id\": \"WaXA\",\n" +
+            "      \"block_id\": \"=qXel\",\n" +
+            "      \"text\": { \n" +
+            "        \"type\": \"plain_text\", \n" +
+            "        \"text\": \"View\", \n" +
+            "        \"emoji\": true \n" +
+            "      },\n" +
+            "      \"value\": \"click_me_123\",\n" +
+            "      \"type\": \"button\",\n" +
+            "      \"action_ts\": \"1548426417.840180\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    @Test
+    public void block_actions() throws UnsupportedEncodingException {
+        String encoded = URLEncoder.encode(blockActionJson, "UTF-8");
+        String json = URLDecoder.decode(encoded, "UTF-8");
+        BlockActionPayload payload = GsonFactory.createSnakeCase().fromJson(json, BlockActionPayload.class);
+        assertThat(payload.getType(), is("block_actions"));
+    }
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/interactive_messages/response/ActionResponseTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/interactive_messages/response/ActionResponseTest.java
@@ -1,0 +1,34 @@
+package com.github.seratch.jslack.app_backend.interactive_messages.response;
+
+import com.github.seratch.jslack.common.json.GsonFactory;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ActionResponseTest {
+
+    @Test
+    public void test() {
+        ActionResponse response = new ActionResponse();
+        response.setText("something to say");
+        response.setAttachments(Collections.emptyList());
+        response.setBlocks(Collections.emptyList());
+        response.setDeleteOriginal(false);
+        response.setReplaceOriginal(true);
+
+        assertThat(response.getText(), is("something to say"));
+
+        String json = GsonFactory.createSnakeCase().toJson(response);
+        assertThat(json, is("{" +
+                "\"text\":\"something to say\"," +
+                "\"replace_original\":true," +
+                "\"delete_original\":false," +
+                "\"attachments\":[]," +
+                "\"blocks\":[]" +
+                "}"));
+    }
+
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/oauth/OAuthFlowOperatorTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/oauth/OAuthFlowOperatorTest.java
@@ -1,0 +1,46 @@
+package com.github.seratch.jslack.app_backend.oauth;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
+import com.github.seratch.jslack.app_backend.config.SlackAppConfig;
+import com.github.seratch.jslack.app_backend.oauth.payload.VerificationCodePayload;
+import com.github.seratch.jslack.common.http.SlackHttpClient;
+import okhttp3.*;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class OAuthFlowOperatorTest {
+
+    @Test
+    public void callOAuthAccessMethod() throws IOException, SlackApiException {
+        SlackHttpClient httpClient = mock(SlackHttpClient.class);
+        Request httpRequest = mock(Request.class);
+        Response httpResponse = mock(Response.class);
+        ResponseBody httpResponseBody = mock(ResponseBody.class);
+        RequestBody httpRequestBody = mock(RequestBody.class);
+        when(httpClient.postForm(anyString(), any(FormBody.class))).thenReturn(httpResponse);
+        when(httpResponse.code()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(httpResponseBody);
+        when(httpResponseBody.string()).thenReturn("{\"ok\": true}");
+        when(httpResponse.request()).thenReturn(httpRequest);
+        when(httpRequest.body()).thenReturn(httpRequestBody);
+
+        Slack slack = Slack.getInstance(httpClient);
+        SlackAppConfig config = SlackAppConfig.builder().build();
+        OAuthFlowOperator operator = new OAuthFlowOperator(slack, config);
+
+        VerificationCodePayload payload = new VerificationCodePayload();
+        payload.setCode("123");
+        payload.setState("random");
+        OAuthAccessResponse response = operator.callOAuthAccessMethod(payload);
+        assertThat(response.getError(), is(nullValue()));
+    }
+
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/oauth/payload/VerificationCodePayloadTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/oauth/payload/VerificationCodePayloadTest.java
@@ -1,0 +1,23 @@
+package com.github.seratch.jslack.app_backend.oauth.payload;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class VerificationCodePayloadTest {
+
+    @Test
+    public void test() {
+        Map<String, String> queryParameters = new HashMap<>();
+        queryParameters.put("code", "123");
+        queryParameters.put("state", "random");
+        VerificationCodePayload payload = VerificationCodePayload.from(queryParameters);
+        assertThat(payload.getCode(), is("123"));
+        assertThat(payload.getState(), is("random"));
+    }
+
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/slash_commands/payload/SlashCommandPayloadParserTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/slash_commands/payload/SlashCommandPayloadParserTest.java
@@ -1,0 +1,43 @@
+package com.github.seratch.jslack.app_backend.slash_commands.payload;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SlashCommandPayloadParserTest {
+
+    SlashCommandPayloadParser parser = new SlashCommandPayloadParser();
+
+    @Test
+    public void parse() {
+        String body = "token=gIkuvaNzQIHg97ATvDxqgjtO" +
+                "&team_id=T0001" +
+                "&team_domain=example" +
+                "&enterprise_id=E0001" +
+                "&enterprise_name=Globular%20Construct%20Inc" +
+                "&channel_id=C2147483705" +
+                "&channel_name=test" +
+                "&user_id=U2147483697" +
+                "&user_name=Steve" +
+                "&command=/weather" +
+                "&text=94070" +
+                "&response_url=https://hooks.slack.com/commands/1234/5678" +
+                "&trigger_id=13345224609.738474920.8088930838d88f008e0";
+        SlashCommandPayload payload = parser.parse(body);
+
+        assertThat(payload.getToken(), is("gIkuvaNzQIHg97ATvDxqgjtO"));
+        assertThat(payload.getTeamId(), is("T0001"));
+        assertThat(payload.getTeamDomain(), is("example"));
+        assertThat(payload.getEnterpriseId(), is("E0001"));
+        assertThat(payload.getEnterpriseName(), is("Globular Construct Inc"));
+        assertThat(payload.getChannelId(), is("C2147483705"));
+        assertThat(payload.getChannelName(), is("test"));
+        assertThat(payload.getUserId(), is("U2147483697"));
+        assertThat(payload.getUserName(), is("Steve"));
+        assertThat(payload.getCommand(), is("/weather"));
+        assertThat(payload.getText(), is("94070"));
+        assertThat(payload.getResponseUrl(), is("https://hooks.slack.com/commands/1234/5678"));
+        assertThat(payload.getTriggerId(), is("13345224609.738474920.8088930838d88f008e0"));
+    }
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/slash_commands/response/SlashCommandResponseTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/slash_commands/response/SlashCommandResponseTest.java
@@ -1,0 +1,17 @@
+package com.github.seratch.jslack.app_backend.slash_commands.response;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class SlashCommandResponseTest {
+
+    @Test
+    public void test() {
+        SlashCommandResponse response = new SlashCommandResponse();
+        response.setResponseType("ephemeral");
+        assertThat(response.getResponseType(), is("ephemeral"));
+    }
+
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/util/RequestTokenVerifierTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/util/RequestTokenVerifierTest.java
@@ -1,0 +1,36 @@
+package com.github.seratch.jslack.app_backend.util;
+
+import com.github.seratch.jslack.app_backend.slash_commands.payload.SlashCommandPayload;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class RequestTokenVerifierTest {
+
+    RequestTokenVerifier validator = new RequestTokenVerifier("expected");
+
+    @Test
+    public void slashCommandPayload() {
+        {
+            assertThat(validator.isValid((String) null), is(false));
+        }
+
+        {
+            SlashCommandPayload payload = new SlashCommandPayload();
+            assertThat(validator.isValid(payload), is(false));
+        }
+
+        {
+            SlashCommandPayload payload = new SlashCommandPayload();
+            payload.setToken("expected");
+            assertThat(validator.isValid(payload), is(true));
+        }
+
+        {
+            SlashCommandPayload payload = new SlashCommandPayload();
+            payload.setToken("expected ");
+            assertThat(validator.isValid(payload), is(false));
+        }
+    }
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/request/ApiGatewayRequestTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/request/ApiGatewayRequestTest.java
@@ -1,0 +1,17 @@
+package com.github.seratch.jslack.app_backend.vendor.aws.lambda.request;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class ApiGatewayRequestTest {
+
+    @Test
+    public void test() {
+        ApiGatewayRequest req = new ApiGatewayRequest();
+        req.setBody("something");
+        assertThat(req.getBody(), is("something"));
+    }
+
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/response/ApiGatewayResponseTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/response/ApiGatewayResponseTest.java
@@ -1,0 +1,16 @@
+package com.github.seratch.jslack.app_backend.vendor.aws.lambda.response;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class ApiGatewayResponseTest {
+
+    @Test
+    public void test() {
+        ApiGatewayResponse response = ApiGatewayResponse.builder().setRawBody("something").build();
+        assertThat(response.getBody(), is("something"));
+    }
+
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This pull request brings some useful classes to build Slack App backend in Java (or other JVM langs). Currently, the `app_backend` package contains:

* Some useful classes to handle slash command payloads
* Some useful classes to handle interactive messages payloads
* Type definitions for AWS Lambda

After merging this PR, I'm going to move all the things under `com.github.seratch.jslack.api.events` to `com.github.seratch.jslack.app_backend.events`. Events API support is a very new one. I'm not sure how many people use this package but I'm sorry for the incompatibility.