### PR TITLE
Don't kill thread when event handling fails

### DIFF
--- a/src/main/java/com/github/seratch/jslack/app_backend/events/EventsDispatcherImpl.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/events/EventsDispatcherImpl.java
@@ -66,10 +66,14 @@ public class EventsDispatcherImpl implements EventsDispatcher {
         if (eventHandlers == null || eventHandlers.size() == 0) {
             log.debug("No event handler registered for type: {}", eventType);
         } else {
-            Class<?> clazz = eventHandlers.get(0).getEventPayloadClass();
-            EventsApiPayload<?> event = (EventsApiPayload) GsonFactory.createSnakeCase().fromJson(json, clazz);
-            for (EventHandler<?> handler : eventHandlers) {
-                handler.acceptUntypedObject(event);
+            try {
+                Class<?> clazz = eventHandlers.get(0).getEventPayloadClass();
+                EventsApiPayload<?> event = (EventsApiPayload) GsonFactory.createSnakeCase().fromJson(json, clazz);
+                for (EventHandler<?> handler : eventHandlers) {
+                    handler.acceptUntypedObject(event);
+                }
+            } catch (Exception ex) {
+                log.error("Exception handling event with type: {}", eventType, ex);
             }
         }
     }


### PR DESCRIPTION
Currently , if the EventsDispatcher fails deserialize an event payload, or if an exception occurs during the implementing handler, the thread polling the queue will die and not continue polling. This means you'll miss all events after the first failure. Instead, it should log an error but continue handling events.