### PR TITLE
Add Slack signature support

### DIFF
--- a/src/main/java/com/github/seratch/jslack/app_backend/SlackSignature.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/SlackSignature.java
@@ -1,0 +1,88 @@
+package com.github.seratch.jslack.app_backend;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * see "https://api.slack.com/docs/verifying-requests-from-slack"
+ */
+public class SlackSignature {
+
+    public static final String ALGORITHM = "HmacSHA256";
+
+
+    private SlackSignature() {
+    }
+
+    public static class HeaderNames {
+        private HeaderNames() {
+        }
+
+        public static final String X_SLACK_REQUEST_TIMESTAMP = "X-Slack-Request-Timestamp";
+
+        public static final String X_SLACK_SIGNATURE = "X-Slack-Signature";
+
+    }
+
+    public static class Secret {
+        private Secret() {
+        }
+
+        public static final String DEFAULT_ENV_NAME = "SLACK_SIGNING_SECRET";
+    }
+
+
+    @Slf4j
+    public static class Generator {
+
+        private final String slackSigningSecret;
+
+        public Generator() {
+            this(System.getenv(Secret.DEFAULT_ENV_NAME));
+        }
+
+        public Generator(String slackSigningSecret) {
+            this.slackSigningSecret = slackSigningSecret;
+        }
+
+        public String generate(String slackRequestTimestamp, String requestBody) {
+            if (slackRequestTimestamp == null) {
+                return null;
+            }
+
+            // 1) Retrieve the X-Slack-Request-Timestamp header on the HTTP request, and the body of the request.
+            // "slackRequestTimestamp" here
+
+            // 2) Concatenate the version number, the timestamp, and the body of the request to form a basestring.
+            //    Use a colon as the delimiter between the three elements.
+            //    For example, v0:123456789:command=/weather&text=94070. The version number right now is always v0.
+            String baseString = "v0:" + slackRequestTimestamp + ":" + requestBody;
+
+            // 3) With the help of HMAC SHA256 implemented in your favorite programming, hash the above basestring,
+            //    using the Slack Signing Secret as the key.
+            SecretKeySpec sk = new SecretKeySpec(slackSigningSecret.getBytes(), ALGORITHM);
+            try {
+                Mac mac = Mac.getInstance(ALGORITHM);
+                mac.init(sk);
+                byte[] macBytes = mac.doFinal(baseString.getBytes());
+                StringBuilder hashValue = new StringBuilder(2 * macBytes.length);
+                for (byte macByte : macBytes) {
+                    hashValue.append(String.format("%02x", macByte & 0xff));
+                }
+                return "v0=" + hashValue.toString();
+
+                // 4) Compare this computed signature to the X-Slack-Signature header on the request.
+
+            } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+                log.error("Failed to hash the base string value with HMAC-SHA256 because {}", e.getMessage(), e);
+                return null;
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/util/RequestTokenVerifier.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/util/RequestTokenVerifier.java
@@ -4,6 +4,8 @@ import com.github.seratch.jslack.app_backend.interactive_messages.payload.Attach
 import com.github.seratch.jslack.app_backend.interactive_messages.payload.BlockActionPayload;
 import com.github.seratch.jslack.app_backend.slash_commands.payload.SlashCommandPayload;
 
+// Use SlackSignature instead
+@Deprecated
 public class RequestTokenVerifier {
 
     // https://api.slack.com/apps/{apiAppId}

--- a/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/util/SlackSignatureVerifier.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/util/SlackSignatureVerifier.java
@@ -1,0 +1,30 @@
+package com.github.seratch.jslack.app_backend.vendor.aws.lambda.util;
+
+import com.github.seratch.jslack.app_backend.SlackSignature;
+import com.github.seratch.jslack.app_backend.vendor.aws.lambda.request.ApiGatewayRequest;
+
+public class SlackSignatureVerifier {
+
+    private final SlackSignature.Generator signatureGenerator;
+
+    public SlackSignatureVerifier() {
+        this(new SlackSignature.Generator());
+    }
+
+    public SlackSignatureVerifier(SlackSignature.Generator signatureGenerator) {
+        this.signatureGenerator = signatureGenerator;
+    }
+
+    public boolean isValid(ApiGatewayRequest request) {
+        if (request != null && request.getHeaders() != null) {
+            String requestTimestamp = request.getHeaders().get(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP);
+            String requestBody = request.getBody();
+            String expected = signatureGenerator.generate(requestTimestamp, requestBody);
+            String actual = request.getHeaders().get(SlackSignature.HeaderNames.X_SLACK_SIGNATURE);
+            return actual != null && expected != null && actual.equals(expected);
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/SlackSignatureTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/SlackSignatureTest.java
@@ -1,0 +1,20 @@
+package com.github.seratch.jslack.app_backend;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class SlackSignatureTest {
+
+    @Test
+    public void test() {
+        // https://api.slack.com/docs/verifying-requests-from-slack
+        SlackSignature.Generator generator = new SlackSignature.Generator("8f742231b10e8888abcd99yyyzzz85a5");
+        String timestamp = "1531420618";
+        String requestBody = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+        String generatedValue = generator.generate(timestamp, requestBody);
+        assertThat(generatedValue, is("v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"));
+    }
+
+}

--- a/src/test/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/util/SlackSignatureVerifierTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/util/SlackSignatureVerifierTest.java
@@ -1,0 +1,50 @@
+package com.github.seratch.jslack.app_backend.vendor.aws.lambda.util;
+
+import com.github.seratch.jslack.app_backend.SlackSignature;
+import com.github.seratch.jslack.app_backend.vendor.aws.lambda.request.ApiGatewayRequest;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+// https://api.slack.com/docs/verifying-requests-from-slack
+public class SlackSignatureVerifierTest {
+
+    @Test
+    public void valid() {
+        SlackSignature.Generator generator = new SlackSignature.Generator("8f742231b10e8888abcd99yyyzzz85a5");
+        String timestamp = "1531420618";
+        String requestBody = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+        SlackSignatureVerifier verifier = new SlackSignatureVerifier(generator);
+
+        ApiGatewayRequest request = new ApiGatewayRequest();
+        request.setBody(requestBody);
+        request.setHeaders(new HashMap<>());
+        request.getHeaders().put("X-Slack-Request-Timestamp", timestamp);
+        String validSignature = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
+        request.getHeaders().put("X-Slack-Signature", validSignature);
+
+        assertThat(verifier.isValid(request), is(true));
+    }
+
+    @Test
+    public void invalid() {
+        SlackSignature.Generator generator = new SlackSignature.Generator("8f742231b10e8888abcd99yyyzzz85a5");
+        String timestamp = "1531420620"; // invalid timestamp
+        String requestBody = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+        SlackSignatureVerifier verifier = new SlackSignatureVerifier(generator);
+
+        ApiGatewayRequest request = new ApiGatewayRequest();
+        request.setBody(requestBody);
+        request.setHeaders(new HashMap<>());
+        request.getHeaders().put("X-Slack-Request-Timestamp", timestamp);
+
+        String invalidSignature = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
+        request.getHeaders().put("X-Slack-Signature", invalidSignature);
+
+        assertThat(verifier.isValid(request), is(false));
+    }
+
+}


### PR DESCRIPTION
This pull request adds an implementation which generates Slack's signatures. Verification tokens are already deprecated and will be terminated at some point. All Slack app developers need to move to signatures.

https://api.slack.com/docs/verifying-requests-from-slack