### PR TITLE
Fix several missing parts

### DIFF
--- a/json-logs/samples/api/channels.info.json
+++ b/json-logs/samples/api/channels.info.json
@@ -85,8 +85,11 @@
       },
       "attachments": [
         {
-          "msg_subtype": "",
+          "text": "",
+          "footer": "",
+          "id": 12345,
           "fallback": "",
+          "msg_subtype": "",
           "callback_id": "",
           "color": "",
           "pretext": "",
@@ -101,7 +104,6 @@
           "author_subname": "",
           "channel_id": "",
           "channel_name": "",
-          "id": 12345,
           "bot_id": "",
           "is_msg_unfurl": false,
           "is_reply_unfurl": false,
@@ -110,7 +112,6 @@
           "is_app_unfurl": false,
           "title": "",
           "title_link": "",
-          "text": "",
           "fields": [
             {
               "title": "",
@@ -125,7 +126,6 @@
           "thumb_url": "",
           "thumb_width": 12345,
           "thumb_height": 12345,
-          "footer": "",
           "footer_icon": "",
           "ts": "",
           "mrkdwn_in": [

--- a/json-logs/samples/rtm/ErrorEvent.json
+++ b/json-logs/samples/rtm/ErrorEvent.json
@@ -1,0 +1,7 @@
+{
+  "type": "error",
+  "error": {
+    "code": 123,
+    "msg": ""
+  }
+}

--- a/src/main/java/com/github/seratch/jslack/api/model/event/ErrorEvent.java
+++ b/src/main/java/com/github/seratch/jslack/api/model/event/ErrorEvent.java
@@ -1,0 +1,34 @@
+package com.github.seratch.jslack.api.model.event;
+
+import lombok.Data;
+
+/**
+ * If there was a problem connecting an error will be returned,
+ * including a descriptive error message:
+ *
+ * <pre>
+ * {
+ *     "type": "error",
+ *     "error": {
+ *         "code": 1,
+ *         "msg": "Socket URL has expired"
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * https://api.slack.com/rtm
+ */
+@Data
+public class ErrorEvent implements Event {
+
+    public static final String TYPE_NAME = "error";
+
+    private final String type = TYPE_NAME;
+    private Error error;
+
+    @Data
+    public static class Error {
+        private Integer code;
+        private String msg;
+    }
+}

--- a/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/AttachmentActionPayload.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/interactive_messages/payload/AttachmentActionPayload.java
@@ -44,6 +44,12 @@ public class AttachmentActionPayload {
         private String name;
         private String type;
         private String value;
+        private List<SelectedOption> selectedOptions;
+
+        @Data
+        public static class SelectedOption {
+            private String value;
+        }
     }
 
     @Data

--- a/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/response/ApiGatewayResponse.java
+++ b/src/main/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/response/ApiGatewayResponse.java
@@ -57,31 +57,51 @@ public class ApiGatewayResponse {
         private byte[] binaryBody;
         private boolean base64Encoded;
 
-        public Builder setStatusCode(int statusCode) {
+        public Builder statusCode(int statusCode) {
             this.statusCode = statusCode;
             return this;
         }
 
-        public Builder setHeaders(Map<String, String> headers) {
+        @Deprecated
+        public Builder setStatusCode(int statusCode) {
+            return statusCode(statusCode);
+        }
+
+        public Builder headers(Map<String, String> headers) {
             this.headers = headers;
             return this;
+        }
+
+        @Deprecated
+        public Builder setHeaders(Map<String, String> headers) {
+            return headers(headers);
         }
 
         /**
          * Builds the {@link ApiGatewayResponse} using the passed raw body string.
          */
-        public Builder setRawBody(String rawBody) {
+        public Builder rawBody(String rawBody) {
             this.rawBody = rawBody;
             return this;
+        }
+
+        @Deprecated
+        public Builder setRawBody(String rawBody) {
+            return rawBody(rawBody);
         }
 
         /**
          * Builds the {@link ApiGatewayResponse} using the passed object body
          * converted to JSON.
          */
-        public Builder setObjectBody(Object objectBody) {
+        public Builder objectBody(Object objectBody) {
             this.objectBody = objectBody;
             return this;
+        }
+
+        @Deprecated
+        public Builder setObjectBody(Object objectBody) {
+            return objectBody(objectBody);
         }
 
         /**
@@ -89,10 +109,15 @@ public class ApiGatewayResponse {
          * encoded as base64. {@link #setBase64Encoded(boolean)
          * setBase64Encoded(true)} will be in invoked automatically.
          */
-        public Builder setBinaryBody(byte[] binaryBody) {
+        public Builder binaryBody(byte[] binaryBody) {
             this.binaryBody = binaryBody;
-            setBase64Encoded(true);
+            base64Encoded(true);
             return this;
+        }
+
+        @Deprecated
+        public Builder setBinaryBody(byte[] binaryBody) {
+            return binaryBody(binaryBody);
         }
 
         /**
@@ -103,9 +128,14 @@ public class ApiGatewayResponse {
          * Types"
          * </ol>
          */
-        public Builder setBase64Encoded(boolean base64Encoded) {
+        public Builder base64Encoded(boolean base64Encoded) {
             this.base64Encoded = base64Encoded;
             return this;
+        }
+
+        @Deprecated
+        public Builder setBase64Encoded(boolean base64Encoded) {
+            return base64Encoded(base64Encoded);
         }
 
         public ApiGatewayResponse build() {

--- a/src/test/java/com/github/seratch/jslack/RTMPayloadDumpTest.java
+++ b/src/test/java/com/github/seratch/jslack/RTMPayloadDumpTest.java
@@ -39,6 +39,7 @@ public class RTMPayloadDumpTest {
                 new DndUpdatedUserEvent(),
                 new EmailDomainChangedEvent(),
                 buildEmojiChangedEvent(),
+                new ErrorEvent(),
                 new FileChangeEvent(),
                 new FileCommentAddedEvent(),
                 new FileCommentDeletedEvent(),

--- a/src/test/java/com/github/seratch/jslack/Slack_users_Test.java
+++ b/src/test/java/com/github/seratch/jslack/Slack_users_Test.java
@@ -27,7 +27,19 @@ public class Slack_users_Test {
     Slack slack = Slack.getInstance(SlackTestConfig.get());
 
     @Test
-    public void users() throws IOException, SlackApiException {
+    public void showUsers() throws IOException, SlackApiException {
+        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+        UsersListResponse users = slack.methods().usersList(UsersListRequest.builder()
+                .token(token)
+                .limit(100)
+                .build());
+        for (User member : users.getMembers()) {
+            log.info("user id: {} , name: {}", member.getId(), member.getName());
+        }
+    }
+
+    @Test
+    public void usersScenarios() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
 
         {

--- a/src/test/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/response/ApiGatewayResponseTest.java
+++ b/src/test/java/com/github/seratch/jslack/app_backend/vendor/aws/lambda/response/ApiGatewayResponseTest.java
@@ -9,7 +9,7 @@ public class ApiGatewayResponseTest {
 
     @Test
     public void test() {
-        ApiGatewayResponse response = ApiGatewayResponse.builder().setRawBody("something").build();
+        ApiGatewayResponse response = ApiGatewayResponse.builder().rawBody("something").build();
         assertThat(response.getBody(), is("something"));
     }
 


### PR DESCRIPTION
- Add ErrorEvent type to RTM events
- Add selected_options to `interactive_message` payloads
- Make the naming of setter methods in ApiGatewayResponseBuilder consistent with others generated by Lombok