### PR TITLE
Refactor SlackHttpClient to allow library users to inject code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build/
 downloaded_files/
 
 logs/
+json-logs/

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/src/main/java/com/github/seratch/jslack/Slack.java
+++ b/src/main/java/com/github/seratch/jslack/Slack.java
@@ -43,7 +43,7 @@ public class Slack {
     private Slack(SlackConfig config, SlackHttpClient httpClient) {
         this.config = config;
         this.httpClient = httpClient;
-        this.httpClient.setConfig(config);
+        this.httpClient.setConfig(this.config);
     }
 
     public static Slack getInstance() {
@@ -70,9 +70,10 @@ public class Slack {
      * Send a data to Incoming Webhook endpoint.
      */
     public WebhookResponse send(String url, Payload payload) throws IOException {
-        Response httpResponse = getHttpClient().postJsonPostRequest(url, payload);
+        SlackHttpClient httpClient = getHttpClient();
+        Response httpResponse = httpClient.postJsonPostRequest(url, payload);
         String body = httpResponse.body().string();
-        SlackHttpClient.debugLog(httpResponse, body, SlackConfig.DEFAULT);
+        httpClient.runHttpResponseListeners(httpResponse, body);
 
         return WebhookResponse.builder()
                 .code(httpResponse.code())

--- a/src/main/java/com/github/seratch/jslack/SlackConfig.java
+++ b/src/main/java/com/github/seratch/jslack/SlackConfig.java
@@ -1,6 +1,12 @@
 package com.github.seratch.jslack;
 
+import com.github.seratch.jslack.common.http.listener.DetailedLoggingListener;
+import com.github.seratch.jslack.common.http.listener.HttpResponseListener;
+import com.github.seratch.jslack.common.http.listener.ResponsePrettyPrintingListener;
 import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 public class SlackConfig {
@@ -17,11 +23,18 @@ public class SlackConfig {
         }
     };
 
+    public SlackConfig() {
+        getHttpClientResponseHandlers().add(new DetailedLoggingListener());
+        getHttpClientResponseHandlers().add(new ResponsePrettyPrintingListener());
+    }
+
     private boolean prettyResponseLoggingEnabled = false;
 
     /**
      * Don't enable this flag in production. This flag enables some validation features for development.
      */
     private boolean libraryMaintainerMode = false;
+
+    private List<HttpResponseListener> httpClientResponseHandlers = new ArrayList<>();
 
 }

--- a/src/main/java/com/github/seratch/jslack/api/model/Latest.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Latest.java
@@ -23,4 +23,5 @@ public class Latest {
     private String botId;
     private String threadTs;
     private String ts;
+    private Message.Icons icons;
 }

--- a/src/main/java/com/github/seratch/jslack/api/model/MatchedItem.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/MatchedItem.java
@@ -66,6 +66,8 @@ public class MatchedItem {
     private String prettyType;
     @SerializedName("is_external")
     private boolean external;
+    @SerializedName("is_starred")
+    private boolean starred;
     private String externalType;
     private boolean editable;
     private boolean displayAsBot;

--- a/src/main/java/com/github/seratch/jslack/api/model/Message.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/Message.java
@@ -160,6 +160,8 @@ public class Message {
 
         @SerializedName("is_public")
         private boolean _public;
+        @SerializedName("is_starred")
+        private boolean starred;
 
         public boolean isPublic() {
             return _public;

--- a/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/ResponseSender.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/ResponseSender.java
@@ -17,9 +17,10 @@ public class ResponseSender {
     }
 
     public WebhookResponse send(String responseUrl, ActionResponse response) throws IOException {
-        Response httpResponse = slack.getHttpClient().postJsonPostRequest(responseUrl, response);
+        SlackHttpClient httpClient = slack.getHttpClient();
+        Response httpResponse = httpClient.postJsonPostRequest(responseUrl, response);
         String body = httpResponse.body().string();
-        SlackHttpClient.debugLog(httpResponse, body);
+        httpClient.runHttpResponseListeners(httpResponse, body);
 
         return WebhookResponse.builder()
                 .code(httpResponse.code())

--- a/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/DelayedResponseSender.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/slash_commands/DelayedResponseSender.java
@@ -23,7 +23,7 @@ public class DelayedResponseSender {
     public WebhookResponse send(SlashCommandPayload payload, SlashCommandResponse response) throws IOException {
         Response httpResponse = httpClient.postJsonPostRequest(payload.getResponseUrl(), response);
         String body = httpResponse.body().string();
-        SlackHttpClient.debugLog(httpResponse, body, httpClient.getConfig());
+        httpClient.runHttpResponseListeners(httpResponse, body);
 
         return WebhookResponse.builder()
                 .code(httpResponse.code())

--- a/src/main/java/com/github/seratch/jslack/common/http/SlackHttpClient.java
+++ b/src/main/java/com/github/seratch/jslack/common/http/SlackHttpClient.java
@@ -2,22 +2,17 @@ package com.github.seratch.jslack.common.http;
 
 import com.github.seratch.jslack.SlackConfig;
 import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.common.http.listener.DetailedLoggingListener;
+import com.github.seratch.jslack.common.http.listener.HttpResponseListener;
 import com.github.seratch.jslack.common.json.GsonFactory;
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
-import okio.Buffer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 @Slf4j
 public class SlackHttpClient {
-
-    private static final Logger JSON_RESPONSE_LOGGER = LoggerFactory.getLogger("com.github.seratach.jslack.maintainer.json");
 
     private final OkHttpClient okHttpClient;
 
@@ -71,56 +66,18 @@ public class SlackHttpClient {
         return gson.toJson(obj);
     }
 
-    public static void debugLog(Response response, String body) throws IOException {
-        debugLog(response, body, SlackConfig.DEFAULT);
-    }
 
-    public static void debugLog(Response response, String body, SlackConfig config) throws IOException {
-        if (log.isDebugEnabled()) {
-            Buffer requestBody = new Buffer();
-            response.request().body().writeTo(requestBody);
-            String textRequestBody = null;
-            try {
-                textRequestBody = requestBody.buffer().readUtf8();
-            } catch (Exception e) {
-                log.debug("Failed to read request body because {}, error: {}", e.getMessage(), e.getClass().getCanonicalName());
-            }
-
-            log.debug("\n[Request URL]\n{} {}\n" +
-                            "[Specified Request Headers]\n{}" +
-                            "[Request Body]\n{}\n\n" +
-                            "Content-Type: {}\n" +
-                            "Content Length: {}\n" +
-                            "\n" +
-                            "[Response Status]\n{} {}\n" +
-                            "[Response Headers]\n{}" +
-                            "[Response Body]\n{}\n",
-                    response.request().method(),
-                    response.request().url(),
-                    response.request().headers(),
-                    textRequestBody,
-                    response.request().body().contentType(),
-                    response.request().body().contentLength(),
-                    response.code(),
-                    response.message(),
-                    response.headers(),
-                    body);
-
-            if (config.isPrettyResponseLoggingEnabled() && body != null && body.trim().startsWith("{")) {
-                JsonParser parser = new JsonParser();
-                JsonElement jsonObj = parser.parse(body);
-                String prettifiedJson = GsonFactory.createSnakeCase(config).toJson(jsonObj);
-                JSON_RESPONSE_LOGGER.debug("--- Pretty printing the response ---\n" +
-                        prettifiedJson + "\n" +
-                        "-----------------------------------------");
-            }
+    public void runHttpResponseListeners(Response response, String body) {
+        HttpResponseListener.State state = new HttpResponseListener.State(config, response, body);
+        for (HttpResponseListener responseListener : config.getHttpClientResponseHandlers()) {
+            responseListener.accept(state);
         }
     }
 
     public <T> T parseJsonResponse(Response response, Class<T> clazz) throws IOException, SlackApiException {
         if (response.code() == 200) {
             String body = response.body().string();
-            debugLog(response, body, config);
+            runHttpResponseListeners(response, body);
             return GsonFactory.createSnakeCase(config).fromJson(body, clazz);
         } else {
             String body = response.body().string();
@@ -128,16 +85,19 @@ public class SlackHttpClient {
         }
     }
 
+    private static final DetailedLoggingListener DETAILED_LOGGER = new DetailedLoggingListener();
+
     // use parseJsonResponse instead
     @Deprecated
     public static <T> T buildJsonResponse(Response response, Class<T> clazz) throws IOException, SlackApiException {
         if (response.code() == 200) {
             String body = response.body().string();
-            debugLog(response, body);
+            DETAILED_LOGGER.accept(new HttpResponseListener.State(SlackConfig.DEFAULT, response, body));
             return GsonFactory.createSnakeCase().fromJson(body, clazz);
         } else {
             String body = response.body().string();
             throw new SlackApiException(response, body);
         }
     }
+
 }

--- a/src/main/java/com/github/seratch/jslack/common/http/listener/DetailedLoggingListener.java
+++ b/src/main/java/com/github/seratch/jslack/common/http/listener/DetailedLoggingListener.java
@@ -1,0 +1,60 @@
+package com.github.seratch.jslack.common.http.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Response;
+import okio.Buffer;
+
+import java.io.IOException;
+
+@Slf4j
+public class DetailedLoggingListener extends HttpResponseListener {
+
+    @Override
+    public void accept(State state) {
+        if (log.isDebugEnabled()) {
+            Response response = state.getResponse();
+            String body = state.getParsedResponseBody();
+
+            Buffer requestBody = new Buffer();
+            try {
+                response.request().body().writeTo(requestBody);
+            } catch (IOException e) {
+                log.error("Failed to read the request body because {}", e.getMessage(), e);
+            }
+
+            String textRequestBody = null;
+            try {
+                textRequestBody = requestBody.buffer().readUtf8();
+            } catch (Exception e) {
+                log.debug("Failed to read request body because {}, error: {}", e.getMessage(), e.getClass().getCanonicalName());
+            }
+
+            Long contentLength = null;
+            try {
+                contentLength = response.request().body().contentLength();
+            } catch (IOException e) {
+                log.error("Failed to read the content length because {}", e.getMessage(), e);
+            }
+
+            log.debug("\n[Request URL]\n{} {}\n" +
+                            "[Specified Request Headers]\n{}" +
+                            "[Request Body]\n{}\n\n" +
+                            "Content-Type: {}\n" +
+                            "Content Length: {}\n" +
+                            "\n" +
+                            "[Response Status]\n{} {}\n" +
+                            "[Response Headers]\n{}" +
+                            "[Response Body]\n{}\n",
+                    response.request().method(),
+                    response.request().url(),
+                    response.request().headers(),
+                    textRequestBody,
+                    response.request().body().contentType(),
+                    contentLength,
+                    response.code(),
+                    response.message(),
+                    response.headers(),
+                    body);
+        }
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/common/http/listener/HttpResponseListener.java
+++ b/src/main/java/com/github/seratch/jslack/common/http/listener/HttpResponseListener.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.common.http.listener;
+
+import com.github.seratch.jslack.SlackConfig;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import okhttp3.Response;
+
+import java.util.function.Consumer;
+
+public abstract class HttpResponseListener implements Consumer<HttpResponseListener.State> {
+
+    public abstract void accept(State state);
+
+    @AllArgsConstructor
+    @Data
+    public static class State {
+        private SlackConfig config;
+        private Response response;
+        private String parsedResponseBody;
+    }
+
+}

--- a/src/main/java/com/github/seratch/jslack/common/http/listener/ResponsePrettyPrintingListener.java
+++ b/src/main/java/com/github/seratch/jslack/common/http/listener/ResponsePrettyPrintingListener.java
@@ -1,0 +1,28 @@
+package com.github.seratch.jslack.common.http.listener;
+
+import com.github.seratch.jslack.SlackConfig;
+import com.github.seratch.jslack.common.json.GsonFactory;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ResponsePrettyPrintingListener extends HttpResponseListener {
+
+    private static final Logger JSON_RESPONSE_LOGGER = LoggerFactory.getLogger("com.github.seratach.jslack.maintainer.json");
+    private static final JsonParser JSON_PARSER = new JsonParser();
+
+    @Override
+    public void accept(State state) {
+        SlackConfig config = state.getConfig();
+        String body = state.getParsedResponseBody();
+        if (config.isPrettyResponseLoggingEnabled() && body != null && body.trim().startsWith("{")) {
+            JsonElement jsonObj = JSON_PARSER.parse(body);
+            String prettifiedJson = GsonFactory.createSnakeCase(config).toJson(jsonObj);
+
+            JSON_RESPONSE_LOGGER.debug("--- Pretty printing the response ---\n" +
+                    prettifiedJson + "\n" +
+                    "-----------------------------------------");
+        }
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/shortcut/Shortcut.java
+++ b/src/main/java/com/github/seratch/jslack/shortcut/Shortcut.java
@@ -41,6 +41,8 @@ public interface Shortcut {
      */
     List<Message> findRecentMessagesByName(ChannelName name) throws IOException, SlackApiException;
 
+    List<Message> findRecentMessagesByName(ChannelName name, int limit) throws IOException, SlackApiException;
+
     /**
      * Adds a reaction to a specified message.
      */

--- a/src/main/java/com/github/seratch/jslack/shortcut/impl/ShortcutImpl.java
+++ b/src/main/java/com/github/seratch/jslack/shortcut/impl/ShortcutImpl.java
@@ -67,13 +67,18 @@ public class ShortcutImpl implements Shortcut {
 
     @Override
     public List<Message> findRecentMessagesByName(ChannelName name) throws IOException, SlackApiException {
+        return findRecentMessagesByName(name, 1000);
+    }
+
+    @Override
+    public List<Message> findRecentMessagesByName(ChannelName name, int limit) throws IOException, SlackApiException {
         Optional<ChannelId> maybeChannelId = findChannelIdByName(name);
         if (maybeChannelId.isPresent()) {
             ChannelId channelId = maybeChannelId.get();
             ChannelsHistoryResponse response = slack.methods().channelsHistory(ChannelsHistoryRequest.builder()
                     .token(apiToken.get().getValue())
                     .channel(channelId.getValue())
-                    .count(1000)
+                    .count(limit)
                     .build());
             if (response.isOk()) {
                 response.getMessages().forEach(message -> {

--- a/src/test/java/com/github/seratch/jslack/CleanupTest.java
+++ b/src/test/java/com/github/seratch/jslack/CleanupTest.java
@@ -12,6 +12,8 @@ import com.github.seratch.jslack.api.model.ConversationType;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Ignore;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.util.Arrays;
 

--- a/src/test/java/com/github/seratch/jslack/ExamplesTest.java
+++ b/src/test/java/com/github/seratch/jslack/ExamplesTest.java
@@ -10,6 +10,7 @@ import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageRespon
 import com.github.seratch.jslack.api.model.Channel;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/seratch/jslack/Slack_api_test_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_api_test_Test.java
@@ -11,6 +11,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import org.junit.Ignore;
 import org.junit.Test;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/src/test/java/com/github/seratch/jslack/Slack_apps_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_apps_Test.java
@@ -7,6 +7,8 @@ import com.github.seratch.jslack.api.methods.response.apps.permissions.AppsPermi
 import com.github.seratch.jslack.api.methods.response.apps.permissions.AppsPermissionsRequestResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/seratch/jslack/Slack_auth_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_auth_Test.java
@@ -7,6 +7,8 @@ import com.github.seratch.jslack.api.methods.response.auth.AuthRevokeResponse;
 import com.github.seratch.jslack.api.methods.response.auth.AuthTestResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/seratch/jslack/Slack_blockkit_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_blockkit_Test.java
@@ -20,6 +20,8 @@ import com.github.seratch.jslack.shortcut.model.ApiToken;
 import com.github.seratch.jslack.shortcut.model.ChannelId;
 import com.github.seratch.jslack.shortcut.model.ChannelName;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 import java.util.*;

--- a/src/test/java/com/github/seratch/jslack/Slack_bots_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_bots_Test.java
@@ -7,6 +7,8 @@ import com.github.seratch.jslack.api.methods.response.bots.BotsInfoResponse;
 import com.github.seratch.jslack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 import java.util.List;
@@ -22,28 +24,27 @@ public class Slack_bots_Test {
     Slack slack = Slack.getInstance(SlackTestConfig.get());
 
     @Test
+    public void botsInfoError() throws IOException, SlackApiException {
+        BotsInfoResponse response = slack.methods().botsInfo(BotsInfoRequest.builder().build());
+        assertThat(response.getError(), is(notNullValue()));
+        assertThat(response.isOk(), is(false));
+    }
+
+    @Test
     public void botsInfo() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
 
-        List<User> users = slack.methods()
-                .usersList(UsersListRequest.builder()
-                        .token(token)
-                        .build())
-                .getMembers();
+        List<User> users = slack.methods().usersList(UsersListRequest.builder().token(token).build()).getMembers();
         User user = users.stream()
                 .filter(u -> u.isBot() && !"USLACKBOT".equals(u.getId()))
                 .findFirst()
                 .get();
-        String bot = user.getProfile()
-                .getBotId();
+        String bot = user.getProfile().getBotId();
 
-        BotsInfoResponse response = slack.methods()
-                .botsInfo(BotsInfoRequest.builder()
-                        .token(token)
-                        .bot(bot)
-                        .build());
+        BotsInfoResponse response = slack.methods().botsInfo(BotsInfoRequest.builder().token(token).bot(bot).build());
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getBot(), is(notNullValue()));
     }
+
 }

--- a/src/test/java/com/github/seratch/jslack/Slack_channels_chat_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_channels_chat_Test.java
@@ -11,6 +11,8 @@ import com.github.seratch.jslack.api.model.Channel;
 import com.github.seratch.jslack.api.model.Message;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 
@@ -90,6 +92,7 @@ public class Slack_channels_chat_Test {
             ChannelsHistoryResponse history = slack.methods().channelsHistory(ChannelsHistoryRequest.builder()
                     .token(token)
                     .channel(channelId)
+                    .count(20)
                     .build());
             assertThat(history.isOk(), is(true));
 
@@ -118,6 +121,7 @@ public class Slack_channels_chat_Test {
             ConversationsHistoryResponse history = slack.methods().conversationsHistory(ConversationsHistoryRequest.builder()
                     .token(token)
                     .channel(channelId)
+                    .limit(20)
                     .build());
             assertThat(history.isOk(), is(true));
 

--- a/src/test/java/com/github/seratch/jslack/Slack_conversations_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_conversations_Test.java
@@ -15,6 +15,9 @@ import com.github.seratch.jslack.api.model.block.composition.MarkdownTextObject;
 import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
+import testing.TestChannelGenerator;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;

--- a/src/test/java/com/github/seratch/jslack/Slack_dialogs_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_dialogs_Test.java
@@ -8,6 +8,7 @@ import com.github.seratch.jslack.api.model.dialog.DialogSubType;
 import com.github.seratch.jslack.api.model.dialog.DialogTextElement;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/src/test/java/com/github/seratch/jslack/Slack_dnd_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_dnd_Test.java
@@ -9,6 +9,8 @@ import com.github.seratch.jslack.api.methods.response.dnd.DndTeamInfoResponse;
 import com.github.seratch.jslack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/test/java/com/github/seratch/jslack/Slack_emoji_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_emoji_Test.java
@@ -5,6 +5,8 @@ import com.github.seratch.jslack.api.methods.request.emoji.EmojiListRequest;
 import com.github.seratch.jslack.api.methods.response.emoji.EmojiListResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/seratch/jslack/Slack_files_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_files_Test.java
@@ -17,6 +17,9 @@ import com.github.seratch.jslack.api.methods.response.files.comments.FilesCommen
 import com.github.seratch.jslack.api.model.Conversation;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
+import testing.TestChannelGenerator;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/com/github/seratch/jslack/Slack_groups_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_groups_Test.java
@@ -8,6 +8,8 @@ import com.github.seratch.jslack.api.methods.response.groups.*;
 import com.github.seratch.jslack.api.model.Group;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 
@@ -50,7 +52,7 @@ public class Slack_groups_Test {
 
         {
             GroupsHistoryResponse response = slack.methods().groupsHistory(
-                    GroupsHistoryRequest.builder().token(token).channel(group.getId()).build());
+                    GroupsHistoryRequest.builder().token(token).channel(group.getId()).count(10).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }

--- a/src/test/java/com/github/seratch/jslack/Slack_im_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_im_Test.java
@@ -9,6 +9,8 @@ import com.github.seratch.jslack.api.methods.response.users.UsersListResponse;
 import com.github.seratch.jslack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.util.List;
 
@@ -96,6 +98,7 @@ public class Slack_im_Test {
         ImHistoryResponse historyResponse = slack.methods().imHistory(ImHistoryRequest.builder()
                 .token(token)
                 .channel(channelId)
+                .count(10)
                 .build());
         assertThat(historyResponse.getError(), is(nullValue()));
         assertThat(historyResponse.isOk(), is(true));

--- a/src/test/java/com/github/seratch/jslack/Slack_incomingWebhooks_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_incomingWebhooks_Test.java
@@ -10,6 +10,7 @@ import com.github.seratch.jslack.api.webhook.Payload;
 import com.github.seratch.jslack.api.webhook.WebhookResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/com/github/seratch/jslack/Slack_mpim_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_mpim_Test.java
@@ -8,6 +8,8 @@ import com.github.seratch.jslack.api.methods.response.users.UsersListResponse;
 import com.github.seratch.jslack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 import java.util.List;
@@ -47,7 +49,7 @@ public class Slack_mpim_Test {
         assertThat(markResponse.getError(), is(nullValue()));
         assertThat(markResponse.isOk(), is(true));
 
-        MpimHistoryResponse historyResponse = slack.methods().mpimHistory(MpimHistoryRequest.builder().token(token).channel(channelId).build());
+        MpimHistoryResponse historyResponse = slack.methods().mpimHistory(MpimHistoryRequest.builder().token(token).channel(channelId).count(10).build());
         assertThat(historyResponse.getError(), is(nullValue()));
         assertThat(historyResponse.isOk(), is(true));
 

--- a/src/test/java/com/github/seratch/jslack/Slack_oauth_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_oauth_Test.java
@@ -7,6 +7,7 @@ import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthTokenResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/seratch/jslack/Slack_pins_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_pins_Test.java
@@ -12,6 +12,7 @@ import com.github.seratch.jslack.api.methods.response.pins.PinsListResponse;
 import com.github.seratch.jslack.api.methods.response.pins.PinsRemoveResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/com/github/seratch/jslack/Slack_reactions_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_reactions_Test.java
@@ -15,6 +15,7 @@ import com.github.seratch.jslack.api.methods.response.reactions.ReactionsListRes
 import com.github.seratch.jslack.api.methods.response.reactions.ReactionsRemoveResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/seratch/jslack/Slack_reminders_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_reminders_Test.java
@@ -10,6 +10,7 @@ import com.github.seratch.jslack.api.methods.response.reminders.RemindersDeleteR
 import com.github.seratch.jslack.api.methods.response.reminders.RemindersInfoResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;

--- a/src/test/java/com/github/seratch/jslack/Slack_rtm_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_rtm_Test.java
@@ -18,6 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
+import testing.TestChannelGenerator;
 
 import javax.websocket.DeploymentException;
 import java.io.IOException;
@@ -80,7 +83,7 @@ public class Slack_rtm_Test {
 
         // need to invite the bot user to the created channel before starting an RTM session
         inviteBotUser(channelId);
-        
+
         String botToken = System.getenv(Constants.SLACK_BOT_USER_TEST_OAUTH_ACCESS_TOKEN);
 
         RTMEventsDispatcher dispatcher = RTMEventsDispatcherFactory.getInstance();
@@ -115,7 +118,7 @@ public class Slack_rtm_Test {
             assertThat(hello2.counter.get(), is(3));
         }
     }
-    
+
     @Test
     public void rtmStart() throws Exception {
         // TODO: "prefs" support
@@ -149,7 +152,7 @@ public class Slack_rtm_Test {
             channelGenerator.archiveChannel(channel);
         }
     }
-    
+
     @Ignore
     @Test
     public void rtmConnect_withoutFullConnectedUserInfo() throws Exception {

--- a/src/test/java/com/github/seratch/jslack/Slack_scim_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_scim_Test.java
@@ -4,6 +4,8 @@ import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.scim.request.UsersDeleteRequest;
 import com.github.seratch.jslack.api.scim.response.UsersDeleteResponse;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/seratch/jslack/Slack_search_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_search_Test.java
@@ -10,6 +10,8 @@ import com.github.seratch.jslack.api.methods.response.search.SearchMessagesRespo
 import com.github.seratch.jslack.api.model.MatchedItem;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/seratch/jslack/Slack_shortcut_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_shortcut_Test.java
@@ -17,6 +17,8 @@ import com.github.seratch.jslack.shortcut.model.ChannelName;
 import com.github.seratch.jslack.shortcut.model.ReactionName;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -46,7 +48,7 @@ public class Slack_shortcut_Test {
         assertThat(maybeChannelName.isPresent(), is(true));
         assertThat(maybeChannelName.get(), is(channelName));
 
-        List<Message> messages = shortcut.findRecentMessagesByName(channelName);
+        List<Message> messages = shortcut.findRecentMessagesByName(channelName, 10);
         assertThat(messages, is(notNullValue()));
 
         SearchAllResponse searchResult = shortcut.search("hello");
@@ -65,25 +67,25 @@ public class Slack_shortcut_Test {
         List<Attachment> attachments = Arrays.asList(attachment);
 
         {
-            ChatPostMessageResponse response = shortcut.post(ChannelName.of("general"), "hello, hello!");
+            ChatPostMessageResponse response = shortcut.post(ChannelName.of("random"), "hello, hello!");
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
-            ChatPostMessageResponse response = shortcut.postAsBot(ChannelName.of("general"), "hello, hello!");
+            ChatPostMessageResponse response = shortcut.postAsBot(ChannelName.of("random"), "hello, hello!");
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
-            ChatPostMessageResponse response = shortcut.post(ChannelName.of("general"), "Hi, these are my attachments!", attachments);
+            ChatPostMessageResponse response = shortcut.post(ChannelName.of("random"), "Hi, these are my attachments!", attachments);
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
-            ChatPostMessageResponse response = shortcut.postAsBot(ChannelName.of("general"), "Hi, these are my attachments!", attachments);
+            ChatPostMessageResponse response = shortcut.postAsBot(ChannelName.of("random"), "Hi, these are my attachments!", attachments);
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }

--- a/src/test/java/com/github/seratch/jslack/Slack_stars_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_stars_Test.java
@@ -12,6 +12,7 @@ import com.github.seratch.jslack.api.methods.response.stars.StarsListResponse;
 import com.github.seratch.jslack.api.methods.response.stars.StarsRemoveResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/com/github/seratch/jslack/Slack_team_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_team_Test.java
@@ -14,6 +14,8 @@ import com.github.seratch.jslack.api.methods.response.team.profile.TeamProfileGe
 import com.github.seratch.jslack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.util.List;
 

--- a/src/test/java/com/github/seratch/jslack/Slack_usergroups_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_usergroups_Test.java
@@ -8,6 +8,8 @@ import com.github.seratch.jslack.api.methods.response.usergroups.UsergroupsListR
 import com.github.seratch.jslack.api.methods.response.usergroups.users.UsergroupUsersListResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/src/test/java/com/github/seratch/jslack/Slack_users_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_users_Test.java
@@ -7,6 +7,8 @@ import com.github.seratch.jslack.api.methods.response.users.*;
 import com.github.seratch.jslack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/com/github/seratch/jslack/Slack_users_profile_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_users_profile_Test.java
@@ -8,6 +8,8 @@ import com.github.seratch.jslack.api.methods.response.users.profile.UsersProfile
 import com.github.seratch.jslack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import testing.Constants;
+import testing.SlackTestConfig;
 
 import java.io.IOException;
 

--- a/src/test/java/testing/Constants.java
+++ b/src/test/java/testing/Constants.java
@@ -1,4 +1,4 @@
-package com.github.seratch.jslack;
+package testing;
 
 public class Constants {
     private Constants() {

--- a/src/test/java/testing/SlackTestConfig.java
+++ b/src/test/java/testing/SlackTestConfig.java
@@ -1,4 +1,7 @@
-package com.github.seratch.jslack;
+package testing;
+
+import com.github.seratch.jslack.SlackConfig;
+import testing.json.JsonDataRecordingListener;
 
 public class SlackTestConfig {
 
@@ -10,6 +13,7 @@ public class SlackTestConfig {
     static {
         CONFIG.setLibraryMaintainerMode(true);
         CONFIG.setPrettyResponseLoggingEnabled(true);
+        CONFIG.getHttpClientResponseHandlers().add(new JsonDataRecordingListener());
     }
 
     public static SlackConfig get() {

--- a/src/test/java/testing/TestChannelGenerator.java
+++ b/src/test/java/testing/TestChannelGenerator.java
@@ -1,5 +1,6 @@
-package com.github.seratch.jslack;
+package testing;
 
+import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.request.conversations.ConversationsArchiveRequest;
 import com.github.seratch.jslack.api.methods.request.conversations.ConversationsCreateRequest;

--- a/src/test/java/testing/json/JsonDataRecorder.java
+++ b/src/test/java/testing/json/JsonDataRecorder.java
@@ -1,0 +1,63 @@
+package testing.json;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Response;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class JsonDataRecorder {
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    private String outputDirectory;
+
+    public JsonDataRecorder(String outputDirectory) {
+        this.outputDirectory = outputDirectory;
+    }
+
+    public void writeMergedResponse(Response response, String body) throws IOException {
+        if (body == null || (!body.trim().startsWith("{") && !body.trim().startsWith("["))) {
+            // given body is not in JSON format
+            return;
+        }
+        JsonParser jsonParser = new JsonParser();
+        String json = null;
+        String path = response.request().url().url().getPath();
+        try {
+            Path jsonFilePath = new File(toFilePath(path)).toPath();
+            json = Files.readAllLines(jsonFilePath, UTF_8).stream().collect(Collectors.joining());
+        } catch (NoSuchFileException e) {
+        }
+        if (json == null || json.trim().isEmpty()) {
+            json = "{}";
+        }
+        JsonElement obj = jsonParser.parse(json);
+        JsonObject result = obj.getAsJsonObject();
+        try {
+            JsonObject jsonObj = jsonParser.parse(body).getAsJsonObject();
+            MergeJsonBuilder.mergeJsonObjects(result, MergeJsonBuilder.ConflictStrategy.PREFER_NON_NULL, jsonObj);
+        } catch (MergeJsonBuilder.JsonConflictException e) {
+            log.warn("Failed to merge JSON objects because {}", e.getMessage(), e);
+        }
+        json = new GsonBuilder().setPrettyPrinting().create().toJson(result);
+        Path filePath = new File(toFilePath(path)).toPath();
+        Files.createDirectories(filePath.getParent());
+        Files.write(filePath, json.getBytes(UTF_8));
+    }
+
+    private String toFilePath(String path) {
+        return outputDirectory + "/" + path + ".json";
+    }
+
+}

--- a/src/test/java/testing/json/JsonDataRecordingListener.java
+++ b/src/test/java/testing/json/JsonDataRecordingListener.java
@@ -1,0 +1,21 @@
+package testing.json;
+
+import com.github.seratch.jslack.common.http.listener.HttpResponseListener;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class JsonDataRecordingListener extends HttpResponseListener {
+
+    JsonDataRecorder recorder = new JsonDataRecorder("./json-logs");
+    @Override
+    public void accept(State state) {
+        try {
+
+            recorder.writeMergedResponse(state.getResponse(), state.getParsedResponseBody());
+        } catch (IOException e) {
+            log.error("Failed to write JSON files because {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/test/java/testing/json/MergeJsonBuilder.java
+++ b/src/test/java/testing/json/MergeJsonBuilder.java
@@ -1,0 +1,98 @@
+package testing.json;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.Map;
+
+/**
+ * https://stackoverflow.com/a/34092374/840108
+ */
+public class MergeJsonBuilder {
+
+    private MergeJsonBuilder() {
+    }
+
+    public enum ConflictStrategy {
+        THROW_EXCEPTION,
+        PREFER_FIRST_OBJ,
+        PREFER_SECOND_OBJ,
+        PREFER_NON_NULL
+    }
+
+    public static class JsonConflictException extends Exception {
+
+        public JsonConflictException(String message) {
+            super(message);
+        }
+
+    }
+
+    public static void mergeJsonObjects(
+            JsonObject destinationObject,
+            ConflictStrategy conflictResolutionStrategy,
+            JsonObject... jsonObjects) throws JsonConflictException {
+
+        for (JsonObject obj : jsonObjects) {
+            mergeJsonObjects(destinationObject, obj, conflictResolutionStrategy);
+        }
+    }
+
+    private static void mergeJsonObjects(
+            JsonObject leftObj,
+            JsonObject rightObj,
+            ConflictStrategy conflictStrategy) throws JsonConflictException {
+
+        for (Map.Entry<String, JsonElement> rightEntry : rightObj.entrySet()) {
+            String rightKey = rightEntry.getKey();
+            JsonElement rightVal = rightEntry.getValue();
+            if (leftObj.has(rightKey)) {
+                //conflict
+                JsonElement leftVal = leftObj.get(rightKey);
+                if (leftVal.isJsonArray() && rightVal.isJsonArray()) {
+                    JsonArray leftArr = leftVal.getAsJsonArray();
+                    JsonArray rightArr = rightVal.getAsJsonArray();
+                    //concat the arrays -- there cannot be a conflict in an array, it's just a collection of stuff
+                    for (int i = 0; i < rightArr.size(); i++) {
+                        leftArr.add(rightArr.get(i));
+                    }
+                } else if (leftVal.isJsonObject() && rightVal.isJsonObject()) {
+                    //recursive merging
+                    mergeJsonObjects(leftVal.getAsJsonObject(), rightVal.getAsJsonObject(), conflictStrategy);
+                } else {//not both arrays or objects, normal merge with conflict resolution
+                    handleMergeConflict(rightKey, leftObj, leftVal, rightVal, conflictStrategy);
+                }
+            } else {//no conflict, add to the object
+                leftObj.add(rightKey, rightVal);
+            }
+        }
+    }
+
+    private static void handleMergeConflict(
+            String key,
+            JsonObject leftObj,
+            JsonElement leftVal,
+            JsonElement rightVal,
+            ConflictStrategy conflictStrategy) throws JsonConflictException {
+
+        switch (conflictStrategy) {
+            case PREFER_FIRST_OBJ:
+                break;//do nothing, the right val gets thrown out
+            case PREFER_SECOND_OBJ:
+                leftObj.add(key, rightVal);//right side auto-wins, replace left val with its val
+                break;
+            case PREFER_NON_NULL:
+                //check if right side is not null, and left side is null, in which case we use the right val
+                if (leftVal.isJsonNull() && !rightVal.isJsonNull()) {
+                    leftObj.add(key, rightVal);
+                }//else do nothing since either the left value is non-null or the right value is null
+                break;
+            case THROW_EXCEPTION:
+                throw new JsonConflictException("Key " + key + " exists in both objects and the conflict resolution strategy is " + conflictStrategy);
+            default:
+                throw new UnsupportedOperationException("The conflict strategy " + conflictStrategy + " is unknown and cannot be processed");
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request brings more enhancement points in SlackHttpClient to library users. I've refactored existing code and moved them as `DetailedLoggingListener` and `ResponsePrettyPrintingListener`. Also, I added `JsonDataRecordingListener` for tests.