### PR TITLE
Add handier methods to build web-api requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ ChannelsCreateRequest channelCreation = ChannelsCreateRequest.builder().token(to
 ChannelsCreateResponse response = slack.methods().channelsCreate(channelCreation);
 ```
 
+Or, using lambda function to build a request could be much simpler. You don't need to type the long class name!
+
+```java
+final String token = System.getenv("SLACK_BOT_TEST_API_TOKEN");
+ChannelsCreateResponse response =
+  slack.methods().channelsCreate(req -> req.token(token).name(channelName).build());
+```
 #### API Methods Examples
 
 You can find more examples here: https://github.com/seratch/jslack/tree/master/src/test/java/com/github/seratch/jslack
@@ -214,19 +221,18 @@ Slack slack = Slack.getInstance();
 
 // find all channels in the team
 ChannelsListResponse channelsResponse = slack.methods().channelsList(
-  ChannelsListRequest.builder().token(token).build());
+  req -> req.token(token).build());
 assertThat(channelsResponse.isOk(), is(true));
 // find #general
 Channel general = channelsResponse.getChannels().stream()
         .filter(c -> c.getName().equals("general")).findFirst().get();
 
 // https://slack.com/api/chat.postMessage
-ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(
-  ChatPostMessageRequest.builder()
-    .token(token)
-    .channel(general.getId())
-    .text("Hello World!")
-    .build());
+ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(req -> req
+  .token(token)
+  .channel(general.getId())
+  .text("Hello World!")
+  .build());
 assertThat(postResponse.isOk(), is(true));
 
 // timestamp of the posted message
@@ -234,22 +240,21 @@ String messageTimestamp = postResponse.getMessage().getTs();
 
 Thread.sleep(1000L);
 
-ChatDeleteResponse deleteResponse = slack.methods().chatDelete(
-  ChatDeleteRequest.builder()
-    .token(token)
-    .channel(general.getId())
-    .ts(messageTimestamp)
-    .build());
+ChatDeleteResponse deleteResponse = slack.methods().chatDelete(req -> req
+  .token(token)
+  .channel(general.getId())
+  .ts(messageTimestamp)
+  .build());
 assertThat(deleteResponse.isOk(), is(true));
 ```
 
 ##### Open a dialog modal
 
 ```java
-String token = "api-token";
+final String token = "api-token";
     
 // Required.  See https://api.slack.com/dialogs#implementation
-String triggerId = "trigger-id";
+final String triggerId = "trigger-id";
 
 Slack slack = Slack.getInstance();
 
@@ -284,7 +289,7 @@ Dialog dialog = Dialog.builder()
   .submitLabel("")
   .build();
 
-DialogOpenResponse openDialogResponse = slack.methods().dialogOpen(DialogOpenRequest.builder()
+DialogOpenResponse openDialogResponse = slack.methods().dialogOpen(req -> req
   .token(token)
   .triggerId(triggerId)
   .dialog(dialog)

--- a/jslack-all/pom.xml
+++ b/jslack-all/pom.xml
@@ -18,17 +18,17 @@
         <dependency>
             <groupId>com.github.seratch</groupId>
             <artifactId>jslack-api-model</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.seratch</groupId>
             <artifactId>jslack-api-client</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.seratch</groupId>
             <artifactId>jslack-app-backend</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/jslack-api-client/pom.xml
+++ b/jslack-api-client/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.github.seratch</groupId>
             <artifactId>jslack-api-model</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
@@ -144,11 +144,15 @@ public interface MethodsClient {
 
     ApiTestResponse apiTest(ApiTestRequest req) throws IOException, SlackApiException;
 
+    ApiTestResponse apiTest(RequestBuilder<ApiTestRequest, ApiTestRequest.ApiTestRequestBuilder> req) throws IOException, SlackApiException;
+
     // ------------------------------
     // apps
     // ------------------------------
 
     AppsUninstallResponse appsUninstall(AppsUninstallRequest req) throws IOException, SlackApiException;
+
+    AppsUninstallResponse appsUninstall(RequestBuilder<AppsUninstallRequest, AppsUninstallRequest.AppsUninstallRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // apps.permissions
@@ -156,7 +160,11 @@ public interface MethodsClient {
 
     AppsPermissionsInfoResponse appsPermissionsInfo(AppsPermissionsInfoRequest req) throws IOException, SlackApiException;
 
+    AppsPermissionsInfoResponse appsPermissionsInfo(RequestBuilder<AppsPermissionsInfoRequest, AppsPermissionsInfoRequest.AppsPermissionsInfoRequestBuilder> req) throws IOException, SlackApiException;
+
     AppsPermissionsRequestResponse appsPermissionsRequest(AppsPermissionsRequestRequest req) throws IOException, SlackApiException;
+
+    AppsPermissionsRequestResponse appsPermissionsRequest(RequestBuilder<AppsPermissionsRequestRequest, AppsPermissionsRequestRequest.AppsPermissionsRequestRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // apps.permissions.resources
@@ -204,7 +212,11 @@ public interface MethodsClient {
 
     AuthRevokeResponse authRevoke(AuthRevokeRequest req) throws IOException, SlackApiException;
 
+    AuthRevokeResponse authRevoke(RequestBuilder<AuthRevokeRequest, AuthRevokeRequest.AuthRevokeRequestBuilder> req) throws IOException, SlackApiException;
+
     AuthTestResponse authTest(AuthTestRequest req) throws IOException, SlackApiException;
+
+    AuthTestResponse authTest(RequestBuilder<AuthTestRequest, AuthTestRequest.AuthTestRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // bots
@@ -212,39 +224,71 @@ public interface MethodsClient {
 
     BotsInfoResponse botsInfo(BotsInfoRequest req) throws IOException, SlackApiException;
 
+    BotsInfoResponse botsInfo(RequestBuilder<BotsInfoRequest, BotsInfoRequest.BotsInfoRequestBuilder> req) throws IOException, SlackApiException;
+
     // ------------------------------
     // channels
     // ------------------------------
 
     ChannelsArchiveResponse channelsArchive(ChannelsArchiveRequest req) throws IOException, SlackApiException;
 
+    ChannelsArchiveResponse channelsArchive(RequestBuilder<ChannelsArchiveRequest, ChannelsArchiveRequest.ChannelsArchiveRequestBuilder> req) throws IOException, SlackApiException;
+
     ChannelsCreateResponse channelsCreate(ChannelsCreateRequest req) throws IOException, SlackApiException;
+
+    ChannelsCreateResponse channelsCreate(RequestBuilder<ChannelsCreateRequest, ChannelsCreateRequest.ChannelsCreateRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsHistoryResponse channelsHistory(ChannelsHistoryRequest req) throws IOException, SlackApiException;
 
+    ChannelsHistoryResponse channelsHistory(RequestBuilder<ChannelsHistoryRequest, ChannelsHistoryRequest.ChannelsHistoryRequestBuilder> req) throws IOException, SlackApiException;
+
     ChannelsRepliesResponse channelsReplies(ChannelsRepliesRequest req) throws IOException, SlackApiException;
+
+    ChannelsRepliesResponse channelsReplies(RequestBuilder<ChannelsRepliesRequest, ChannelsRepliesRequest.ChannelsRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsInfoResponse channelsInfo(ChannelsInfoRequest req) throws IOException, SlackApiException;
 
+    ChannelsInfoResponse channelsInfo(RequestBuilder<ChannelsInfoRequest, ChannelsInfoRequest.ChannelsInfoRequestBuilder> req) throws IOException, SlackApiException;
+
     ChannelsListResponse channelsList(ChannelsListRequest req) throws IOException, SlackApiException;
+
+    ChannelsListResponse channelsList(RequestBuilder<ChannelsListRequest, ChannelsListRequest.ChannelsListRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsInviteResponse channelsInvite(ChannelsInviteRequest req) throws IOException, SlackApiException;
 
+    ChannelsInviteResponse channelsInvite(RequestBuilder<ChannelsInviteRequest, ChannelsInviteRequest.ChannelsInviteRequestBuilder> req) throws IOException, SlackApiException;
+
     ChannelsJoinResponse channelsJoin(ChannelsJoinRequest req) throws IOException, SlackApiException;
+
+    ChannelsJoinResponse channelsJoin(RequestBuilder<ChannelsJoinRequest, ChannelsJoinRequest.ChannelsJoinRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsKickResponse channelsKick(ChannelsKickRequest req) throws IOException, SlackApiException;
 
+    ChannelsKickResponse channelsKick(RequestBuilder<ChannelsKickRequest, ChannelsKickRequest.ChannelsKickRequestBuilder> req) throws IOException, SlackApiException;
+
     ChannelsLeaveResponse channelsLeave(ChannelsLeaveRequest req) throws IOException, SlackApiException;
+
+    ChannelsLeaveResponse channelsLeave(RequestBuilder<ChannelsLeaveRequest, ChannelsLeaveRequest.ChannelsLeaveRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsMarkResponse channelsMark(ChannelsMarkRequest req) throws IOException, SlackApiException;
 
+    ChannelsMarkResponse channelsMark(RequestBuilder<ChannelsMarkRequest, ChannelsMarkRequest.ChannelsMarkRequestBuilder> req) throws IOException, SlackApiException;
+
     ChannelsRenameResponse channelsRename(ChannelsRenameRequest req) throws IOException, SlackApiException;
+
+    ChannelsRenameResponse channelsRename(RequestBuilder<ChannelsRenameRequest, ChannelsRenameRequest.ChannelsRenameRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsSetPurposeResponse channelsSetPurpose(ChannelsSetPurposeRequest req) throws IOException, SlackApiException;
 
+    ChannelsSetPurposeResponse channelsSetPurpose(RequestBuilder<ChannelsSetPurposeRequest, ChannelsSetPurposeRequest.ChannelsSetPurposeRequestBuilder> req) throws IOException, SlackApiException;
+
     ChannelsSetTopicResponse channelsSetTopic(ChannelsSetTopicRequest req) throws IOException, SlackApiException;
 
+    ChannelsSetTopicResponse channelsSetTopic(RequestBuilder<ChannelsSetTopicRequest, ChannelsSetTopicRequest.ChannelsSetTopicRequestBuilder> req) throws IOException, SlackApiException;
+
     ChannelsUnarchiveResponse channelsUnarchive(ChannelsUnarchiveRequest req) throws IOException, SlackApiException;
+
+    ChannelsUnarchiveResponse channelsUnarchive(RequestBuilder<ChannelsUnarchiveRequest, ChannelsUnarchiveRequest.ChannelsUnarchiveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // chat
@@ -252,21 +296,39 @@ public interface MethodsClient {
 
     ChatGetPermalinkResponse chatGetPermalink(ChatGetPermalinkRequest req) throws IOException, SlackApiException;
 
+    ChatGetPermalinkResponse chatGetPermalink(RequestBuilder<ChatGetPermalinkRequest, ChatGetPermalinkRequest.ChatGetPermalinkRequestBuilder> req) throws IOException, SlackApiException;
+
     ChatDeleteResponse chatDelete(ChatDeleteRequest req) throws IOException, SlackApiException;
+
+    ChatDeleteResponse chatDelete(RequestBuilder<ChatDeleteRequest, ChatDeleteRequest.ChatDeleteRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatDeleteScheduledMessageResponse chatDeleteScheduledMessage(ChatDeleteScheduledMessageRequest req) throws IOException, SlackApiException;
 
+    ChatDeleteScheduledMessageResponse chatDeleteScheduledMessage(RequestBuilder<ChatDeleteScheduledMessageRequest, ChatDeleteScheduledMessageRequest.ChatDeleteScheduledMessageRequestBuilder> req) throws IOException, SlackApiException;
+
     ChatMeMessageResponse chatMeMessage(ChatMeMessageRequest req) throws IOException, SlackApiException;
+
+    ChatMeMessageResponse chatMeMessage(RequestBuilder<ChatMeMessageRequest, ChatMeMessageRequest.ChatMeMessageRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatPostEphemeralResponse chatPostEphemeral(ChatPostEphemeralRequest req) throws IOException, SlackApiException;
 
+    ChatPostEphemeralResponse chatPostEphemeral(RequestBuilder<ChatPostEphemeralRequest, ChatPostEphemeralRequest.ChatPostEphemeralRequestBuilder> req) throws IOException, SlackApiException;
+
     ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest req) throws IOException, SlackApiException;
+
+    ChatPostMessageResponse chatPostMessage(RequestBuilder<ChatPostMessageRequest, ChatPostMessageRequest.ChatPostMessageRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatScheduleMessageResponse chatScheduleMessage(ChatScheduleMessageRequest req) throws IOException, SlackApiException;
 
+    ChatScheduleMessageResponse chatScheduleMessage(RequestBuilder<ChatScheduleMessageRequest, ChatScheduleMessageRequest.ChatScheduleMessageRequestBuilder> req) throws IOException, SlackApiException;
+
     ChatUpdateResponse chatUpdate(ChatUpdateRequest req) throws IOException, SlackApiException;
 
+    ChatUpdateResponse chatUpdate(RequestBuilder<ChatUpdateRequest, ChatUpdateRequest.ChatUpdateRequestBuilder> req) throws IOException, SlackApiException;
+
     ChatUnfurlResponse chatUnfurl(ChatUnfurlRequest req) throws IOException, SlackApiException;
+
+    ChatUnfurlResponse chatUnfurl(RequestBuilder<ChatUnfurlRequest, ChatUnfurlRequest.ChatUnfurlRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // chat.scheduledMessages
@@ -274,43 +336,79 @@ public interface MethodsClient {
 
     ChatScheduleMessagesListResponse chatScheduleMessagesListMessage(ChatScheduleMessagesListRequest req) throws IOException, SlackApiException;
 
+    ChatScheduleMessagesListResponse chatScheduleMessagesListMessage(RequestBuilder<ChatScheduleMessagesListRequest, ChatScheduleMessagesListRequest.ChatScheduleMessagesListRequestBuilder> req) throws IOException, SlackApiException;
+
     // ------------------------------
     // conversations
     // ------------------------------
 
     ConversationsArchiveResponse conversationsArchive(ConversationsArchiveRequest req) throws IOException, SlackApiException;
 
+    ConversationsArchiveResponse conversationsArchive(RequestBuilder<ConversationsArchiveRequest, ConversationsArchiveRequest.ConversationsArchiveRequestBuilder> req) throws IOException, SlackApiException;
+
     ConversationsCloseResponse conversationsClose(ConversationsCloseRequest req) throws IOException, SlackApiException;
+
+    ConversationsCloseResponse conversationsClose(RequestBuilder<ConversationsCloseRequest, ConversationsCloseRequest.ConversationsCloseRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsCreateResponse conversationsCreate(ConversationsCreateRequest req) throws IOException, SlackApiException;
 
+    ConversationsCreateResponse conversationsCreate(RequestBuilder<ConversationsCreateRequest, ConversationsCreateRequest.ConversationsCreateRequestBuilder> req) throws IOException, SlackApiException;
+
     ConversationsHistoryResponse conversationsHistory(ConversationsHistoryRequest req) throws IOException, SlackApiException;
+
+    ConversationsHistoryResponse conversationsHistory(RequestBuilder<ConversationsHistoryRequest, ConversationsHistoryRequest.ConversationsHistoryRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsInfoResponse conversationsInfo(ConversationsInfoRequest req) throws IOException, SlackApiException;
 
+    ConversationsInfoResponse conversationsInfo(RequestBuilder<ConversationsInfoRequest, ConversationsInfoRequest.ConversationsInfoRequestBuilder> req) throws IOException, SlackApiException;
+
     ConversationsInviteResponse conversationsInvite(ConversationsInviteRequest req) throws IOException, SlackApiException;
+
+    ConversationsInviteResponse conversationsInvite(RequestBuilder<ConversationsInviteRequest, ConversationsInviteRequest.ConversationsInviteRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsJoinResponse conversationsJoin(ConversationsJoinRequest req) throws IOException, SlackApiException;
 
+    ConversationsJoinResponse conversationsJoin(RequestBuilder<ConversationsJoinRequest, ConversationsJoinRequest.ConversationsJoinRequestBuilder> req) throws IOException, SlackApiException;
+
     ConversationsKickResponse conversationsKick(ConversationsKickRequest req) throws IOException, SlackApiException;
+
+    ConversationsKickResponse conversationsKick(RequestBuilder<ConversationsKickRequest, ConversationsKickRequest.ConversationsKickRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsLeaveResponse conversationsLeave(ConversationsLeaveRequest req) throws IOException, SlackApiException;
 
+    ConversationsLeaveResponse conversationsLeave(RequestBuilder<ConversationsLeaveRequest, ConversationsLeaveRequest.ConversationsLeaveRequestBuilder> req) throws IOException, SlackApiException;
+
     ConversationsListResponse conversationsList(ConversationsListRequest req) throws IOException, SlackApiException;
+
+    ConversationsListResponse conversationsList(RequestBuilder<ConversationsListRequest, ConversationsListRequest.ConversationsListRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsMembersResponse conversationsMembers(ConversationsMembersRequest req) throws IOException, SlackApiException;
 
+    ConversationsMembersResponse conversationsMembers(RequestBuilder<ConversationsMembersRequest, ConversationsMembersRequest.ConversationsMembersRequestBuilder> req) throws IOException, SlackApiException;
+
     ConversationsOpenResponse conversationsOpen(ConversationsOpenRequest req) throws IOException, SlackApiException;
+
+    ConversationsOpenResponse conversationsOpen(RequestBuilder<ConversationsOpenRequest, ConversationsOpenRequest.ConversationsOpenRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsRenameResponse conversationsRename(ConversationsRenameRequest req) throws IOException, SlackApiException;
 
+    ConversationsRenameResponse conversationsRename(RequestBuilder<ConversationsRenameRequest, ConversationsRenameRequest.ConversationsRenameRequestBuilder> req) throws IOException, SlackApiException;
+
     ConversationsRepliesResponse conversationsReplies(ConversationsRepliesRequest req) throws IOException, SlackApiException;
+
+    ConversationsRepliesResponse conversationsReplies(RequestBuilder<ConversationsRepliesRequest, ConversationsRepliesRequest.ConversationsRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsSetPurposeResponse conversationsSetPurpose(ConversationsSetPurposeRequest req) throws IOException, SlackApiException;
 
+    ConversationsSetPurposeResponse conversationsSetPurpose(RequestBuilder<ConversationsSetPurposeRequest, ConversationsSetPurposeRequest.ConversationsSetPurposeRequestBuilder> req) throws IOException, SlackApiException;
+
     ConversationsSetTopicResponse conversationsSetTopic(ConversationsSetTopicRequest req) throws IOException, SlackApiException;
 
+    ConversationsSetTopicResponse conversationsSetTopic(RequestBuilder<ConversationsSetTopicRequest, ConversationsSetTopicRequest.ConversationsSetTopicRequestBuilder> req) throws IOException, SlackApiException;
+
     ConversationsUnarchiveResponse conversationsUnarchive(ConversationsUnarchiveRequest req) throws IOException, SlackApiException;
+
+    ConversationsUnarchiveResponse conversationsUnarchive(RequestBuilder<ConversationsUnarchiveRequest, ConversationsUnarchiveRequest.ConversationsUnarchiveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // dialog
@@ -318,19 +416,31 @@ public interface MethodsClient {
 
     DialogOpenResponse dialogOpen(DialogOpenRequest req) throws IOException, SlackApiException;
 
+    DialogOpenResponse dialogOpen(RequestBuilder<DialogOpenRequest, DialogOpenRequest.DialogOpenRequestBuilder> req) throws IOException, SlackApiException;
+
     // ------------------------------
     // dnd
     // ------------------------------
 
     DndEndDndResponse dndEndDnd(DndEndDndRequest req) throws IOException, SlackApiException;
 
+    DndEndDndResponse dndEndDnd(RequestBuilder<DndEndDndRequest, DndEndDndRequest.DndEndDndRequestBuilder> req) throws IOException, SlackApiException;
+
     DndEndSnoozeResponse dndEndSnooze(DndEndSnoozeRequest req) throws IOException, SlackApiException;
+
+    DndEndSnoozeResponse dndEndSnooze(RequestBuilder<DndEndSnoozeRequest, DndEndSnoozeRequest.DndEndSnoozeRequestBuilder> req) throws IOException, SlackApiException;
 
     DndInfoResponse dndInfo(DndInfoRequest req) throws IOException, SlackApiException;
 
+    DndInfoResponse dndInfo(RequestBuilder<DndInfoRequest, DndInfoRequest.DndInfoRequestBuilder> req) throws IOException, SlackApiException;
+
     DndSetSnoozeResponse dndSetSnooze(DndSetSnoozeRequest req) throws IOException, SlackApiException;
 
+    DndSetSnoozeResponse dndSetSnooze(RequestBuilder<DndSetSnoozeRequest, DndSetSnoozeRequest.DndSetSnoozeRequestBuilder> req) throws IOException, SlackApiException;
+
     DndTeamInfoResponse dndTeamInfo(DndTeamInfoRequest req) throws IOException, SlackApiException;
+
+    DndTeamInfoResponse dndTeamInfo(RequestBuilder<DndTeamInfoRequest, DndTeamInfoRequest.DndTeamInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // emoji
@@ -338,21 +448,35 @@ public interface MethodsClient {
 
     EmojiListResponse emojiList(EmojiListRequest req) throws IOException, SlackApiException;
 
+    EmojiListResponse emojiList(RequestBuilder<EmojiListRequest, EmojiListRequest.EmojiListRequestBuilder> req) throws IOException, SlackApiException;
+
     // ------------------------------
     // files
     // ------------------------------
 
     FilesDeleteResponse filesDelete(FilesDeleteRequest req) throws IOException, SlackApiException;
 
+    FilesDeleteResponse filesDelete(RequestBuilder<FilesDeleteRequest, FilesDeleteRequest.FilesDeleteRequestBuilder> req) throws IOException, SlackApiException;
+
     FilesInfoResponse filesInfo(FilesInfoRequest req) throws IOException, SlackApiException;
+
+    FilesInfoResponse filesInfo(RequestBuilder<FilesInfoRequest, FilesInfoRequest.FilesInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     FilesListResponse filesList(FilesListRequest req) throws IOException, SlackApiException;
 
+    FilesListResponse filesList(RequestBuilder<FilesListRequest, FilesListRequest.FilesListRequestBuilder> req) throws IOException, SlackApiException;
+
     FilesRevokePublicURLResponse filesRevokePublicURL(FilesRevokePublicURLRequest req) throws IOException, SlackApiException;
+
+    FilesRevokePublicURLResponse filesRevokePublicURL(RequestBuilder<FilesRevokePublicURLRequest, FilesRevokePublicURLRequest.FilesRevokePublicURLRequestBuilder> req) throws IOException, SlackApiException;
 
     FilesSharedPublicURLResponse filesSharedPublicURL(FilesSharedPublicURLRequest req) throws IOException, SlackApiException;
 
+    FilesSharedPublicURLResponse filesSharedPublicURL(RequestBuilder<FilesSharedPublicURLRequest, FilesSharedPublicURLRequest.FilesSharedPublicURLRequestBuilder> req) throws IOException, SlackApiException;
+
     FilesUploadResponse filesUpload(FilesUploadRequest req) throws IOException, SlackApiException;
+
+    FilesUploadResponse filesUpload(RequestBuilder<FilesUploadRequest, FilesUploadRequest.FilesUploadRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // files.comments
@@ -376,39 +500,71 @@ public interface MethodsClient {
 
     GroupsArchiveResponse groupsArchive(GroupsArchiveRequest req) throws IOException, SlackApiException;
 
+    GroupsArchiveResponse groupsArchive(RequestBuilder<GroupsArchiveRequest, GroupsArchiveRequest.GroupsArchiveRequestBuilder> req) throws IOException, SlackApiException;
+
     // https://github.com/slackapi/slack-api-specs/issues/12
     @Deprecated
     GroupsCloseResponse groupsClose(GroupsCloseRequest req) throws IOException, SlackApiException;
 
     GroupsCreateChildResponse groupsCreateChild(GroupsCreateChildRequest req) throws IOException, SlackApiException;
 
+    GroupsCreateChildResponse groupsCreateChild(RequestBuilder<GroupsCreateChildRequest, GroupsCreateChildRequest.GroupsCreateChildRequestBuilder> req) throws IOException, SlackApiException;
+
     GroupsCreateResponse groupsCreate(GroupsCreateRequest req) throws IOException, SlackApiException;
+
+    GroupsCreateResponse groupsCreate(RequestBuilder<GroupsCreateRequest, GroupsCreateRequest.GroupsCreateRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsHistoryResponse groupsHistory(GroupsHistoryRequest req) throws IOException, SlackApiException;
 
+    GroupsHistoryResponse groupsHistory(RequestBuilder<GroupsHistoryRequest, GroupsHistoryRequest.GroupsHistoryRequestBuilder> req) throws IOException, SlackApiException;
+
     GroupsInfoResponse groupsInfo(GroupsInfoRequest req) throws IOException, SlackApiException;
+
+    GroupsInfoResponse groupsInfo(RequestBuilder<GroupsInfoRequest, GroupsInfoRequest.GroupsInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsInviteResponse groupsInvite(GroupsInviteRequest req) throws IOException, SlackApiException;
 
+    GroupsInviteResponse groupsInvite(RequestBuilder<GroupsInviteRequest, GroupsInviteRequest.GroupsInviteRequestBuilder> req) throws IOException, SlackApiException;
+
     GroupsKickResponse groupsKick(GroupsKickRequest req) throws IOException, SlackApiException;
+
+    GroupsKickResponse groupsKick(RequestBuilder<GroupsKickRequest, GroupsKickRequest.GroupsKickRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsLeaveResponse groupsLeave(GroupsLeaveRequest req) throws IOException, SlackApiException;
 
+    GroupsLeaveResponse groupsLeave(RequestBuilder<GroupsLeaveRequest, GroupsLeaveRequest.GroupsLeaveRequestBuilder> req) throws IOException, SlackApiException;
+
     GroupsListResponse groupsList(GroupsListRequest req) throws IOException, SlackApiException;
+
+    GroupsListResponse groupsList(RequestBuilder<GroupsListRequest, GroupsListRequest.GroupsListRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsMarkResponse groupsMark(GroupsMarkRequest req) throws IOException, SlackApiException;
 
+    GroupsMarkResponse groupsMark(RequestBuilder<GroupsMarkRequest, GroupsMarkRequest.GroupsMarkRequestBuilder> req) throws IOException, SlackApiException;
+
     GroupsOpenResponse groupsOpen(GroupsOpenRequest req) throws IOException, SlackApiException;
+
+    GroupsOpenResponse groupsOpen(RequestBuilder<GroupsOpenRequest, GroupsOpenRequest.GroupsOpenRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsRenameResponse groupsRename(GroupsRenameRequest req) throws IOException, SlackApiException;
 
+    GroupsRenameResponse groupsRename(RequestBuilder<GroupsRenameRequest, GroupsRenameRequest.GroupsRenameRequestBuilder> req) throws IOException, SlackApiException;
+
     GroupsSetPurposeResponse groupsSetPurpose(GroupsSetPurposeRequest req) throws IOException, SlackApiException;
+
+    GroupsSetPurposeResponse groupsSetPurpose(RequestBuilder<GroupsSetPurposeRequest, GroupsSetPurposeRequest.GroupsSetPurposeRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsSetTopicResponse groupsSetTopic(GroupsSetTopicRequest req) throws IOException, SlackApiException;
 
+    GroupsSetTopicResponse groupsSetTopic(RequestBuilder<GroupsSetTopicRequest, GroupsSetTopicRequest.GroupsSetTopicRequestBuilder> req) throws IOException, SlackApiException;
+
     GroupsUnarchiveResponse groupsUnarchive(GroupsUnarchiveRequest req) throws IOException, SlackApiException;
 
+    GroupsUnarchiveResponse groupsUnarchive(RequestBuilder<GroupsUnarchiveRequest, GroupsUnarchiveRequest.GroupsUnarchiveRequestBuilder> req) throws IOException, SlackApiException;
+
     GroupsRepliesResponse groupsReplies(GroupsRepliesRequest req) throws IOException, SlackApiException;
+
+    GroupsRepliesResponse groupsReplies(RequestBuilder<GroupsRepliesRequest, GroupsRepliesRequest.GroupsRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // im
@@ -416,15 +572,27 @@ public interface MethodsClient {
 
     ImCloseResponse imClose(ImCloseRequest req) throws IOException, SlackApiException;
 
+    ImCloseResponse imClose(RequestBuilder<ImCloseRequest, ImCloseRequest.ImCloseRequestBuilder> req) throws IOException, SlackApiException;
+
     ImHistoryResponse imHistory(ImHistoryRequest req) throws IOException, SlackApiException;
+
+    ImHistoryResponse imHistory(RequestBuilder<ImHistoryRequest, ImHistoryRequest.ImHistoryRequestBuilder> req) throws IOException, SlackApiException;
 
     ImListResponse imList(ImListRequest req) throws IOException, SlackApiException;
 
+    ImListResponse imList(RequestBuilder<ImListRequest, ImListRequest.ImListRequestBuilder> req) throws IOException, SlackApiException;
+
     ImMarkResponse imMark(ImMarkRequest req) throws IOException, SlackApiException;
+
+    ImMarkResponse imMark(RequestBuilder<ImMarkRequest, ImMarkRequest.ImMarkRequestBuilder> req) throws IOException, SlackApiException;
 
     ImOpenResponse imOpen(ImOpenRequest req) throws IOException, SlackApiException;
 
+    ImOpenResponse imOpen(RequestBuilder<ImOpenRequest, ImOpenRequest.ImOpenRequestBuilder> req) throws IOException, SlackApiException;
+
     ImRepliesResponse imReplies(ImRepliesRequest req) throws IOException, SlackApiException;
+
+    ImRepliesResponse imReplies(RequestBuilder<ImRepliesRequest, ImRepliesRequest.ImRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // migration
@@ -432,21 +600,35 @@ public interface MethodsClient {
 
     MigrationExchangeResponse migrationExchange(MigrationExchangeRequest req) throws IOException, SlackApiException;
 
+    MigrationExchangeResponse migrationExchange(RequestBuilder<MigrationExchangeRequest, MigrationExchangeRequest.MigrationExchangeRequestBuilder> req) throws IOException, SlackApiException;
+
     // ------------------------------
     // mpim
     // ------------------------------
 
     MpimCloseResponse mpimClose(MpimCloseRequest req) throws IOException, SlackApiException;
 
+    MpimCloseResponse mpimClose(RequestBuilder<MpimCloseRequest, MpimCloseRequest.MpimCloseRequestBuilder> req) throws IOException, SlackApiException;
+
     MpimHistoryResponse mpimHistory(MpimHistoryRequest req) throws IOException, SlackApiException;
+
+    MpimHistoryResponse mpimHistory(RequestBuilder<MpimHistoryRequest, MpimHistoryRequest.MpimHistoryRequestBuilder> req) throws IOException, SlackApiException;
 
     MpimListResponse mpimList(MpimListRequest req) throws IOException, SlackApiException;
 
+    MpimListResponse mpimList(RequestBuilder<MpimListRequest, MpimListRequest.MpimListRequestBuilder> req) throws IOException, SlackApiException;
+
     MpimRepliesResponse mpimReplies(MpimRepliesRequest req) throws IOException, SlackApiException;
+
+    MpimRepliesResponse mpimReplies(RequestBuilder<MpimRepliesRequest, MpimRepliesRequest.MpimRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     MpimMarkResponse mpimMark(MpimMarkRequest req) throws IOException, SlackApiException;
 
+    MpimMarkResponse mpimMark(RequestBuilder<MpimMarkRequest, MpimMarkRequest.MpimMarkRequestBuilder> req) throws IOException, SlackApiException;
+
     MpimOpenResponse mpimOpen(MpimOpenRequest req) throws IOException, SlackApiException;
+
+    MpimOpenResponse mpimOpen(RequestBuilder<MpimOpenRequest, MpimOpenRequest.MpimOpenRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // oauth
@@ -454,7 +636,11 @@ public interface MethodsClient {
 
     OAuthAccessResponse oauthAccess(OAuthAccessRequest req) throws IOException, SlackApiException;
 
+    OAuthAccessResponse oauthAccess(RequestBuilder<OAuthAccessRequest, OAuthAccessRequest.OAuthAccessRequestBuilder> req) throws IOException, SlackApiException;
+
     OAuthTokenResponse oauthToken(OAuthTokenRequest req) throws IOException, SlackApiException;
+
+    OAuthTokenResponse oauthToken(RequestBuilder<OAuthTokenRequest, OAuthTokenRequest.OAuthTokenRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // pins
@@ -462,9 +648,15 @@ public interface MethodsClient {
 
     PinsAddResponse pinsAdd(PinsAddRequest req) throws IOException, SlackApiException;
 
+    PinsAddResponse pinsAdd(RequestBuilder<PinsAddRequest, PinsAddRequest.PinsAddRequestBuilder> req) throws IOException, SlackApiException;
+
     PinsListResponse pinsList(PinsListRequest req) throws IOException, SlackApiException;
 
+    PinsListResponse pinsList(RequestBuilder<PinsListRequest, PinsListRequest.PinsListRequestBuilder> req) throws IOException, SlackApiException;
+
     PinsRemoveResponse pinsRemove(PinsRemoveRequest req) throws IOException, SlackApiException;
+
+    PinsRemoveResponse pinsRemove(RequestBuilder<PinsRemoveRequest, PinsRemoveRequest.PinsRemoveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // reactions
@@ -472,11 +664,19 @@ public interface MethodsClient {
 
     ReactionsAddResponse reactionsAdd(ReactionsAddRequest req) throws IOException, SlackApiException;
 
+    ReactionsAddResponse reactionsAdd(RequestBuilder<ReactionsAddRequest, ReactionsAddRequest.ReactionsAddRequestBuilder> req) throws IOException, SlackApiException;
+
     ReactionsGetResponse reactionsGet(ReactionsGetRequest req) throws IOException, SlackApiException;
+
+    ReactionsGetResponse reactionsGet(RequestBuilder<ReactionsGetRequest, ReactionsGetRequest.ReactionsGetRequestBuilder> req) throws IOException, SlackApiException;
 
     ReactionsListResponse reactionsList(ReactionsListRequest req) throws IOException, SlackApiException;
 
+    ReactionsListResponse reactionsList(RequestBuilder<ReactionsListRequest, ReactionsListRequest.ReactionsListRequestBuilder> req) throws IOException, SlackApiException;
+
     ReactionsRemoveResponse reactionsRemove(ReactionsRemoveRequest req) throws IOException, SlackApiException;
+
+    ReactionsRemoveResponse reactionsRemove(RequestBuilder<ReactionsRemoveRequest, ReactionsRemoveRequest.ReactionsRemoveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // reminders
@@ -484,13 +684,23 @@ public interface MethodsClient {
 
     RemindersAddResponse remindersAdd(RemindersAddRequest req) throws IOException, SlackApiException;
 
+    RemindersAddResponse remindersAdd(RequestBuilder<RemindersAddRequest, RemindersAddRequest.RemindersAddRequestBuilder> req) throws IOException, SlackApiException;
+
     RemindersCompleteResponse remindersComplete(RemindersCompleteRequest req) throws IOException, SlackApiException;
+
+    RemindersCompleteResponse remindersComplete(RequestBuilder<RemindersCompleteRequest, RemindersCompleteRequest.RemindersCompleteRequestBuilder> req) throws IOException, SlackApiException;
 
     RemindersDeleteResponse remindersDelete(RemindersDeleteRequest req) throws IOException, SlackApiException;
 
+    RemindersDeleteResponse remindersDelete(RequestBuilder<RemindersDeleteRequest, RemindersDeleteRequest.RemindersDeleteRequestBuilder> req) throws IOException, SlackApiException;
+
     RemindersInfoResponse remindersInfo(RemindersInfoRequest req) throws IOException, SlackApiException;
 
+    RemindersInfoResponse remindersInfo(RequestBuilder<RemindersInfoRequest, RemindersInfoRequest.RemindersInfoRequestBuilder> req) throws IOException, SlackApiException;
+
     RemindersListResponse remindersList(RemindersListRequest req) throws IOException, SlackApiException;
+
+    RemindersListResponse remindersList(RequestBuilder<RemindersListRequest, RemindersListRequest.RemindersListRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // rtm
@@ -498,7 +708,11 @@ public interface MethodsClient {
 
     RTMConnectResponse rtmConnect(RTMConnectRequest req) throws IOException, SlackApiException;
 
+    RTMConnectResponse rtmConnect(RequestBuilder<RTMConnectRequest, RTMConnectRequest.RTMConnectRequestBuilder> req) throws IOException, SlackApiException;
+
     RTMStartResponse rtmStart(RTMStartRequest req) throws IOException, SlackApiException;
+
+    RTMStartResponse rtmStart(RequestBuilder<RTMStartRequest, RTMStartRequest.RTMStartRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // search
@@ -506,9 +720,15 @@ public interface MethodsClient {
 
     SearchAllResponse searchAll(SearchAllRequest req) throws IOException, SlackApiException;
 
+    SearchAllResponse searchAll(RequestBuilder<SearchAllRequest, SearchAllRequest.SearchAllRequestBuilder> req) throws IOException, SlackApiException;
+
     SearchMessagesResponse searchMessages(SearchMessagesRequest req) throws IOException, SlackApiException;
 
+    SearchMessagesResponse searchMessages(RequestBuilder<SearchMessagesRequest, SearchMessagesRequest.SearchMessagesRequestBuilder> req) throws IOException, SlackApiException;
+
     SearchFilesResponse searchFiles(SearchFilesRequest req) throws IOException, SlackApiException;
+
+    SearchFilesResponse searchFiles(RequestBuilder<SearchFilesRequest, SearchFilesRequest.SearchFilesRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // stars
@@ -516,9 +736,15 @@ public interface MethodsClient {
 
     StarsAddResponse starsAdd(StarsAddRequest req) throws IOException, SlackApiException;
 
+    StarsAddResponse starsAdd(RequestBuilder<StarsAddRequest, StarsAddRequest.StarsAddRequestBuilder> req) throws IOException, SlackApiException;
+
     StarsListResponse starsList(StarsListRequest req) throws IOException, SlackApiException;
 
+    StarsListResponse starsList(RequestBuilder<StarsListRequest, StarsListRequest.StarsListRequestBuilder> req) throws IOException, SlackApiException;
+
     StarsRemoveResponse starsRemove(StarsRemoveRequest req) throws IOException, SlackApiException;
+
+    StarsRemoveResponse starsRemove(RequestBuilder<StarsRemoveRequest, StarsRemoveRequest.StarsRemoveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // team
@@ -526,13 +752,23 @@ public interface MethodsClient {
 
     TeamAccessLogsResponse teamAccessLogs(TeamAccessLogsRequest req) throws IOException, SlackApiException;
 
+    TeamAccessLogsResponse teamAccessLogs(RequestBuilder<TeamAccessLogsRequest, TeamAccessLogsRequest.TeamAccessLogsRequestBuilder> req) throws IOException, SlackApiException;
+
     TeamBillableInfoResponse teamBillableInfo(TeamBillableInfoRequest req) throws IOException, SlackApiException;
+
+    TeamBillableInfoResponse teamBillableInfo(RequestBuilder<TeamBillableInfoRequest, TeamBillableInfoRequest.TeamBillableInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     TeamInfoResponse teamInfo(TeamInfoRequest req) throws IOException, SlackApiException;
 
+    TeamInfoResponse teamInfo(RequestBuilder<TeamInfoRequest, TeamInfoRequest.TeamInfoRequestBuilder> req) throws IOException, SlackApiException;
+
     TeamIntegrationLogsResponse teamIntegrationLogs(TeamIntegrationLogsRequest req) throws IOException, SlackApiException;
 
+    TeamIntegrationLogsResponse teamIntegrationLogs(RequestBuilder<TeamIntegrationLogsRequest, TeamIntegrationLogsRequest.TeamIntegrationLogsRequestBuilder> req) throws IOException, SlackApiException;
+
     TeamProfileGetResponse teamProfileGet(TeamProfileGetRequest req) throws IOException, SlackApiException;
+
+    TeamProfileGetResponse teamProfileGet(RequestBuilder<TeamProfileGetRequest, TeamProfileGetRequest.TeamProfileGetRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // usergroups
@@ -540,17 +776,31 @@ public interface MethodsClient {
 
     UsergroupsCreateResponse usergroupsCreate(UsergroupsCreateRequest req) throws IOException, SlackApiException;
 
+    UsergroupsCreateResponse usergroupsCreate(RequestBuilder<UsergroupsCreateRequest, UsergroupsCreateRequest.UsergroupsCreateRequestBuilder> req) throws IOException, SlackApiException;
+
     UsergroupsDisableResponse usergroupsDisable(UsergroupsDisableRequest req) throws IOException, SlackApiException;
+
+    UsergroupsDisableResponse usergroupsDisable(RequestBuilder<UsergroupsDisableRequest, UsergroupsDisableRequest.UsergroupsDisableRequestBuilder> req) throws IOException, SlackApiException;
 
     UsergroupsEnableResponse usergroupsEnable(UsergroupsEnableRequest req) throws IOException, SlackApiException;
 
+    UsergroupsEnableResponse usergroupsEnable(RequestBuilder<UsergroupsEnableRequest, UsergroupsEnableRequest.UsergroupsEnableRequestBuilder> req) throws IOException, SlackApiException;
+
     UsergroupsListResponse usergroupsList(UsergroupsListRequest req) throws IOException, SlackApiException;
+
+    UsergroupsListResponse usergroupsList(RequestBuilder<UsergroupsListRequest, UsergroupsListRequest.UsergroupsListRequestBuilder> req) throws IOException, SlackApiException;
 
     UsergroupsUpdateResponse usergroupsUpdate(UsergroupsUpdateRequest req) throws IOException, SlackApiException;
 
+    UsergroupsUpdateResponse usergroupsUpdate(RequestBuilder<UsergroupsUpdateRequest, UsergroupsUpdateRequest.UsergroupsUpdateRequestBuilder> req) throws IOException, SlackApiException;
+
     UsergroupUsersListResponse usergroupUsersList(UsergroupUsersListRequest req) throws IOException, SlackApiException;
 
+    UsergroupUsersListResponse usergroupUsersList(RequestBuilder<UsergroupUsersListRequest, UsergroupUsersListRequest.UsergroupUsersListRequestBuilder> req) throws IOException, SlackApiException;
+
     UsergroupUsersUpdateResponse usergroupUsersUpdate(UsergroupUsersUpdateRequest req) throws IOException, SlackApiException;
+
+    UsergroupUsersUpdateResponse usergroupUsersUpdate(RequestBuilder<UsergroupUsersUpdateRequest, UsergroupUsersUpdateRequest.UsergroupUsersUpdateRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // users
@@ -558,23 +808,43 @@ public interface MethodsClient {
 
     UsersConversationsResponse usersConversations(UsersConversationsRequest req) throws IOException, SlackApiException;
 
+    UsersConversationsResponse usersConversations(RequestBuilder<UsersConversationsRequest, UsersConversationsRequest.UsersConversationsRequestBuilder> req) throws IOException, SlackApiException;
+
     UsersDeletePhotoResponse usersDeletePhoto(UsersDeletePhotoRequest req) throws IOException, SlackApiException;
+
+    UsersDeletePhotoResponse usersDeletePhoto(RequestBuilder<UsersDeletePhotoRequest, UsersDeletePhotoRequest.UsersDeletePhotoRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersGetPresenceResponse usersGetPresence(UsersGetPresenceRequest req) throws IOException, SlackApiException;
 
+    UsersGetPresenceResponse usersGetPresence(RequestBuilder<UsersGetPresenceRequest, UsersGetPresenceRequest.UsersGetPresenceRequestBuilder> req) throws IOException, SlackApiException;
+
     UsersIdentityResponse usersIdentity(UsersIdentityRequest req) throws IOException, SlackApiException;
+
+    UsersIdentityResponse usersIdentity(RequestBuilder<UsersIdentityRequest, UsersIdentityRequest.UsersIdentityRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersInfoResponse usersInfo(UsersInfoRequest req) throws IOException, SlackApiException;
 
+    UsersInfoResponse usersInfo(RequestBuilder<UsersInfoRequest, UsersInfoRequest.UsersInfoRequestBuilder> req) throws IOException, SlackApiException;
+
     UsersListResponse usersList(UsersListRequest req) throws IOException, SlackApiException;
+
+    UsersListResponse usersList(RequestBuilder<UsersListRequest, UsersListRequest.UsersListRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersLookupByEmailResponse usersLookupByEmail(UsersLookupByEmailRequest req) throws IOException, SlackApiException;
 
+    UsersLookupByEmailResponse usersLookupByEmail(RequestBuilder<UsersLookupByEmailRequest, UsersLookupByEmailRequest.UsersLookupByEmailRequestBuilder> req) throws IOException, SlackApiException;
+
     UsersSetActiveResponse usersSetActive(UsersSetActiveRequest req) throws IOException, SlackApiException;
+
+    UsersSetActiveResponse usersSetActive(RequestBuilder<UsersSetActiveRequest, UsersSetActiveRequest.UsersSetActiveRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersSetPhotoResponse usersSetPhoto(UsersSetPhotoRequest req) throws IOException, SlackApiException;
 
+    UsersSetPhotoResponse usersSetPhoto(RequestBuilder<UsersSetPhotoRequest, UsersSetPhotoRequest.UsersSetPhotoRequestBuilder> req) throws IOException, SlackApiException;
+
     UsersSetPresenceResponse usersSetPresence(UsersSetPresenceRequest req) throws IOException, SlackApiException;
+
+    UsersSetPresenceResponse usersSetPresence(RequestBuilder<UsersSetPresenceRequest, UsersSetPresenceRequest.UsersSetPresenceRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // users.profile
@@ -582,6 +852,10 @@ public interface MethodsClient {
 
     UsersProfileGetResponse usersProfileGet(UsersProfileGetRequest req) throws IOException, SlackApiException;
 
+    UsersProfileGetResponse usersProfileGet(RequestBuilder<UsersProfileGetRequest, UsersProfileGetRequest.UsersProfileGetRequestBuilder> req) throws IOException, SlackApiException;
+
     UsersProfileSetResponse usersProfileSet(UsersProfileSetRequest req) throws IOException, SlackApiException;
+
+    UsersProfileSetResponse usersProfileSet(RequestBuilder<UsersProfileSetRequest, UsersProfileSetRequest.UsersProfileSetRequestBuilder> req) throws IOException, SlackApiException;
 
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/RequestBuilder.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/RequestBuilder.java
@@ -1,0 +1,8 @@
+package com.github.seratch.jslack.api.methods;
+
+@FunctionalInterface
+public interface RequestBuilder<R extends SlackApiRequest, Builder> {
+
+    R build(Builder builder);
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
@@ -2,6 +2,7 @@ package com.github.seratch.jslack.api.methods.impl;
 
 import com.github.seratch.jslack.api.methods.Methods;
 import com.github.seratch.jslack.api.methods.MethodsClient;
+import com.github.seratch.jslack.api.methods.RequestBuilder;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.request.api.ApiTestRequest;
 import com.github.seratch.jslack.api.methods.request.apps.AppsUninstallRequest;
@@ -150,8 +151,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ApiTestResponse apiTest(RequestBuilder<ApiTestRequest, ApiTestRequest.ApiTestRequestBuilder> req) throws IOException, SlackApiException {
+        return apiTest(req.build(ApiTestRequest.builder()));
+    }
+
+    @Override
     public AppsUninstallResponse appsUninstall(AppsUninstallRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.APPS_UNINSTALL, req.getToken(), AppsUninstallResponse.class);
+    }
+
+    @Override
+    public AppsUninstallResponse appsUninstall(RequestBuilder<AppsUninstallRequest, AppsUninstallRequest.AppsUninstallRequestBuilder> req) throws IOException, SlackApiException {
+        return appsUninstall(req.build(AppsUninstallRequest.builder()));
     }
 
     @Override
@@ -160,8 +171,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public AppsPermissionsInfoResponse appsPermissionsInfo(RequestBuilder<AppsPermissionsInfoRequest, AppsPermissionsInfoRequest.AppsPermissionsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return appsPermissionsInfo(req.build(AppsPermissionsInfoRequest.builder()));
+    }
+
+    @Override
     public AppsPermissionsRequestResponse appsPermissionsRequest(AppsPermissionsRequestRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.APPS_PERMISSIONS_REQUEST, req.getToken(), AppsPermissionsRequestResponse.class);
+    }
+
+    @Override
+    public AppsPermissionsRequestResponse appsPermissionsRequest(RequestBuilder<AppsPermissionsRequestRequest, AppsPermissionsRequestRequest.AppsPermissionsRequestRequestBuilder> req) throws IOException, SlackApiException {
+        return appsPermissionsRequest(req.build(AppsPermissionsRequestRequest.builder()));
     }
 
     @Override
@@ -190,8 +211,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public AuthRevokeResponse authRevoke(RequestBuilder<AuthRevokeRequest, AuthRevokeRequest.AuthRevokeRequestBuilder> req) throws IOException, SlackApiException {
+        return authRevoke(req.build(AuthRevokeRequest.builder()));
+    }
+
+    @Override
     public AuthTestResponse authTest(AuthTestRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.AUTH_TEST, req.getToken(), AuthTestResponse.class);
+    }
+
+    @Override
+    public AuthTestResponse authTest(RequestBuilder<AuthTestRequest, AuthTestRequest.AuthTestRequestBuilder> req) throws IOException, SlackApiException {
+        return authTest(req.build(AuthTestRequest.builder()));
     }
 
     @Override
@@ -200,8 +231,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public BotsInfoResponse botsInfo(RequestBuilder<BotsInfoRequest, BotsInfoRequest.BotsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return botsInfo(req.build(BotsInfoRequest.builder()));
+    }
+
+    @Override
     public ChannelsArchiveResponse channelsArchive(ChannelsArchiveRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHANNELS_ARCHIVE, req.getToken(), ChannelsArchiveResponse.class);
+    }
+
+    @Override
+    public ChannelsArchiveResponse channelsArchive(RequestBuilder<ChannelsArchiveRequest, ChannelsArchiveRequest.ChannelsArchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsArchive(req.build(ChannelsArchiveRequest.builder()));
     }
 
     @Override
@@ -210,8 +251,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChannelsCreateResponse channelsCreate(RequestBuilder<ChannelsCreateRequest, ChannelsCreateRequest.ChannelsCreateRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsCreate(req.build(ChannelsCreateRequest.builder()));
+    }
+
+    @Override
     public ChannelsHistoryResponse channelsHistory(ChannelsHistoryRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHANNELS_HISTORY, req.getToken(), ChannelsHistoryResponse.class);
+    }
+
+    @Override
+    public ChannelsHistoryResponse channelsHistory(RequestBuilder<ChannelsHistoryRequest, ChannelsHistoryRequest.ChannelsHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsHistory(req.build(ChannelsHistoryRequest.builder()));
     }
 
     @Override
@@ -220,8 +271,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChannelsRepliesResponse channelsReplies(RequestBuilder<ChannelsRepliesRequest, ChannelsRepliesRequest.ChannelsRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsReplies(req.build(ChannelsRepliesRequest.builder()));
+    }
+
+    @Override
     public ChannelsInfoResponse channelsInfo(ChannelsInfoRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHANNELS_INFO, req.getToken(), ChannelsInfoResponse.class);
+    }
+
+    @Override
+    public ChannelsInfoResponse channelsInfo(RequestBuilder<ChannelsInfoRequest, ChannelsInfoRequest.ChannelsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsInfo(req.build(ChannelsInfoRequest.builder()));
     }
 
     @Override
@@ -230,8 +291,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChannelsListResponse channelsList(RequestBuilder<ChannelsListRequest, ChannelsListRequest.ChannelsListRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsList(req.build(ChannelsListRequest.builder()));
+    }
+
+    @Override
     public ChannelsInviteResponse channelsInvite(ChannelsInviteRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHANNELS_INVITE, req.getToken(), ChannelsInviteResponse.class);
+    }
+
+    @Override
+    public ChannelsInviteResponse channelsInvite(RequestBuilder<ChannelsInviteRequest, ChannelsInviteRequest.ChannelsInviteRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsInvite(req.build(ChannelsInviteRequest.builder()));
     }
 
     @Override
@@ -240,8 +311,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChannelsJoinResponse channelsJoin(RequestBuilder<ChannelsJoinRequest, ChannelsJoinRequest.ChannelsJoinRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsJoin(req.build(ChannelsJoinRequest.builder()));
+    }
+
+    @Override
     public ChannelsKickResponse channelsKick(ChannelsKickRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHANNELS_KICK, req.getToken(), ChannelsKickResponse.class);
+    }
+
+    @Override
+    public ChannelsKickResponse channelsKick(RequestBuilder<ChannelsKickRequest, ChannelsKickRequest.ChannelsKickRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsKick(req.build(ChannelsKickRequest.builder()));
     }
 
     @Override
@@ -250,8 +331,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChannelsLeaveResponse channelsLeave(RequestBuilder<ChannelsLeaveRequest, ChannelsLeaveRequest.ChannelsLeaveRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsLeave(req.build(ChannelsLeaveRequest.builder()));
+    }
+
+    @Override
     public ChannelsMarkResponse channelsMark(ChannelsMarkRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHANNELS_MARK, req.getToken(), ChannelsMarkResponse.class);
+    }
+
+    @Override
+    public ChannelsMarkResponse channelsMark(RequestBuilder<ChannelsMarkRequest, ChannelsMarkRequest.ChannelsMarkRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsMark(req.build(ChannelsMarkRequest.builder()));
     }
 
     @Override
@@ -260,8 +351,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChannelsRenameResponse channelsRename(RequestBuilder<ChannelsRenameRequest, ChannelsRenameRequest.ChannelsRenameRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsRename(req.build(ChannelsRenameRequest.builder()));
+    }
+
+    @Override
     public ChannelsSetPurposeResponse channelsSetPurpose(ChannelsSetPurposeRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHANNELS_SET_PURPOSE, req.getToken(), ChannelsSetPurposeResponse.class);
+    }
+
+    @Override
+    public ChannelsSetPurposeResponse channelsSetPurpose(RequestBuilder<ChannelsSetPurposeRequest, ChannelsSetPurposeRequest.ChannelsSetPurposeRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsSetPurpose(req.build(ChannelsSetPurposeRequest.builder()));
     }
 
     @Override
@@ -270,8 +371,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChannelsSetTopicResponse channelsSetTopic(RequestBuilder<ChannelsSetTopicRequest, ChannelsSetTopicRequest.ChannelsSetTopicRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsSetTopic(req.build(ChannelsSetTopicRequest.builder()));
+    }
+
+    @Override
     public ChannelsUnarchiveResponse channelsUnarchive(ChannelsUnarchiveRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHANNELS_UNARCHIVE, req.getToken(), ChannelsUnarchiveResponse.class);
+    }
+
+    @Override
+    public ChannelsUnarchiveResponse channelsUnarchive(RequestBuilder<ChannelsUnarchiveRequest, ChannelsUnarchiveRequest.ChannelsUnarchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsUnarchive(req.build(ChannelsUnarchiveRequest.builder()));
     }
 
     @Override
@@ -280,8 +391,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChatGetPermalinkResponse chatGetPermalink(RequestBuilder<ChatGetPermalinkRequest, ChatGetPermalinkRequest.ChatGetPermalinkRequestBuilder> req) throws IOException, SlackApiException {
+        return chatGetPermalink(req.build(ChatGetPermalinkRequest.builder()));
+    }
+
+    @Override
     public ChatDeleteResponse chatDelete(ChatDeleteRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHAT_DELETE, req.getToken(), ChatDeleteResponse.class);
+    }
+
+    @Override
+    public ChatDeleteResponse chatDelete(RequestBuilder<ChatDeleteRequest, ChatDeleteRequest.ChatDeleteRequestBuilder> req) throws IOException, SlackApiException {
+        return chatDelete(req.build(ChatDeleteRequest.builder()));
     }
 
     @Override
@@ -290,8 +411,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChatDeleteScheduledMessageResponse chatDeleteScheduledMessage(RequestBuilder<ChatDeleteScheduledMessageRequest, ChatDeleteScheduledMessageRequest.ChatDeleteScheduledMessageRequestBuilder> req) throws IOException, SlackApiException {
+        return chatDeleteScheduledMessage(req.build(ChatDeleteScheduledMessageRequest.builder()));
+    }
+
+    @Override
     public ChatMeMessageResponse chatMeMessage(ChatMeMessageRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHAT_ME_MESSAGE, req.getToken(), ChatMeMessageResponse.class);
+    }
+
+    @Override
+    public ChatMeMessageResponse chatMeMessage(RequestBuilder<ChatMeMessageRequest, ChatMeMessageRequest.ChatMeMessageRequestBuilder> req) throws IOException, SlackApiException {
+        return chatMeMessage(req.build(ChatMeMessageRequest.builder()));
     }
 
     @Override
@@ -300,8 +431,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChatPostEphemeralResponse chatPostEphemeral(RequestBuilder<ChatPostEphemeralRequest, ChatPostEphemeralRequest.ChatPostEphemeralRequestBuilder> req) throws IOException, SlackApiException {
+        return chatPostEphemeral(req.build(ChatPostEphemeralRequest.builder()));
+    }
+
+    @Override
     public ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHAT_POST_MESSAGE, req.getToken(), ChatPostMessageResponse.class);
+    }
+
+    @Override
+    public ChatPostMessageResponse chatPostMessage(RequestBuilder<ChatPostMessageRequest, ChatPostMessageRequest.ChatPostMessageRequestBuilder> req) throws IOException, SlackApiException {
+        return chatPostMessage(req.build(ChatPostMessageRequest.builder()));
     }
 
     @Override
@@ -310,8 +451,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChatScheduleMessageResponse chatScheduleMessage(RequestBuilder<ChatScheduleMessageRequest, ChatScheduleMessageRequest.ChatScheduleMessageRequestBuilder> req) throws IOException, SlackApiException {
+        return chatScheduleMessage(req.build(ChatScheduleMessageRequest.builder()));
+    }
+
+    @Override
     public ChatUpdateResponse chatUpdate(ChatUpdateRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHAT_UPDATE, req.getToken(), ChatUpdateResponse.class);
+    }
+
+    @Override
+    public ChatUpdateResponse chatUpdate(RequestBuilder<ChatUpdateRequest, ChatUpdateRequest.ChatUpdateRequestBuilder> req) throws IOException, SlackApiException {
+        return chatUpdate(req.build(ChatUpdateRequest.builder()));
     }
 
     @Override
@@ -320,8 +471,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ChatUnfurlResponse chatUnfurl(RequestBuilder<ChatUnfurlRequest, ChatUnfurlRequest.ChatUnfurlRequestBuilder> req) throws IOException, SlackApiException {
+        return chatUnfurl(req.build(ChatUnfurlRequest.builder()));
+    }
+
+    @Override
     public ChatScheduleMessagesListResponse chatScheduleMessagesListMessage(ChatScheduleMessagesListRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CHAT_SCHEDULED_MESSAGES_LIST, req.getToken(), ChatScheduleMessagesListResponse.class);
+    }
+
+    @Override
+    public ChatScheduleMessagesListResponse chatScheduleMessagesListMessage(RequestBuilder<ChatScheduleMessagesListRequest, ChatScheduleMessagesListRequest.ChatScheduleMessagesListRequestBuilder> req) throws IOException, SlackApiException {
+        return chatScheduleMessagesListMessage(req.build(ChatScheduleMessagesListRequest.builder()));
     }
 
     @Override
@@ -331,9 +492,19 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ConversationsArchiveResponse conversationsArchive(RequestBuilder<ConversationsArchiveRequest, ConversationsArchiveRequest.ConversationsArchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsArchive(req.build(ConversationsArchiveRequest.builder()));
+    }
+
+    @Override
     public ConversationsCloseResponse conversationsClose(ConversationsCloseRequest req)
             throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CONVERSATIONS_CLOSE, req.getToken(), ConversationsCloseResponse.class);
+    }
+
+    @Override
+    public ConversationsCloseResponse conversationsClose(RequestBuilder<ConversationsCloseRequest, ConversationsCloseRequest.ConversationsCloseRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsClose(req.build(ConversationsCloseRequest.builder()));
     }
 
     @Override
@@ -343,9 +514,19 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ConversationsCreateResponse conversationsCreate(RequestBuilder<ConversationsCreateRequest, ConversationsCreateRequest.ConversationsCreateRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsCreate(req.build(ConversationsCreateRequest.builder()));
+    }
+
+    @Override
     public ConversationsHistoryResponse conversationsHistory(ConversationsHistoryRequest req)
             throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CONVERSATIONS_HISTORY, req.getToken(), ConversationsHistoryResponse.class);
+    }
+
+    @Override
+    public ConversationsHistoryResponse conversationsHistory(RequestBuilder<ConversationsHistoryRequest, ConversationsHistoryRequest.ConversationsHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsHistory(req.build(ConversationsHistoryRequest.builder()));
     }
 
     @Override
@@ -355,9 +536,19 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ConversationsInfoResponse conversationsInfo(RequestBuilder<ConversationsInfoRequest, ConversationsInfoRequest.ConversationsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsInfo(req.build(ConversationsInfoRequest.builder()));
+    }
+
+    @Override
     public ConversationsInviteResponse conversationsInvite(ConversationsInviteRequest req)
             throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CONVERSATIONS_INVITE, req.getToken(), ConversationsInviteResponse.class);
+    }
+
+    @Override
+    public ConversationsInviteResponse conversationsInvite(RequestBuilder<ConversationsInviteRequest, ConversationsInviteRequest.ConversationsInviteRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsInvite(req.build(ConversationsInviteRequest.builder()));
     }
 
     @Override
@@ -367,9 +558,19 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ConversationsJoinResponse conversationsJoin(RequestBuilder<ConversationsJoinRequest, ConversationsJoinRequest.ConversationsJoinRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsJoin(req.build(ConversationsJoinRequest.builder()));
+    }
+
+    @Override
     public ConversationsKickResponse conversationsKick(ConversationsKickRequest req)
             throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CONVERSATIONS_KICK, req.getToken(), ConversationsKickResponse.class);
+    }
+
+    @Override
+    public ConversationsKickResponse conversationsKick(RequestBuilder<ConversationsKickRequest, ConversationsKickRequest.ConversationsKickRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsKick(req.build(ConversationsKickRequest.builder()));
     }
 
     @Override
@@ -379,9 +580,19 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ConversationsLeaveResponse conversationsLeave(RequestBuilder<ConversationsLeaveRequest, ConversationsLeaveRequest.ConversationsLeaveRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsLeave(req.build(ConversationsLeaveRequest.builder()));
+    }
+
+    @Override
     public ConversationsListResponse conversationsList(ConversationsListRequest req)
             throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CONVERSATIONS_LIST, req.getToken(), ConversationsListResponse.class);
+    }
+
+    @Override
+    public ConversationsListResponse conversationsList(RequestBuilder<ConversationsListRequest, ConversationsListRequest.ConversationsListRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsList(req.build(ConversationsListRequest.builder()));
     }
 
     @Override
@@ -391,9 +602,19 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ConversationsMembersResponse conversationsMembers(RequestBuilder<ConversationsMembersRequest, ConversationsMembersRequest.ConversationsMembersRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsMembers(req.build(ConversationsMembersRequest.builder()));
+    }
+
+    @Override
     public ConversationsOpenResponse conversationsOpen(ConversationsOpenRequest req)
             throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CONVERSATIONS_OPEN, req.getToken(), ConversationsOpenResponse.class);
+    }
+
+    @Override
+    public ConversationsOpenResponse conversationsOpen(RequestBuilder<ConversationsOpenRequest, ConversationsOpenRequest.ConversationsOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsOpen(req.build(ConversationsOpenRequest.builder()));
     }
 
     @Override
@@ -403,9 +624,19 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ConversationsRenameResponse conversationsRename(RequestBuilder<ConversationsRenameRequest, ConversationsRenameRequest.ConversationsRenameRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsRename(req.build(ConversationsRenameRequest.builder()));
+    }
+
+    @Override
     public ConversationsRepliesResponse conversationsReplies(ConversationsRepliesRequest req)
             throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CONVERSATIONS_REPLIES, req.getToken(), ConversationsRepliesResponse.class);
+    }
+
+    @Override
+    public ConversationsRepliesResponse conversationsReplies(RequestBuilder<ConversationsRepliesRequest, ConversationsRepliesRequest.ConversationsRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsReplies(req.build(ConversationsRepliesRequest.builder()));
     }
 
     @Override
@@ -415,9 +646,19 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ConversationsSetPurposeResponse conversationsSetPurpose(RequestBuilder<ConversationsSetPurposeRequest, ConversationsSetPurposeRequest.ConversationsSetPurposeRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsSetPurpose(req.build(ConversationsSetPurposeRequest.builder()));
+    }
+
+    @Override
     public ConversationsSetTopicResponse conversationsSetTopic(ConversationsSetTopicRequest req)
             throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.CONVERSATIONS_SET_TOPIC, req.getToken(), ConversationsSetTopicResponse.class);
+    }
+
+    @Override
+    public ConversationsSetTopicResponse conversationsSetTopic(RequestBuilder<ConversationsSetTopicRequest, ConversationsSetTopicRequest.ConversationsSetTopicRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsSetTopic(req.build(ConversationsSetTopicRequest.builder()));
     }
 
     @Override
@@ -427,9 +668,19 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ConversationsUnarchiveResponse conversationsUnarchive(RequestBuilder<ConversationsUnarchiveRequest, ConversationsUnarchiveRequest.ConversationsUnarchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsUnarchive(req.build(ConversationsUnarchiveRequest.builder()));
+    }
+
+    @Override
     public DialogOpenResponse dialogOpen(DialogOpenRequest req)
             throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.DIALOG_OPEN, req.getToken(), DialogOpenResponse.class);
+    }
+
+    @Override
+    public DialogOpenResponse dialogOpen(RequestBuilder<DialogOpenRequest, DialogOpenRequest.DialogOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return dialogOpen(req.build(DialogOpenRequest.builder()));
     }
 
     @Override
@@ -438,8 +689,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public DndEndDndResponse dndEndDnd(RequestBuilder<DndEndDndRequest, DndEndDndRequest.DndEndDndRequestBuilder> req) throws IOException, SlackApiException {
+        return dndEndDnd(req.build(DndEndDndRequest.builder()));
+    }
+
+    @Override
     public DndEndSnoozeResponse dndEndSnooze(DndEndSnoozeRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.DND_END_SNOOZE, req.getToken(), DndEndSnoozeResponse.class);
+    }
+
+    @Override
+    public DndEndSnoozeResponse dndEndSnooze(RequestBuilder<DndEndSnoozeRequest, DndEndSnoozeRequest.DndEndSnoozeRequestBuilder> req) throws IOException, SlackApiException {
+        return dndEndSnooze(req.build(DndEndSnoozeRequest.builder()));
     }
 
     @Override
@@ -448,8 +709,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public DndInfoResponse dndInfo(RequestBuilder<DndInfoRequest, DndInfoRequest.DndInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return dndInfo(req.build(DndInfoRequest.builder()));
+    }
+
+    @Override
     public DndSetSnoozeResponse dndSetSnooze(DndSetSnoozeRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.DND_SET_SNOOZE, req.getToken(), DndSetSnoozeResponse.class);
+    }
+
+    @Override
+    public DndSetSnoozeResponse dndSetSnooze(RequestBuilder<DndSetSnoozeRequest, DndSetSnoozeRequest.DndSetSnoozeRequestBuilder> req) throws IOException, SlackApiException {
+        return dndSetSnooze(req.build(DndSetSnoozeRequest.builder()));
     }
 
     @Override
@@ -458,8 +729,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public DndTeamInfoResponse dndTeamInfo(RequestBuilder<DndTeamInfoRequest, DndTeamInfoRequest.DndTeamInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return dndTeamInfo(req.build(DndTeamInfoRequest.builder()));
+    }
+
+    @Override
     public EmojiListResponse emojiList(EmojiListRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.EMOJI_LIST, req.getToken(), EmojiListResponse.class);
+    }
+
+    @Override
+    public EmojiListResponse emojiList(RequestBuilder<EmojiListRequest, EmojiListRequest.EmojiListRequestBuilder> req) throws IOException, SlackApiException {
+        return emojiList(req.build(EmojiListRequest.builder()));
     }
 
     @Override
@@ -468,8 +749,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public FilesDeleteResponse filesDelete(RequestBuilder<FilesDeleteRequest, FilesDeleteRequest.FilesDeleteRequestBuilder> req) throws IOException, SlackApiException {
+        return filesDelete(req.build(FilesDeleteRequest.builder()));
+    }
+
+    @Override
     public FilesInfoResponse filesInfo(FilesInfoRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.FILES_INFO, req.getToken(), FilesInfoResponse.class);
+    }
+
+    @Override
+    public FilesInfoResponse filesInfo(RequestBuilder<FilesInfoRequest, FilesInfoRequest.FilesInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return filesInfo(req.build(FilesInfoRequest.builder()));
     }
 
     @Override
@@ -478,13 +769,28 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public FilesListResponse filesList(RequestBuilder<FilesListRequest, FilesListRequest.FilesListRequestBuilder> req) throws IOException, SlackApiException {
+        return filesList(req.build(FilesListRequest.builder()));
+    }
+
+    @Override
     public FilesRevokePublicURLResponse filesRevokePublicURL(FilesRevokePublicURLRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.FILES_REVOKE_PUBLIC_URL, req.getToken(), FilesRevokePublicURLResponse.class);
     }
 
     @Override
+    public FilesRevokePublicURLResponse filesRevokePublicURL(RequestBuilder<FilesRevokePublicURLRequest, FilesRevokePublicURLRequest.FilesRevokePublicURLRequestBuilder> req) throws IOException, SlackApiException {
+        return filesRevokePublicURL(req.build(FilesRevokePublicURLRequest.builder()));
+    }
+
+    @Override
     public FilesSharedPublicURLResponse filesSharedPublicURL(FilesSharedPublicURLRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.FILES_SHARED_PUBLIC_URL, req.getToken(), FilesSharedPublicURLResponse.class);
+    }
+
+    @Override
+    public FilesSharedPublicURLResponse filesSharedPublicURL(RequestBuilder<FilesSharedPublicURLRequest, FilesSharedPublicURLRequest.FilesSharedPublicURLRequestBuilder> req) throws IOException, SlackApiException {
+        return filesSharedPublicURL(req.build(FilesSharedPublicURLRequest.builder()));
     }
 
     @Override
@@ -494,6 +800,11 @@ public class MethodsClientImpl implements MethodsClient {
         } else {
             return doPostFormWithToken(toForm(req), Methods.FILES_UPLOAD, req.getToken(), FilesUploadResponse.class);
         }
+    }
+
+    @Override
+    public FilesUploadResponse filesUpload(RequestBuilder<FilesUploadRequest, FilesUploadRequest.FilesUploadRequestBuilder> req) throws IOException, SlackApiException {
+        return filesUpload(req.build(FilesUploadRequest.builder()));
     }
 
     @Override
@@ -517,6 +828,11 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public GroupsArchiveResponse groupsArchive(RequestBuilder<GroupsArchiveRequest, GroupsArchiveRequest.GroupsArchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsArchive(req.build(GroupsArchiveRequest.builder()));
+    }
+
+    @Override
     public GroupsCloseResponse groupsClose(GroupsCloseRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.GROUPS_CLOSE, req.getToken(), GroupsCloseResponse.class);
     }
@@ -527,8 +843,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public GroupsCreateChildResponse groupsCreateChild(RequestBuilder<GroupsCreateChildRequest, GroupsCreateChildRequest.GroupsCreateChildRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsCreateChild(req.build(GroupsCreateChildRequest.builder()));
+    }
+
+    @Override
     public GroupsCreateResponse groupsCreate(GroupsCreateRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.GROUPS_CREATE, req.getToken(), GroupsCreateResponse.class);
+    }
+
+    @Override
+    public GroupsCreateResponse groupsCreate(RequestBuilder<GroupsCreateRequest, GroupsCreateRequest.GroupsCreateRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsCreate(req.build(GroupsCreateRequest.builder()));
     }
 
     @Override
@@ -537,8 +863,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public GroupsHistoryResponse groupsHistory(RequestBuilder<GroupsHistoryRequest, GroupsHistoryRequest.GroupsHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsHistory(req.build(GroupsHistoryRequest.builder()));
+    }
+
+    @Override
     public GroupsRepliesResponse groupsReplies(GroupsRepliesRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.GROUPS_REPLIES, req.getToken(), GroupsRepliesResponse.class);
+    }
+
+    @Override
+    public GroupsRepliesResponse groupsReplies(RequestBuilder<GroupsRepliesRequest, GroupsRepliesRequest.GroupsRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsReplies(req.build(GroupsRepliesRequest.builder()));
     }
 
     @Override
@@ -547,8 +883,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public GroupsInfoResponse groupsInfo(RequestBuilder<GroupsInfoRequest, GroupsInfoRequest.GroupsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsInfo(req.build(GroupsInfoRequest.builder()));
+    }
+
+    @Override
     public GroupsInviteResponse groupsInvite(GroupsInviteRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.GROUPS_INVITE, req.getToken(), GroupsInviteResponse.class);
+    }
+
+    @Override
+    public GroupsInviteResponse groupsInvite(RequestBuilder<GroupsInviteRequest, GroupsInviteRequest.GroupsInviteRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsInvite(req.build(GroupsInviteRequest.builder()));
     }
 
     @Override
@@ -557,8 +903,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public GroupsKickResponse groupsKick(RequestBuilder<GroupsKickRequest, GroupsKickRequest.GroupsKickRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsKick(req.build(GroupsKickRequest.builder()));
+    }
+
+    @Override
     public GroupsLeaveResponse groupsLeave(GroupsLeaveRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.GROUPS_LEAVE, req.getToken(), GroupsLeaveResponse.class);
+    }
+
+    @Override
+    public GroupsLeaveResponse groupsLeave(RequestBuilder<GroupsLeaveRequest, GroupsLeaveRequest.GroupsLeaveRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsLeave(req.build(GroupsLeaveRequest.builder()));
     }
 
     @Override
@@ -567,8 +923,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public GroupsListResponse groupsList(RequestBuilder<GroupsListRequest, GroupsListRequest.GroupsListRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsList(req.build(GroupsListRequest.builder()));
+    }
+
+    @Override
     public GroupsMarkResponse groupsMark(GroupsMarkRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.GROUPS_MARK, req.getToken(), GroupsMarkResponse.class);
+    }
+
+    @Override
+    public GroupsMarkResponse groupsMark(RequestBuilder<GroupsMarkRequest, GroupsMarkRequest.GroupsMarkRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsMark(req.build(GroupsMarkRequest.builder()));
     }
 
     @Override
@@ -577,8 +943,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public GroupsOpenResponse groupsOpen(RequestBuilder<GroupsOpenRequest, GroupsOpenRequest.GroupsOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsOpen(req.build(GroupsOpenRequest.builder()));
+    }
+
+    @Override
     public GroupsRenameResponse groupsRename(GroupsRenameRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.GROUPS_RENAME, req.getToken(), GroupsRenameResponse.class);
+    }
+
+    @Override
+    public GroupsRenameResponse groupsRename(RequestBuilder<GroupsRenameRequest, GroupsRenameRequest.GroupsRenameRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsRename(req.build(GroupsRenameRequest.builder()));
     }
 
     @Override
@@ -587,8 +963,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public GroupsSetPurposeResponse groupsSetPurpose(RequestBuilder<GroupsSetPurposeRequest, GroupsSetPurposeRequest.GroupsSetPurposeRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsSetPurpose(req.build(GroupsSetPurposeRequest.builder()));
+    }
+
+    @Override
     public GroupsSetTopicResponse groupsSetTopic(GroupsSetTopicRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.GROUPS_SET_TOPIC, req.getToken(), GroupsSetTopicResponse.class);
+    }
+
+    @Override
+    public GroupsSetTopicResponse groupsSetTopic(RequestBuilder<GroupsSetTopicRequest, GroupsSetTopicRequest.GroupsSetTopicRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsSetTopic(req.build(GroupsSetTopicRequest.builder()));
     }
 
     @Override
@@ -597,8 +983,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public GroupsUnarchiveResponse groupsUnarchive(RequestBuilder<GroupsUnarchiveRequest, GroupsUnarchiveRequest.GroupsUnarchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsUnarchive(req.build(GroupsUnarchiveRequest.builder()));
+    }
+
+    @Override
     public ImCloseResponse imClose(ImCloseRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.IM_CLOSE, req.getToken(), ImCloseResponse.class);
+    }
+
+    @Override
+    public ImCloseResponse imClose(RequestBuilder<ImCloseRequest, ImCloseRequest.ImCloseRequestBuilder> req) throws IOException, SlackApiException {
+        return imClose(req.build(ImCloseRequest.builder()));
     }
 
     @Override
@@ -607,8 +1003,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ImHistoryResponse imHistory(RequestBuilder<ImHistoryRequest, ImHistoryRequest.ImHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return imHistory(req.build(ImHistoryRequest.builder()));
+    }
+
+    @Override
     public ImListResponse imList(ImListRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.IM_LIST, req.getToken(), ImListResponse.class);
+    }
+
+    @Override
+    public ImListResponse imList(RequestBuilder<ImListRequest, ImListRequest.ImListRequestBuilder> req) throws IOException, SlackApiException {
+        return imList(req.build(ImListRequest.builder()));
     }
 
     @Override
@@ -617,8 +1023,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ImMarkResponse imMark(RequestBuilder<ImMarkRequest, ImMarkRequest.ImMarkRequestBuilder> req) throws IOException, SlackApiException {
+        return imMark(req.build(ImMarkRequest.builder()));
+    }
+
+    @Override
     public ImOpenResponse imOpen(ImOpenRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.IM_OPEN, req.getToken(), ImOpenResponse.class);
+    }
+
+    @Override
+    public ImOpenResponse imOpen(RequestBuilder<ImOpenRequest, ImOpenRequest.ImOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return imOpen(req.build(ImOpenRequest.builder()));
     }
 
     @Override
@@ -627,8 +1043,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ImRepliesResponse imReplies(RequestBuilder<ImRepliesRequest, ImRepliesRequest.ImRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return imReplies(req.build(ImRepliesRequest.builder()));
+    }
+
+    @Override
     public MigrationExchangeResponse migrationExchange(MigrationExchangeRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.MIGRATION_EXCHANGE, req.getToken(), MigrationExchangeResponse.class);
+    }
+
+    @Override
+    public MigrationExchangeResponse migrationExchange(RequestBuilder<MigrationExchangeRequest, MigrationExchangeRequest.MigrationExchangeRequestBuilder> req) throws IOException, SlackApiException {
+        return migrationExchange(req.build(MigrationExchangeRequest.builder()));
     }
 
     @Override
@@ -637,8 +1063,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public MpimCloseResponse mpimClose(RequestBuilder<MpimCloseRequest, MpimCloseRequest.MpimCloseRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimClose(req.build(MpimCloseRequest.builder()));
+    }
+
+    @Override
     public MpimHistoryResponse mpimHistory(MpimHistoryRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.MPIM_HISTORY, req.getToken(), MpimHistoryResponse.class);
+    }
+
+    @Override
+    public MpimHistoryResponse mpimHistory(RequestBuilder<MpimHistoryRequest, MpimHistoryRequest.MpimHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimHistory(req.build(MpimHistoryRequest.builder()));
     }
 
     @Override
@@ -647,8 +1083,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public MpimListResponse mpimList(RequestBuilder<MpimListRequest, MpimListRequest.MpimListRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimList(req.build(MpimListRequest.builder()));
+    }
+
+    @Override
     public MpimRepliesResponse mpimReplies(MpimRepliesRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.MPIM_REPLIES, req.getToken(), MpimRepliesResponse.class);
+    }
+
+    @Override
+    public MpimRepliesResponse mpimReplies(RequestBuilder<MpimRepliesRequest, MpimRepliesRequest.MpimRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimReplies(req.build(MpimRepliesRequest.builder()));
     }
 
     @Override
@@ -657,8 +1103,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public MpimMarkResponse mpimMark(RequestBuilder<MpimMarkRequest, MpimMarkRequest.MpimMarkRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimMark(req.build(MpimMarkRequest.builder()));
+    }
+
+    @Override
     public MpimOpenResponse mpimOpen(MpimOpenRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.MPIM_OPEN, req.getToken(), MpimOpenResponse.class);
+    }
+
+    @Override
+    public MpimOpenResponse mpimOpen(RequestBuilder<MpimOpenRequest, MpimOpenRequest.MpimOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimOpen(req.build(MpimOpenRequest.builder()));
     }
 
     @Override
@@ -667,8 +1123,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public OAuthAccessResponse oauthAccess(RequestBuilder<OAuthAccessRequest, OAuthAccessRequest.OAuthAccessRequestBuilder> req) throws IOException, SlackApiException {
+        return oauthAccess(req.build(OAuthAccessRequest.builder()));
+    }
+
+    @Override
     public OAuthTokenResponse oauthToken(OAuthTokenRequest req) throws IOException, SlackApiException {
         return doPostForm(toForm(req), Methods.OAUTH_TOKEN, OAuthTokenResponse.class);
+    }
+
+    @Override
+    public OAuthTokenResponse oauthToken(RequestBuilder<OAuthTokenRequest, OAuthTokenRequest.OAuthTokenRequestBuilder> req) throws IOException, SlackApiException {
+        return oauthToken(req.build(OAuthTokenRequest.builder()));
     }
 
     @Override
@@ -677,8 +1143,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public PinsAddResponse pinsAdd(RequestBuilder<PinsAddRequest, PinsAddRequest.PinsAddRequestBuilder> req) throws IOException, SlackApiException {
+        return pinsAdd(req.build(PinsAddRequest.builder()));
+    }
+
+    @Override
     public PinsListResponse pinsList(PinsListRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.PINS_LIST, req.getToken(), PinsListResponse.class);
+    }
+
+    @Override
+    public PinsListResponse pinsList(RequestBuilder<PinsListRequest, PinsListRequest.PinsListRequestBuilder> req) throws IOException, SlackApiException {
+        return pinsList(req.build(PinsListRequest.builder()));
     }
 
     @Override
@@ -687,8 +1163,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public PinsRemoveResponse pinsRemove(RequestBuilder<PinsRemoveRequest, PinsRemoveRequest.PinsRemoveRequestBuilder> req) throws IOException, SlackApiException {
+        return pinsRemove(req.build(PinsRemoveRequest.builder()));
+    }
+
+    @Override
     public ReactionsAddResponse reactionsAdd(ReactionsAddRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.REACTIONS_ADD, req.getToken(), ReactionsAddResponse.class);
+    }
+
+    @Override
+    public ReactionsAddResponse reactionsAdd(RequestBuilder<ReactionsAddRequest, ReactionsAddRequest.ReactionsAddRequestBuilder> req) throws IOException, SlackApiException {
+        return reactionsAdd(req.build(ReactionsAddRequest.builder()));
     }
 
     @Override
@@ -697,8 +1183,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ReactionsGetResponse reactionsGet(RequestBuilder<ReactionsGetRequest, ReactionsGetRequest.ReactionsGetRequestBuilder> req) throws IOException, SlackApiException {
+        return reactionsGet(req.build(ReactionsGetRequest.builder()));
+    }
+
+    @Override
     public ReactionsListResponse reactionsList(ReactionsListRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.REACTIONS_LIST, req.getToken(), ReactionsListResponse.class);
+    }
+
+    @Override
+    public ReactionsListResponse reactionsList(RequestBuilder<ReactionsListRequest, ReactionsListRequest.ReactionsListRequestBuilder> req) throws IOException, SlackApiException {
+        return reactionsList(req.build(ReactionsListRequest.builder()));
     }
 
     @Override
@@ -707,8 +1203,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public ReactionsRemoveResponse reactionsRemove(RequestBuilder<ReactionsRemoveRequest, ReactionsRemoveRequest.ReactionsRemoveRequestBuilder> req) throws IOException, SlackApiException {
+        return reactionsRemove(req.build(ReactionsRemoveRequest.builder()));
+    }
+
+    @Override
     public RemindersAddResponse remindersAdd(RemindersAddRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.REMINDERS_ADD, req.getToken(), RemindersAddResponse.class);
+    }
+
+    @Override
+    public RemindersAddResponse remindersAdd(RequestBuilder<RemindersAddRequest, RemindersAddRequest.RemindersAddRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersAdd(req.build(RemindersAddRequest.builder()));
     }
 
     @Override
@@ -717,8 +1223,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public RemindersCompleteResponse remindersComplete(RequestBuilder<RemindersCompleteRequest, RemindersCompleteRequest.RemindersCompleteRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersComplete(req.build(RemindersCompleteRequest.builder()));
+    }
+
+    @Override
     public RemindersDeleteResponse remindersDelete(RemindersDeleteRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.REMINDERS_DELETE, req.getToken(), RemindersDeleteResponse.class);
+    }
+
+    @Override
+    public RemindersDeleteResponse remindersDelete(RequestBuilder<RemindersDeleteRequest, RemindersDeleteRequest.RemindersDeleteRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersDelete(req.build(RemindersDeleteRequest.builder()));
     }
 
     @Override
@@ -727,8 +1243,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public RemindersInfoResponse remindersInfo(RequestBuilder<RemindersInfoRequest, RemindersInfoRequest.RemindersInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersInfo(req.build(RemindersInfoRequest.builder()));
+    }
+
+    @Override
     public RemindersListResponse remindersList(RemindersListRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.REMINDERS_LIST, req.getToken(), RemindersListResponse.class);
+    }
+
+    @Override
+    public RemindersListResponse remindersList(RequestBuilder<RemindersListRequest, RemindersListRequest.RemindersListRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersList(req.build(RemindersListRequest.builder()));
     }
 
     @Override
@@ -737,8 +1263,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public RTMConnectResponse rtmConnect(RequestBuilder<RTMConnectRequest, RTMConnectRequest.RTMConnectRequestBuilder> req) throws IOException, SlackApiException {
+        return rtmConnect(req.build(RTMConnectRequest.builder()));
+    }
+
+    @Override
     public RTMStartResponse rtmStart(RTMStartRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.RTM_START, req.getToken(), RTMStartResponse.class);
+    }
+
+    @Override
+    public RTMStartResponse rtmStart(RequestBuilder<RTMStartRequest, RTMStartRequest.RTMStartRequestBuilder> req) throws IOException, SlackApiException {
+        return rtmStart(req.build(RTMStartRequest.builder()));
     }
 
     @Override
@@ -747,8 +1283,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public SearchAllResponse searchAll(RequestBuilder<SearchAllRequest, SearchAllRequest.SearchAllRequestBuilder> req) throws IOException, SlackApiException {
+        return searchAll(req.build(SearchAllRequest.builder()));
+    }
+
+    @Override
     public SearchMessagesResponse searchMessages(SearchMessagesRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.SEARCH_MESSAGES, req.getToken(), SearchMessagesResponse.class);
+    }
+
+    @Override
+    public SearchMessagesResponse searchMessages(RequestBuilder<SearchMessagesRequest, SearchMessagesRequest.SearchMessagesRequestBuilder> req) throws IOException, SlackApiException {
+        return searchMessages(req.build(SearchMessagesRequest.builder()));
     }
 
     @Override
@@ -757,8 +1303,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public SearchFilesResponse searchFiles(RequestBuilder<SearchFilesRequest, SearchFilesRequest.SearchFilesRequestBuilder> req) throws IOException, SlackApiException {
+        return searchFiles(req.build(SearchFilesRequest.builder()));
+    }
+
+    @Override
     public StarsAddResponse starsAdd(StarsAddRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.STARS_ADD, req.getToken(), StarsAddResponse.class);
+    }
+
+    @Override
+    public StarsAddResponse starsAdd(RequestBuilder<StarsAddRequest, StarsAddRequest.StarsAddRequestBuilder> req) throws IOException, SlackApiException {
+        return starsAdd(req.build(StarsAddRequest.builder()));
     }
 
     @Override
@@ -767,8 +1323,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public StarsListResponse starsList(RequestBuilder<StarsListRequest, StarsListRequest.StarsListRequestBuilder> req) throws IOException, SlackApiException {
+        return starsList(req.build(StarsListRequest.builder()));
+    }
+
+    @Override
     public StarsRemoveResponse starsRemove(StarsRemoveRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.STARS_REMOVE, req.getToken(), StarsRemoveResponse.class);
+    }
+
+    @Override
+    public StarsRemoveResponse starsRemove(RequestBuilder<StarsRemoveRequest, StarsRemoveRequest.StarsRemoveRequestBuilder> req) throws IOException, SlackApiException {
+        return starsRemove(req.build(StarsRemoveRequest.builder()));
     }
 
     @Override
@@ -777,8 +1343,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public TeamAccessLogsResponse teamAccessLogs(RequestBuilder<TeamAccessLogsRequest, TeamAccessLogsRequest.TeamAccessLogsRequestBuilder> req) throws IOException, SlackApiException {
+        return teamAccessLogs(req.build(TeamAccessLogsRequest.builder()));
+    }
+
+    @Override
     public TeamBillableInfoResponse teamBillableInfo(TeamBillableInfoRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.TEAM_BILLABLE_INFO, req.getToken(), TeamBillableInfoResponse.class);
+    }
+
+    @Override
+    public TeamBillableInfoResponse teamBillableInfo(RequestBuilder<TeamBillableInfoRequest, TeamBillableInfoRequest.TeamBillableInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return teamBillableInfo(req.build(TeamBillableInfoRequest.builder()));
     }
 
     @Override
@@ -787,8 +1363,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public TeamInfoResponse teamInfo(RequestBuilder<TeamInfoRequest, TeamInfoRequest.TeamInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return teamInfo(req.build(TeamInfoRequest.builder()));
+    }
+
+    @Override
     public TeamIntegrationLogsResponse teamIntegrationLogs(TeamIntegrationLogsRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.TEAM_INTEGRATION_LOGS, req.getToken(), TeamIntegrationLogsResponse.class);
+    }
+
+    @Override
+    public TeamIntegrationLogsResponse teamIntegrationLogs(RequestBuilder<TeamIntegrationLogsRequest, TeamIntegrationLogsRequest.TeamIntegrationLogsRequestBuilder> req) throws IOException, SlackApiException {
+        return teamIntegrationLogs(req.build(TeamIntegrationLogsRequest.builder()));
     }
 
     @Override
@@ -797,8 +1383,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public TeamProfileGetResponse teamProfileGet(RequestBuilder<TeamProfileGetRequest, TeamProfileGetRequest.TeamProfileGetRequestBuilder> req) throws IOException, SlackApiException {
+        return teamProfileGet(req.build(TeamProfileGetRequest.builder()));
+    }
+
+    @Override
     public UsergroupsCreateResponse usergroupsCreate(UsergroupsCreateRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERGROUPS_CREATE, req.getToken(), UsergroupsCreateResponse.class);
+    }
+
+    @Override
+    public UsergroupsCreateResponse usergroupsCreate(RequestBuilder<UsergroupsCreateRequest, UsergroupsCreateRequest.UsergroupsCreateRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsCreate(req.build(UsergroupsCreateRequest.builder()));
     }
 
     @Override
@@ -807,8 +1403,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public UsergroupsDisableResponse usergroupsDisable(RequestBuilder<UsergroupsDisableRequest, UsergroupsDisableRequest.UsergroupsDisableRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsDisable(req.build(UsergroupsDisableRequest.builder()));
+    }
+
+    @Override
     public UsergroupsEnableResponse usergroupsEnable(UsergroupsEnableRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERGROUPS_ENABLE, req.getToken(), UsergroupsEnableResponse.class);
+    }
+
+    @Override
+    public UsergroupsEnableResponse usergroupsEnable(RequestBuilder<UsergroupsEnableRequest, UsergroupsEnableRequest.UsergroupsEnableRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsEnable(req.build(UsergroupsEnableRequest.builder()));
     }
 
     @Override
@@ -817,8 +1423,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public UsergroupsListResponse usergroupsList(RequestBuilder<UsergroupsListRequest, UsergroupsListRequest.UsergroupsListRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsList(req.build(UsergroupsListRequest.builder()));
+    }
+
+    @Override
     public UsergroupsUpdateResponse usergroupsUpdate(UsergroupsUpdateRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERGROUPS_UPDATE, req.getToken(), UsergroupsUpdateResponse.class);
+    }
+
+    @Override
+    public UsergroupsUpdateResponse usergroupsUpdate(RequestBuilder<UsergroupsUpdateRequest, UsergroupsUpdateRequest.UsergroupsUpdateRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsUpdate(req.build(UsergroupsUpdateRequest.builder()));
     }
 
     @Override
@@ -827,8 +1443,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public UsergroupUsersListResponse usergroupUsersList(RequestBuilder<UsergroupUsersListRequest, UsergroupUsersListRequest.UsergroupUsersListRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupUsersList(req.build(UsergroupUsersListRequest.builder()));
+    }
+
+    @Override
     public UsergroupUsersUpdateResponse usergroupUsersUpdate(UsergroupUsersUpdateRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERGROUPS_USERS_UPDATE, req.getToken(), UsergroupUsersUpdateResponse.class);
+    }
+
+    @Override
+    public UsergroupUsersUpdateResponse usergroupUsersUpdate(RequestBuilder<UsergroupUsersUpdateRequest, UsergroupUsersUpdateRequest.UsergroupUsersUpdateRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupUsersUpdate(req.build(UsergroupUsersUpdateRequest.builder()));
     }
 
     @Override
@@ -837,8 +1463,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public UsersConversationsResponse usersConversations(RequestBuilder<UsersConversationsRequest, UsersConversationsRequest.UsersConversationsRequestBuilder> req) throws IOException, SlackApiException {
+        return usersConversations(req.build(UsersConversationsRequest.builder()));
+    }
+
+    @Override
     public UsersDeletePhotoResponse usersDeletePhoto(UsersDeletePhotoRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERS_DELETE_PHOTO, req.getToken(), UsersDeletePhotoResponse.class);
+    }
+
+    @Override
+    public UsersDeletePhotoResponse usersDeletePhoto(RequestBuilder<UsersDeletePhotoRequest, UsersDeletePhotoRequest.UsersDeletePhotoRequestBuilder> req) throws IOException, SlackApiException {
+        return usersDeletePhoto(req.build(UsersDeletePhotoRequest.builder()));
     }
 
     @Override
@@ -847,8 +1483,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public UsersGetPresenceResponse usersGetPresence(RequestBuilder<UsersGetPresenceRequest, UsersGetPresenceRequest.UsersGetPresenceRequestBuilder> req) throws IOException, SlackApiException {
+        return usersGetPresence(req.build(UsersGetPresenceRequest.builder()));
+    }
+
+    @Override
     public UsersIdentityResponse usersIdentity(UsersIdentityRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERS_IDENTITY, req.getToken(), UsersIdentityResponse.class);
+    }
+
+    @Override
+    public UsersIdentityResponse usersIdentity(RequestBuilder<UsersIdentityRequest, UsersIdentityRequest.UsersIdentityRequestBuilder> req) throws IOException, SlackApiException {
+        return usersIdentity(req.build(UsersIdentityRequest.builder()));
     }
 
     @Override
@@ -857,8 +1503,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public UsersInfoResponse usersInfo(RequestBuilder<UsersInfoRequest, UsersInfoRequest.UsersInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return usersInfo(req.build(UsersInfoRequest.builder()));
+    }
+
+    @Override
     public UsersListResponse usersList(UsersListRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERS_LIST, req.getToken(), UsersListResponse.class);
+    }
+
+    @Override
+    public UsersListResponse usersList(RequestBuilder<UsersListRequest, UsersListRequest.UsersListRequestBuilder> req) throws IOException, SlackApiException {
+        return usersList(req.build(UsersListRequest.builder()));
     }
 
     @Override
@@ -867,8 +1523,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public UsersLookupByEmailResponse usersLookupByEmail(RequestBuilder<UsersLookupByEmailRequest, UsersLookupByEmailRequest.UsersLookupByEmailRequestBuilder> req) throws IOException, SlackApiException {
+        return usersLookupByEmail(req.build(UsersLookupByEmailRequest.builder()));
+    }
+
+    @Override
     public UsersSetActiveResponse usersSetActive(UsersSetActiveRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERS_SET_ACTIVE, req.getToken(), UsersSetActiveResponse.class);
+    }
+
+    @Override
+    public UsersSetActiveResponse usersSetActive(RequestBuilder<UsersSetActiveRequest, UsersSetActiveRequest.UsersSetActiveRequestBuilder> req) throws IOException, SlackApiException {
+        return usersSetActive(req.build(UsersSetActiveRequest.builder()));
     }
 
     @Override
@@ -877,8 +1543,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public UsersSetPhotoResponse usersSetPhoto(RequestBuilder<UsersSetPhotoRequest, UsersSetPhotoRequest.UsersSetPhotoRequestBuilder> req) throws IOException, SlackApiException {
+        return usersSetPhoto(req.build(UsersSetPhotoRequest.builder()));
+    }
+
+    @Override
     public UsersSetPresenceResponse usersSetPresence(UsersSetPresenceRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERS_SET_PRESENCE, req.getToken(), UsersSetPresenceResponse.class);
+    }
+
+    @Override
+    public UsersSetPresenceResponse usersSetPresence(RequestBuilder<UsersSetPresenceRequest, UsersSetPresenceRequest.UsersSetPresenceRequestBuilder> req) throws IOException, SlackApiException {
+        return usersSetPresence(req.build(UsersSetPresenceRequest.builder()));
     }
 
     @Override
@@ -887,8 +1563,18 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public UsersProfileGetResponse usersProfileGet(RequestBuilder<UsersProfileGetRequest, UsersProfileGetRequest.UsersProfileGetRequestBuilder> req) throws IOException, SlackApiException {
+        return usersProfileGet(req.build(UsersProfileGetRequest.builder()));
+    }
+
+    @Override
     public UsersProfileSetResponse usersProfileSet(UsersProfileSetRequest req) throws IOException, SlackApiException {
         return doPostFormWithToken(toForm(req), Methods.USERS_PROFILE_SET, req.getToken(), UsersProfileSetResponse.class);
+    }
+
+    @Override
+    public UsersProfileSetResponse usersProfileSet(RequestBuilder<UsersProfileSetRequest, UsersProfileSetRequest.UsersProfileSetRequestBuilder> req) throws IOException, SlackApiException {
+        return usersProfileSet(req.build(UsersProfileSetRequest.builder()));
     }
 
     protected <T> T doPostForm(

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClient.java
@@ -1,5 +1,6 @@
 package com.github.seratch.jslack.api.scim;
 
+import com.github.seratch.jslack.api.methods.RequestBuilder;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.scim.request.UsersDeleteRequest;
 import com.github.seratch.jslack.api.scim.response.UsersDeleteResponse;
@@ -14,4 +15,7 @@ public interface SCIMClient {
     void setEndpointUrlPrefix(String endpointUrlPrefix);
 
     UsersDeleteResponse delete(UsersDeleteRequest req) throws IOException, SlackApiException;
+
+    UsersDeleteResponse delete(RequestBuilder<UsersDeleteRequest, UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SlackApiException;
+
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClientImpl.java
@@ -1,5 +1,6 @@
 package com.github.seratch.jslack.api.scim;
 
+import com.github.seratch.jslack.api.methods.RequestBuilder;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.scim.request.UsersDeleteRequest;
 import com.github.seratch.jslack.api.scim.response.UsersDeleteResponse;
@@ -28,6 +29,11 @@ public class SCIMClientImpl implements SCIMClient {
     public UsersDeleteResponse delete(UsersDeleteRequest req) throws IOException, SlackApiException {
         Request.Builder request = new Request.Builder().url(endpointUrlPrefix + "/" + req.getId()).addHeader("Authorization", "Bearer " + req.getToken());
         return doDeleteRequest(request, UsersDeleteResponse.class);
+    }
+
+    @Override
+    public UsersDeleteResponse delete(RequestBuilder<UsersDeleteRequest, UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SlackApiException {
+        return delete(req.build(UsersDeleteRequest.builder()));
     }
 
     private <T> T doDeleteRequest(Request.Builder requestBuilder, Class<T> clazz) throws IOException, SlackApiException {

--- a/jslack-api-client/src/test/java/test_with_remote_apis/ExamplesTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/ExamplesTest.java
@@ -2,7 +2,6 @@ package test_with_remote_apis;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.channels.ChannelsListRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatDeleteRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
 import com.github.seratch.jslack.api.methods.response.channels.ChannelsListResponse;
@@ -30,10 +29,10 @@ public class ExamplesTest {
     public void postAMessageToRandomChannel() throws IOException, SlackApiException, InterruptedException {
 
         // find all channels in the team
-        ChannelsListResponse channelsResponse = slack.methods().channelsList(ChannelsListRequest.builder().token(token).build());
+        ChannelsListResponse channelsResponse = slack.methods().channelsList(r -> r.token(token).build());
         assertThat(channelsResponse.isOk(), is(true));
         // find #random
-        List<Channel> channels_ = slack.methods().channelsList(ChannelsListRequest.builder().token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
         Channel random = null;
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {

--- a/jslack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
@@ -6,7 +6,6 @@ import com.github.seratch.jslack.api.model.Field;
 import com.github.seratch.jslack.api.model.block.ActionsBlock;
 import com.github.seratch.jslack.api.model.block.LayoutBlock;
 import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
-import com.github.seratch.jslack.api.model.block.element.BlockElement;
 import com.github.seratch.jslack.api.model.block.element.ButtonElement;
 import com.github.seratch.jslack.api.webhook.Payload;
 import com.github.seratch.jslack.api.webhook.WebhookResponse;

--- a/jslack-api-client/src/test/java/test_with_remote_apis/UnnecessaryChannelsCleanerTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/UnnecessaryChannelsCleanerTest.java
@@ -1,10 +1,6 @@
 package test_with_remote_apis;
 
 import com.github.seratch.jslack.Slack;
-import com.github.seratch.jslack.api.methods.request.channels.ChannelsArchiveRequest;
-import com.github.seratch.jslack.api.methods.request.channels.ChannelsListRequest;
-import com.github.seratch.jslack.api.methods.request.conversations.ConversationsArchiveRequest;
-import com.github.seratch.jslack.api.methods.request.conversations.ConversationsListRequest;
 import com.github.seratch.jslack.api.methods.response.channels.ChannelsArchiveResponse;
 import com.github.seratch.jslack.api.methods.response.conversations.ConversationsArchiveResponse;
 import com.github.seratch.jslack.api.model.Channel;
@@ -31,7 +27,7 @@ public class UnnecessaryChannelsCleanerTest {
     @Test
     public void deleteUnnecessaryPublicChannels() throws Exception {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        for (Channel channel : slack.methods().channelsList(ChannelsListRequest.builder()
+        for (Channel channel : slack.methods().channelsList(r -> r
                 .token(token)
                 .excludeArchived(true)
                 .limit(1000)
@@ -40,7 +36,7 @@ public class UnnecessaryChannelsCleanerTest {
             log.info(channel.toString());
 
             if (channel.getName().startsWith("test") && !channel.isGeneral()) {
-                ChannelsArchiveResponse resp = slack.methods().channelsArchive(ChannelsArchiveRequest.builder()
+                ChannelsArchiveResponse resp = slack.methods().channelsArchive(r -> r
                         .token(token).channel(channel.getId()).build());
                 assertThat(resp.getError(), is(nullValue()));
             }
@@ -51,7 +47,7 @@ public class UnnecessaryChannelsCleanerTest {
     @Test
     public void deleteUnnecessaryPrivateChannels() throws Exception {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        for (Conversation channel : slack.methods().conversationsList(ConversationsListRequest.builder()
+        for (Conversation channel : slack.methods().conversationsList(r -> r
                 .token(token)
                 .excludeArchived(true)
                 .limit(1000)
@@ -62,7 +58,7 @@ public class UnnecessaryChannelsCleanerTest {
 
             if ((channel.getName().startsWith("test") || channel.getName().startsWith("secret-"))
                     && !channel.isGeneral()) {
-                ConversationsArchiveResponse resp = slack.methods().conversationsArchive(ConversationsArchiveRequest.builder()
+                ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
                         .token(token)
                         .channel(channel.getId())
                         .build());

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/BlockKit_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/BlockKit_Test.java
@@ -3,7 +3,6 @@ package test_with_remote_apis.web_api;
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.request.channels.ChannelsInfoRequest;
-import com.github.seratch.jslack.api.methods.request.channels.ChannelsListRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatPostEphemeralRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatUpdateRequest;
@@ -47,7 +46,7 @@ public class BlockKit_Test {
         // ephemeral message creation
         {
             String channelId = null;
-            ChannelsListResponse channelsListResponse = slack.methods().channelsList(ChannelsListRequest.builder()
+            ChannelsListResponse channelsListResponse = slack.methods().channelsList(req -> req
                     .token(token)
                     .excludeArchived(true)
                     .limit(100).build());

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/api_test_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/api_test_Test.java
@@ -29,7 +29,7 @@ public class api_test_Test {
 
     @Test
     public void ok() throws IOException, SlackApiException {
-        ApiTestResponse response = slack.methods().apiTest(ApiTestRequest.builder().foo("fine").build());
+        ApiTestResponse response = slack.methods().apiTest(req -> req.foo("fine").build());
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getArgs().getFoo(), is("fine"));
@@ -37,7 +37,7 @@ public class api_test_Test {
 
     @Test
     public void error() throws IOException, SlackApiException {
-        ApiTestResponse response = slack.methods().apiTest(ApiTestRequest.builder().error("error").build());
+        ApiTestResponse response = slack.methods().apiTest(req -> req.error("error").build());
         assertThat(response.isOk(), is(false));
         assertThat(response.getError(), is("error"));
         assertThat(response.getArgs().getError(), is("error"));
@@ -51,7 +51,7 @@ public class api_test_Test {
         SlackHttpClient slackHttpClient = new SlackHttpClient(okHttpClient);
         Slack slack = Slack.getInstance(SlackTestConfig.get(), slackHttpClient);
 
-        ApiTestResponse response = slack.methods().apiTest(ApiTestRequest.builder().foo("proxy?").build());
+        ApiTestResponse response = slack.methods().apiTest(req -> req.foo("proxy?").build());
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getArgs().getFoo(), is("proxy?"));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/apps_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/apps_Test.java
@@ -2,9 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.apps.AppsUninstallRequest;
-import com.github.seratch.jslack.api.methods.request.apps.permissions.AppsPermissionsInfoRequest;
-import com.github.seratch.jslack.api.methods.request.apps.permissions.AppsPermissionsRequestRequest;
 import com.github.seratch.jslack.api.methods.request.apps.permissions.resources.AppsPermissionsResourcesListRequest;
 import com.github.seratch.jslack.api.methods.request.apps.permissions.scopes.AppsPermissionsScopesListRequest;
 import com.github.seratch.jslack.api.methods.request.apps.permissions.users.AppsPermissionsUsersListRequest;
@@ -35,7 +32,7 @@ public class apps_Test {
     @Test
     public void appsPermissionsRequest() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AppsPermissionsRequestResponse response = slack.methods().appsPermissionsRequest(AppsPermissionsRequestRequest.builder()
+        AppsPermissionsRequestResponse response = slack.methods().appsPermissionsRequest(req -> req
                 .token(token)
                 .triggerId("dummy")
                 .build());
@@ -46,7 +43,7 @@ public class apps_Test {
     @Test
     public void appsPermissionsInfo() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AppsPermissionsInfoResponse response = slack.methods().appsPermissionsInfo(AppsPermissionsInfoRequest.builder()
+        AppsPermissionsInfoResponse response = slack.methods().appsPermissionsInfo(req -> req
                 .token(token)
                 .build());
         assertThat(response.getError(), is("not_allowed_token_type"));
@@ -56,7 +53,7 @@ public class apps_Test {
     @Test
     public void appsUninstall() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AppsUninstallResponse response = slack.methods().appsUninstall(AppsUninstallRequest.builder()
+        AppsUninstallResponse response = slack.methods().appsUninstall(req -> req
                 .token(token)
                 .build());
         assertThat(response.getError(), is("not_allowed_token_type"));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/auth_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/auth_Test.java
@@ -2,8 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.auth.AuthRevokeRequest;
-import com.github.seratch.jslack.api.methods.request.auth.AuthTestRequest;
 import com.github.seratch.jslack.api.methods.response.auth.AuthRevokeResponse;
 import com.github.seratch.jslack.api.methods.response.auth.AuthTestResponse;
 import config.Constants;
@@ -25,7 +23,7 @@ public class auth_Test {
 
     @Test
     public void authRevoke() throws IOException, SlackApiException {
-        AuthRevokeResponse response = slack.methods().authRevoke(AuthRevokeRequest.builder().token("dummy").test(true).build());
+        AuthRevokeResponse response = slack.methods().authRevoke(req -> req.token("dummy").test(true).build());
         assertThat(response.isOk(), is(false));
         assertThat(response.getError(), is("invalid_auth"));
         assertThat(response.isRevoked(), is(false));
@@ -34,7 +32,7 @@ public class auth_Test {
     @Test
     public void authTest() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AuthTestResponse response = slack.methods().authTest(AuthTestRequest.builder().token(token).build());
+        AuthTestResponse response = slack.methods().authTest(req -> req.token(token).build());
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/bots_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/bots_Test.java
@@ -2,8 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.bots.BotsInfoRequest;
-import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
 import com.github.seratch.jslack.api.methods.response.bots.BotsInfoResponse;
 import com.github.seratch.jslack.api.model.User;
 import config.Constants;
@@ -26,7 +24,7 @@ public class bots_Test {
 
     @Test
     public void botsInfoError() throws IOException, SlackApiException {
-        BotsInfoResponse response = slack.methods().botsInfo(BotsInfoRequest.builder().build());
+        BotsInfoResponse response = slack.methods().botsInfo(req -> req.build());
         assertThat(response.getError(), is(notNullValue()));
         assertThat(response.isOk(), is(false));
     }
@@ -35,7 +33,7 @@ public class bots_Test {
     public void botsInfo() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
 
-        List<User> users = slack.methods().usersList(UsersListRequest.builder().token(token).build()).getMembers();
+        List<User> users = slack.methods().usersList(req -> req.token(token).build()).getMembers();
         User user = null;
         for (User u : users) {
             if (u.isBot() && !"USLACKBOT".equals(u.getId())) {
@@ -45,7 +43,7 @@ public class bots_Test {
         }
         String bot = user.getProfile().getBotId();
 
-        BotsInfoResponse response = slack.methods().botsInfo(BotsInfoRequest.builder().token(token).bot(bot).build());
+        BotsInfoResponse response = slack.methods().botsInfo(req -> req.token(token).bot(bot).build());
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getBot(), is(notNullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/chat_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/chat_Test.java
@@ -43,21 +43,22 @@ public class chat_Test {
     @Test
     public void channels_threading() throws IOException, SlackApiException {
 
-        String channelId = null;
-        ChannelsListResponse channelsListResponse = slack.methods().channelsList(ChannelsListRequest.builder()
+        String channelId_ = null;
+        ChannelsListResponse channelsListResponse = slack.methods().channelsList(r -> r
                 .token(token)
                 .excludeArchived(true)
                 .limit(100).build());
         assertThat(channelsListResponse.getError(), is(nullValue()));
         for (Channel channel : channelsListResponse.getChannels()) {
             if (channel.getName().equals("random")) {
-                channelId = channel.getId();
+                channelId_ = channel.getId();
                 break;
             }
         }
-        assertThat(channelId, is(notNullValue()));
+        assertThat(channelId_, is(notNullValue()));
+        final String channelId = channelId_;
 
-        ChatPostMessageResponse firstMessageCreation = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+        ChatPostMessageResponse firstMessageCreation = slack.methods().chatPostMessage(req -> req
                 .channel(channelId)
                 .token(token)
                 .text("[thread] This is a test message posted by unit tests for jslack library")
@@ -66,7 +67,7 @@ public class chat_Test {
         assertThat(firstMessageCreation.getError(), is(nullValue()));
         assertThat(firstMessageCreation.isOk(), is(true));
 
-        ChatPostMessageResponse reply1 = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+        ChatPostMessageResponse reply1 = slack.methods().chatPostMessage(req -> req
                 .channel(channelId)
                 .token(token)
                 .asUser(false)
@@ -78,7 +79,7 @@ public class chat_Test {
         assertThat(reply1.getError(), is(nullValue()));
         assertThat(reply1.isOk(), is(true));
 
-        ChatGetPermalinkResponse permalink = slack.methods().chatGetPermalink(ChatGetPermalinkRequest.builder()
+        ChatGetPermalinkResponse permalink = slack.methods().chatGetPermalink(req -> req
                 .token(token)
                 .channel(channelId)
                 .messageTs(reply1.getTs())
@@ -87,7 +88,7 @@ public class chat_Test {
         assertThat(permalink.isOk(), is(true));
         assertThat(permalink.getPermalink(), is(notNullValue()));
 
-        ChatPostMessageResponse reply2 = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+        ChatPostMessageResponse reply2 = slack.methods().chatPostMessage(req -> req
                 .channel(channelId)
                 .token(token)
                 .asUser(true)
@@ -104,7 +105,7 @@ public class chat_Test {
 
         // via channels.history
         {
-            ChannelsHistoryResponse history = slack.methods().channelsHistory(ChannelsHistoryRequest.builder()
+            ChannelsHistoryResponse history = slack.methods().channelsHistory(req -> req
                     .token(token)
                     .channel(channelId)
                     .count(20)
@@ -133,7 +134,7 @@ public class chat_Test {
 
         // via conversations.history
         {
-            ConversationsHistoryResponse history = slack.methods().conversationsHistory(ConversationsHistoryRequest.builder()
+            ConversationsHistoryResponse history = slack.methods().conversationsHistory(req -> req
                     .token(token)
                     .channel(channelId)
                     .limit(20)
@@ -164,7 +165,7 @@ public class chat_Test {
     @Test
     public void chat_getPermalink() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        ChannelsListResponse channels = slack.methods().channelsList(ChannelsListRequest.builder()
+        ChannelsListResponse channels = slack.methods().channelsList(req -> req
                 .token(token)
                 .excludeArchived(true)
                 .build());
@@ -173,7 +174,7 @@ public class chat_Test {
 
         String channelId = channels.getChannels().get(0).getId();
 
-        ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+        ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(req -> req
                 .channel(channelId)
                 .token(token)
                 .text("Hi, this is a test message from jSlack library's unit tests")
@@ -182,7 +183,7 @@ public class chat_Test {
         assertThat(postResponse.getError(), is(nullValue()));
         assertThat(postResponse.isOk(), is(true));
 
-        ChatGetPermalinkResponse permalink = slack.methods().chatGetPermalink(ChatGetPermalinkRequest.builder()
+        ChatGetPermalinkResponse permalink = slack.methods().chatGetPermalink(req -> req
                 .token(token)
                 .channel(channelId)
                 .messageTs(postResponse.getTs())

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/conversations_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/conversations_Test.java
@@ -2,10 +2,7 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.channels.ChannelsRepliesRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
-import com.github.seratch.jslack.api.methods.request.conversations.*;
-import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
+import com.github.seratch.jslack.api.methods.request.conversations.ConversationsListRequest;
 import com.github.seratch.jslack.api.methods.response.channels.ChannelsRepliesResponse;
 import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
 import com.github.seratch.jslack.api.methods.response.conversations.*;
@@ -13,7 +10,6 @@ import com.github.seratch.jslack.api.methods.response.users.UsersListResponse;
 import com.github.seratch.jslack.api.model.*;
 import com.github.seratch.jslack.api.model.block.ContextBlock;
 import com.github.seratch.jslack.api.model.block.ContextBlockElement;
-import com.github.seratch.jslack.api.model.block.LayoutBlock;
 import com.github.seratch.jslack.api.model.block.composition.MarkdownTextObject;
 import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
 import config.Constants;
@@ -55,12 +51,11 @@ public class conversations_Test {
             assertThat(listResponse.getResponseMetadata(), is(notNullValue()));
         }
 
-        ConversationsCreateResponse createPublicResponse = slack.methods().conversationsCreate(
-                ConversationsCreateRequest.builder()
-                        .token(token)
-                        .name("test" + System.currentTimeMillis())
-                        .isPrivate(false)
-                        .build());
+        ConversationsCreateResponse createPublicResponse = slack.methods().conversationsCreate(r -> r
+                .token(token)
+                .name("test" + System.currentTimeMillis())
+                .isPrivate(false)
+                .build());
         assertThat(createPublicResponse.getError(), is(nullValue()));
         assertThat(createPublicResponse.isOk(), is(true));
         assertThat(createPublicResponse.getChannel(), is(notNullValue()));
@@ -68,39 +63,38 @@ public class conversations_Test {
 
         Conversation channel = createPublicResponse.getChannel();
 
-        ConversationsCreateResponse createPrivateResponse = slack.methods().conversationsCreate(
-                ConversationsCreateRequest.builder()
-                        .token(token)
-                        .name("test" + System.currentTimeMillis())
-                        .isPrivate(true)
-                        .build());
+        ConversationsCreateResponse createPrivateResponse = slack.methods().conversationsCreate(r -> r
+                .token(token)
+                .name("test" + System.currentTimeMillis())
+                .isPrivate(true)
+                .build());
         assertThat(createPrivateResponse.getError(), is(nullValue()));
         assertThat(createPrivateResponse.isOk(), is(true));
         assertThat(createPrivateResponse.getChannel(), is(notNullValue()));
         assertThat(createPrivateResponse.getChannel().isPrivate(), is(true));
 
         {
-            ConversationsArchiveResponse resp = slack.methods().conversationsArchive(ConversationsArchiveRequest.builder()
+            ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
                     .token(token)
                     .channel(createPrivateResponse.getChannel().getId())
                     .build());
             assertThat(resp.getError(), is(nullValue()));
         }
         {
-            ConversationsUnarchiveResponse resp = slack.methods().conversationsUnarchive(ConversationsUnarchiveRequest.builder()
+            ConversationsUnarchiveResponse resp = slack.methods().conversationsUnarchive(r -> r
                     //.token(token)
                     .channel(createPrivateResponse.getChannel().getId())
                     .build());
             assertThat(resp.getError(), is(notNullValue()));
 
-            resp = slack.methods().conversationsUnarchive(ConversationsUnarchiveRequest.builder()
+            resp = slack.methods().conversationsUnarchive(r -> r
                     .token(token)
                     .channel(createPrivateResponse.getChannel().getId())
                     .build());
             assertThat(resp.getError(), is(nullValue()));
         }
         {
-            ConversationsArchiveResponse resp = slack.methods().conversationsArchive(ConversationsArchiveRequest.builder()
+            ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
                     .token(token)
                     .channel(createPrivateResponse.getChannel().getId())
                     .build());
@@ -108,57 +102,52 @@ public class conversations_Test {
         }
 
         {
-            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(
-                    ChatPostMessageRequest.builder()
-                            .token(token)
-                            .channel(createPublicResponse.getChannel().getId())
-                            .text("This is a test message posted by unit tests for jslack library")
-                            .replyBroadcast(false)
-                            .build());
+            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
+                    .token(token)
+                    .channel(createPublicResponse.getChannel().getId())
+                    .text("This is a test message posted by unit tests for jslack library")
+                    .replyBroadcast(false)
+                    .build());
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
 
-            ChatPostMessageResponse postThread1Response = slack.methods().chatPostMessage(
-                    ChatPostMessageRequest.builder()
-                            .token(token)
-                            .channel(createPublicResponse.getChannel().getId())
-                            .threadTs(postMessageResponse.getTs())
-                            .text("[thread 1] This is a test message posted by unit tests for jslack library")
-                            .replyBroadcast(false)
-                            .build());
+            ChatPostMessageResponse postThread1Response = slack.methods().chatPostMessage(r -> r
+                    .token(token)
+                    .channel(createPublicResponse.getChannel().getId())
+                    .threadTs(postMessageResponse.getTs())
+                    .text("[thread 1] This is a test message posted by unit tests for jslack library")
+                    .replyBroadcast(false)
+                    .build());
             assertThat(postThread1Response.getError(), is(nullValue()));
             assertThat(postThread1Response.isOk(), is(true));
 
-            ChatPostMessageResponse postThread2Response = slack.methods().chatPostMessage(
-                    ChatPostMessageRequest.builder()
-                            .token(token)
-                            .channel(createPublicResponse.getChannel().getId())
-                            .threadTs(postMessageResponse.getTs())
-                            .text("[thread 2] This is a test message posted by unit tests for jslack library")
-                            .replyBroadcast(false)
-                            .build());
+            ChatPostMessageResponse postThread2Response = slack.methods().chatPostMessage(r -> r
+                    .token(token)
+                    .channel(createPublicResponse.getChannel().getId())
+                    .threadTs(postMessageResponse.getTs())
+                    .text("[thread 2] This is a test message posted by unit tests for jslack library")
+                    .replyBroadcast(false)
+                    .build());
             assertThat(postThread2Response.getError(), is(nullValue()));
             assertThat(postThread2Response.isOk(), is(true));
 
-            ConversationsRepliesResponse repliesResponse = slack.methods().conversationsReplies(
-                    ConversationsRepliesRequest.builder()
-                            .token(token)
-                            .channel(createPublicResponse.getChannel().getId())
-                            .ts(postMessageResponse.getTs())
-                            .limit(1)
-                            .build());
+            ConversationsRepliesResponse repliesResponse = slack.methods().conversationsReplies(r -> r
+                    .token(token)
+                    .channel(createPublicResponse.getChannel().getId())
+                    .ts(postMessageResponse.getTs())
+                    .limit(1)
+                    .build());
             assertThat(repliesResponse.getError(), is(nullValue()));
             assertThat(repliesResponse.isOk(), is(true));
             assertThat(repliesResponse.getResponseMetadata(), is(notNullValue()));
         }
 
         {
-            ConversationsInfoResponse infoResponse = slack.methods().conversationsInfo(
-                    ConversationsInfoRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .includeLocale(true)
-                            .build());
+            ConversationsInfoResponse infoResponse = slack.methods().conversationsInfo(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .includeLocale(true)
+                    .build());
             assertThat(infoResponse.isOk(), is(true));
             Conversation fetchedConversation = infoResponse.getChannel();
             assertThat(fetchedConversation.isMember(), is(true));
@@ -171,36 +160,33 @@ public class conversations_Test {
         }
 
         {
-            ConversationsSetPurposeResponse setPurposeResponse = slack.methods().conversationsSetPurpose(
-                    ConversationsSetPurposeRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .purpose("purpose")
-                            .build());
+            ConversationsSetPurposeResponse setPurposeResponse = slack.methods().conversationsSetPurpose(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .purpose("purpose")
+                    .build());
             assertThat(setPurposeResponse.getError(), is(nullValue()));
             assertThat(setPurposeResponse.isOk(), is(true));
             assertThat(setPurposeResponse.getChannel().getPurpose().getValue(), is("purpose"));
         }
 
         {
-            ConversationsSetTopicResponse setTopicResponse = slack.methods().conversationsSetTopic(
-                    ConversationsSetTopicRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .topic("topic")
-                            .build());
+            ConversationsSetTopicResponse setTopicResponse = slack.methods().conversationsSetTopic(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .topic("topic")
+                    .build());
             assertThat(setTopicResponse.getError(), is(nullValue()));
             assertThat(setTopicResponse.isOk(), is(true));
             assertThat(setTopicResponse.getChannel().getTopic().getValue(), is("topic"));
         }
 
         {
-            ConversationsHistoryResponse historyResponse = slack.methods().conversationsHistory(
-                    ConversationsHistoryRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .limit(2)
-                            .build());
+            ConversationsHistoryResponse historyResponse = slack.methods().conversationsHistory(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .limit(2)
+                    .build());
             assertThat(historyResponse.getError(), is(nullValue()));
             assertThat(historyResponse.isOk(), is(true));
             // The outcome depends on data
@@ -209,94 +195,86 @@ public class conversations_Test {
         }
 
         {
-            ConversationsMembersResponse membersResponse = slack.methods().conversationsMembers(
-                    ConversationsMembersRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .limit(2)
-                            .build());
+            ConversationsMembersResponse membersResponse = slack.methods().conversationsMembers(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .limit(2)
+                    .build());
             assertThat(membersResponse.isOk(), is(true));
             assertThat(membersResponse.getMembers(), is(notNullValue()));
             assertThat(membersResponse.getMembers().isEmpty(), is(false));
             assertThat(membersResponse.getResponseMetadata(), is(notNullValue()));
 
-            UsersListResponse usersListResponse = slack.methods()
-                    .usersList(UsersListRequest.builder()
-                            .token(token)
-                            .build());
-            String invitee = null;
+            UsersListResponse usersListResponse = slack.methods().usersList(r -> r
+                    .token(token)
+                    .build());
+            String invitee_ = null;
             for (User u : usersListResponse.getMembers()) {
                 if (!"USLACKBOT".equals(u.getId()) && !membersResponse.getMembers().contains(u.getId())) {
-                    invitee = u.getId();
+                    invitee_ = u.getId();
                 }
             }
+            String invitee = invitee_;
 
-            ConversationsInviteResponse inviteResponse = slack.methods().conversationsInvite(
-                    ConversationsInviteRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .users(Arrays.asList(invitee))
-                            .build());
+            ConversationsInviteResponse inviteResponse = slack.methods().conversationsInvite(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .users(Arrays.asList(invitee))
+                    .build());
             assertThat(inviteResponse.getError(), is(nullValue()));
             assertThat(inviteResponse.isOk(), is(true));
 
-            ConversationsKickResponse kickResponse = slack.methods().conversationsKick(
-                    ConversationsKickRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .user(invitee)
-                            .build());
+            ConversationsKickResponse kickResponse = slack.methods().conversationsKick(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .user(invitee)
+                    .build());
             assertThat(kickResponse.getError(), is(nullValue()));
             assertThat(kickResponse.isOk(), is(true));
         }
 
         {
-            ConversationsLeaveResponse leaveResponse = slack.methods().conversationsLeave(
-                    ConversationsLeaveRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .build());
+            ConversationsLeaveResponse leaveResponse = slack.methods().conversationsLeave(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .build());
             assertThat(leaveResponse.getError(), is(nullValue()));
             assertThat(leaveResponse.isOk(), is(true));
         }
 
         {
-            ConversationsJoinResponse joinResponse = slack.methods().conversationsJoin(
-                    ConversationsJoinRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .build());
+            ConversationsJoinResponse joinResponse = slack.methods().conversationsJoin(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .build());
             assertThat(joinResponse.getError(), is(nullValue()));
             assertThat(joinResponse.isOk(), is(true));
         }
 
         {
-            ConversationsRenameResponse renameResponse = slack.methods().conversationsRename(
-                    ConversationsRenameRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .name(channel.getName() + "-1")
-                            .build());
+            ConversationsRenameResponse renameResponse = slack.methods().conversationsRename(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .name(channel.getName() + "-1")
+                    .build());
             assertThat(renameResponse.getError(), is(nullValue()));
             assertThat(renameResponse.isOk(), is(true));
         }
 
         {
-            ConversationsArchiveResponse archiveResponse = slack.methods().conversationsArchive(
-                    ConversationsArchiveRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .build());
+            ConversationsArchiveResponse archiveResponse = slack.methods().conversationsArchive(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .build());
             assertThat(archiveResponse.getError(), is(nullValue()));
             assertThat(archiveResponse.isOk(), is(true));
         }
 
         {
-            ConversationsInfoResponse infoResponse = slack.methods().conversationsInfo(
-                    ConversationsInfoRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .build());
+            ConversationsInfoResponse infoResponse = slack.methods().conversationsInfo(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .build());
             assertThat(infoResponse.getError(), is(nullValue()));
             assertThat(infoResponse.isOk(), is(true));
             Conversation fetchedChannel = infoResponse.getChannel();
@@ -309,32 +287,29 @@ public class conversations_Test {
     @Test
     public void imConversation() throws IOException, SlackApiException {
 
-        UsersListResponse usersListResponse = slack.methods().usersList(
-                UsersListRequest.builder().token(token).build());
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(token).build());
         List<User> users = usersListResponse.getMembers();
         String userId = users.get(0).getId();
 
-        ConversationsOpenResponse openResponse = slack.methods().conversationsOpen(
-                ConversationsOpenRequest.builder()
-                        .token(token)
-                        .users(Arrays.asList(userId))
-                        .returnIm(true)
-                        .build());
+        ConversationsOpenResponse openResponse = slack.methods().conversationsOpen(r -> r
+                .token(token)
+                .users(Arrays.asList(userId))
+                .returnIm(true)
+                .build());
         assertThat(openResponse.getError(), is(nullValue()));
         assertThat(openResponse.isOk(), is(true));
 
-        ConversationsMembersResponse membersResponse = slack.methods().conversationsMembers(
-                ConversationsMembersRequest.builder()
-                        .token(token)
-                        .channel(openResponse.getChannel().getId())
-                        .build());
+        ConversationsMembersResponse membersResponse = slack.methods().conversationsMembers(r -> r
+                .token(token)
+                .channel(openResponse.getChannel().getId())
+                .build());
         assertThat(membersResponse.getError(), is(nullValue()));
         assertThat(membersResponse.isOk(), is(true));
         assertThat(membersResponse.getMembers(), is(notNullValue()));
         assertThat(membersResponse.getMembers().isEmpty(), is(false));
 
-        ConversationsCloseResponse closeResponse = slack.methods().conversationsClose(
-                ConversationsCloseRequest.builder().token(token).channel(openResponse.getChannel().getId()).build());
+        ConversationsCloseResponse closeResponse = slack.methods().conversationsClose(r ->
+                r.token(token).channel(openResponse.getChannel().getId()).build());
         assertThat(closeResponse.isOk(), is(true));
     }
 
@@ -358,46 +333,43 @@ public class conversations_Test {
 
         // text
         {
-            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(
-                    ChatPostMessageRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .text(longText)
-                            .replyBroadcast(false)
-                            .build());
+            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .text(longText)
+                    .replyBroadcast(false)
+                    .build());
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
         }
 
         // attachments
         {
-            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(
-                    ChatPostMessageRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .attachments(Arrays.asList(Attachment.builder().text(longText).build()))
-                            .replyBroadcast(false)
-                            .build());
+            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .attachments(Arrays.asList(Attachment.builder().text(longText).build()))
+                    .replyBroadcast(false)
+                    .build());
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
         }
 
         // blocks
         {
-            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(
-                    ChatPostMessageRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .blocks(Arrays.asList(
-                                            ContextBlock.builder().elements(Arrays.asList(
-                                                    (ContextBlockElement) PlainTextObject.builder().text(longText).build()
-                                            )).build(),
-                                    ContextBlock.builder().elements(Arrays.asList(
-                                            (ContextBlockElement) MarkdownTextObject.builder().text(longText).build()
-                                    )).build()
-                            ))
-                            .replyBroadcast(false)
-                            .build());
+            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .blocks(Arrays.asList(
+                            ContextBlock.builder().elements(Arrays.asList(
+                                    (ContextBlockElement) PlainTextObject.builder().text(longText).build()
+                            )).build(),
+                            ContextBlock.builder().elements(Arrays.asList(
+                                    (ContextBlockElement) MarkdownTextObject.builder().text(longText).build()
+                            )).build()
+                    ))
+                    .replyBroadcast(false)
+                    .build());
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
         }
@@ -415,13 +387,12 @@ public class conversations_Test {
             String threadTs;
             // first message
             {
-                ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(
-                        ChatPostMessageRequest.builder()
-                                .token(token)
-                                .channel(channel.getId())
-                                .text(longText)
-                                .replyBroadcast(false)
-                                .build());
+                ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
+                        .token(token)
+                        .channel(channel.getId())
+                        .text(longText)
+                        .replyBroadcast(false)
+                        .build());
                 assertThat(postMessageResponse.getError(), is(nullValue()));
                 assertThat(postMessageResponse.isOk(), is(true));
                 threadTs = postMessageResponse.getMessage().getTs();
@@ -429,14 +400,13 @@ public class conversations_Test {
 
             {
                 for (int idx = 0; idx < 5; idx++) {
-                    ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(
-                            ChatPostMessageRequest.builder()
-                                    .token(token)
-                                    .channel(channel.getId())
-                                    .threadTs(threadTs)
-                                    .text("Say something at " + new Date())
-                                    .replyBroadcast(false)
-                                    .build());
+                    ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
+                            .token(token)
+                            .channel(channel.getId())
+                            .threadTs(threadTs)
+                            .text("Say something at " + new Date())
+                            .replyBroadcast(false)
+                            .build());
                     assertThat(postMessageResponse.getError(), is(nullValue()));
                     assertThat(postMessageResponse.isOk(), is(true));
                 }
@@ -444,7 +414,7 @@ public class conversations_Test {
 
             // channels.replies
             {
-                ChannelsRepliesResponse response = slack.methods().channelsReplies(ChannelsRepliesRequest.builder()
+                ChannelsRepliesResponse response = slack.methods().channelsReplies(r -> r
                         .token(token)
                         .threadTs(threadTs)
                         .channel(channel.getId())
@@ -462,7 +432,7 @@ public class conversations_Test {
 
             // conversations.replies
             {
-                ConversationsRepliesResponse response = slack.methods().conversationsReplies(ConversationsRepliesRequest.builder()
+                ConversationsRepliesResponse response = slack.methods().conversationsReplies(r -> r
                         .token(token)
                         .ts(threadTs)
                         .channel(channel.getId())

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/dialogs_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/dialogs_Test.java
@@ -2,10 +2,8 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.dialog.DialogOpenRequest;
 import com.github.seratch.jslack.api.methods.response.dialog.DialogOpenResponse;
 import com.github.seratch.jslack.api.model.dialog.Dialog;
-import com.github.seratch.jslack.api.model.dialog.DialogElement;
 import com.github.seratch.jslack.api.model.dialog.DialogSubType;
 import com.github.seratch.jslack.api.model.dialog.DialogTextElement;
 import config.Constants;
@@ -53,7 +51,7 @@ public class dialogs_Test {
          * that same trigger_id in order to succeed. The dialog.open request must also be made within 3
          * seconds of the user action.  Therefore, only an 'invalid trigger' ID response can be tested.
          */
-        DialogOpenResponse dialogOpenResponse = slack.methods().dialogOpen(DialogOpenRequest.builder()
+        DialogOpenResponse dialogOpenResponse = slack.methods().dialogOpen(r -> r
                 .token(token)
                 .triggerId("FAKE_TRIGGER_ID")
                 .dialog(dialog)

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/dnd_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/dnd_Test.java
@@ -2,8 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.dnd.*;
-import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
 import com.github.seratch.jslack.api.methods.response.dnd.*;
 import com.github.seratch.jslack.api.model.User;
 import config.Constants;
@@ -28,10 +26,10 @@ public class dnd_Test {
 
     @Test
     public void dnd() throws IOException, SlackApiException {
-        List<User> members = slack.methods().usersList(UsersListRequest.builder().token(token).presence(true).build()).getMembers();
+        List<User> members = slack.methods().usersList(r -> r.token(token).presence(true).build()).getMembers();
         {
             String user = members.get(0).getId();
-            DndInfoResponse response = slack.methods().dndInfo(DndInfoRequest.builder().token(token).user(user).build());
+            DndInfoResponse response = slack.methods().dndInfo(r -> r.token(token).user(user).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getNextDndStartTs(), is(notNullValue()));
@@ -42,7 +40,7 @@ public class dnd_Test {
             for (User member : members) {
                 users.add(member.getId());
             }
-            DndTeamInfoResponse response = slack.methods().dndTeamInfo(DndTeamInfoRequest.builder().token(token).users(users).build());
+            DndTeamInfoResponse response = slack.methods().dndTeamInfo(r -> r.token(token).users(users).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getUsers(), is(notNullValue()));
@@ -52,14 +50,14 @@ public class dnd_Test {
     @Test
     public void dndEndDnd() throws Exception {
         {
-            DndEndDndResponse response = slack.methods().dndEndDnd(DndEndDndRequest.builder()
+            DndEndDndResponse response = slack.methods().dndEndDnd(r -> r
                     //.token(token)
                     .build());
             assertThat(response.getError(), is(notNullValue()));
             assertThat(response.isOk(), is(false));
         }
         {
-            DndEndDndResponse response = slack.methods().dndEndDnd(DndEndDndRequest.builder()
+            DndEndDndResponse response = slack.methods().dndEndDnd(r -> r
                     .token(token)
                     .build());
             assertThat(response.getError(), is(nullValue()));
@@ -70,14 +68,14 @@ public class dnd_Test {
     @Test
     public void dndEndSnooze() throws Exception {
         {
-            DndEndSnoozeResponse response = slack.methods().dndEndSnooze(DndEndSnoozeRequest.builder()
+            DndEndSnoozeResponse response = slack.methods().dndEndSnooze(r -> r
                     //.token(token)
                     .build());
             assertThat(response.getError(), is(notNullValue()));
             assertThat(response.isOk(), is(false));
         }
         {
-            DndEndSnoozeResponse response = slack.methods().dndEndSnooze(DndEndSnoozeRequest.builder()
+            DndEndSnoozeResponse response = slack.methods().dndEndSnooze(r -> r
                     .token(token)
                     .build());
             assertThat(response.getError(), is("snooze_not_active"));
@@ -85,7 +83,7 @@ public class dnd_Test {
         }
 
         {
-            DndSetSnoozeResponse response = slack.methods().dndSetSnooze(DndSetSnoozeRequest.builder()
+            DndSetSnoozeResponse response = slack.methods().dndSetSnooze(r -> r
                     //.token(token)
                     .numMinutes(10)
                     .build());
@@ -93,7 +91,7 @@ public class dnd_Test {
             assertThat(response.isOk(), is(false));
         }
         {
-            DndSetSnoozeResponse response = slack.methods().dndSetSnooze(DndSetSnoozeRequest.builder()
+            DndSetSnoozeResponse response = slack.methods().dndSetSnooze(r -> r
                     .token(token)
                     .numMinutes(10)
                     .build());
@@ -101,7 +99,7 @@ public class dnd_Test {
             assertThat(response.isOk(), is(true));
         }
         {
-            DndEndSnoozeResponse response = slack.methods().dndEndSnooze(DndEndSnoozeRequest.builder()
+            DndEndSnoozeResponse response = slack.methods().dndEndSnooze(r -> r
                     .token(token)
                     .build());
             assertThat(response.getError(), is(nullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/emoji_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/emoji_Test.java
@@ -2,7 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.emoji.EmojiListRequest;
 import com.github.seratch.jslack.api.methods.response.emoji.EmojiListResponse;
 import config.Constants;
 import config.SlackTestConfig;
@@ -25,7 +24,7 @@ public class emoji_Test {
     public void emojiList() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         {
-            EmojiListResponse response = slack.methods().emojiList(EmojiListRequest.builder().token(token).build());
+            EmojiListResponse response = slack.methods().emojiList(r -> r.token(token).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getEmoji(), is(notNullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/files_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/files_Test.java
@@ -2,10 +2,11 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.channels.ChannelsListRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatDeleteRequest;
-import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
-import com.github.seratch.jslack.api.methods.request.files.*;
+import com.github.seratch.jslack.api.methods.request.files.FilesDeleteRequest;
+import com.github.seratch.jslack.api.methods.request.files.FilesInfoRequest;
+import com.github.seratch.jslack.api.methods.request.files.FilesRevokePublicURLRequest;
+import com.github.seratch.jslack.api.methods.request.files.FilesSharedPublicURLRequest;
 import com.github.seratch.jslack.api.methods.request.files.comments.FilesCommentsAddRequest;
 import com.github.seratch.jslack.api.methods.request.files.comments.FilesCommentsDeleteRequest;
 import com.github.seratch.jslack.api.methods.request.files.comments.FilesCommentsEditRequest;
@@ -42,7 +43,7 @@ public class files_Test {
     @Test
     public void describe() throws IOException, SlackApiException {
         {
-            FilesListResponse response = slack.methods().filesList(FilesListRequest.builder().token(token).build());
+            FilesListResponse response = slack.methods().filesList(r -> r.token(token).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getFiles(), is(notNullValue()));
@@ -51,7 +52,7 @@ public class files_Test {
 
     @Test
     public void createTextFileAndComments() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(ChannelsListRequest.builder().token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -62,9 +63,9 @@ public class files_Test {
         String channelId = channels.get(0);
 
         File file = new File("src/test/resources/sample.txt");
-        com.github.seratch.jslack.api.model.File fileObj;
+        final com.github.seratch.jslack.api.model.File fileObj;
         {
-            FilesUploadResponse response = slack.methods().filesUpload(FilesUploadRequest.builder()
+            FilesUploadResponse response = slack.methods().filesUpload(r -> r
                     .token(token)
                     .channels(channels)
                     .file(file)
@@ -172,7 +173,7 @@ public class files_Test {
         }
 
         {
-            FilesInfoResponse response = slack.methods().filesInfo(FilesInfoRequest.builder()
+            FilesInfoResponse response = slack.methods().filesInfo(r -> r
                     .token(token)
                     .file(fileObj.getId())
                     .build());
@@ -182,7 +183,7 @@ public class files_Test {
 
         {
             FilesSharedPublicURLResponse response = slack.methods().filesSharedPublicURL(
-                    FilesSharedPublicURLRequest.builder().token(token).file(fileObj.getId()).build());
+                    r -> r.token(token).file(fileObj.getId()).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -210,8 +211,8 @@ public class files_Test {
                     .build());
             assertThat(filesInfoResponse.getError(), is(nullValue()));
             assertThat(filesInfoResponse.isOk(), is(true));
-            fileObj = filesInfoResponse.getFile();
-            assertThat(fileObj.getCommentsCount(), is(1));
+            com.github.seratch.jslack.api.model.File file2 = filesInfoResponse.getFile();
+            assertThat(file2.getCommentsCount(), is(1));
 
             FilesCommentsEditResponse editResponse = slack.methods().filesCommentEdit(FilesCommentsEditRequest.builder()
                     .token(token)
@@ -236,12 +237,12 @@ public class files_Test {
                     .build());
             assertThat(filesInfoResponse.getError(), is(nullValue()));
             assertThat(filesInfoResponse.isOk(), is(true));
-            fileObj = filesInfoResponse.getFile();
-            assertThat(fileObj.getCommentsCount(), is(0));
+            com.github.seratch.jslack.api.model.File fileObj2 = filesInfoResponse.getFile();
+            assertThat(fileObj2.getCommentsCount(), is(0));
         }
 
         {
-            ChatDeleteResponse response = slack.methods().chatDelete(ChatDeleteRequest.builder()
+            ChatDeleteResponse response = slack.methods().chatDelete(r -> r
                     .token(token)
                     .channel(channelId)
                     .ts(fileObj
@@ -254,7 +255,7 @@ public class files_Test {
             assertThat(response.isOk(), is(true));
         }
         {
-            FilesDeleteResponse response = slack.methods().filesDelete(FilesDeleteRequest.builder()
+            FilesDeleteResponse response = slack.methods().filesDelete(r -> r
                     .token(token)
                     .file(fileObj.getId())
                     .build());
@@ -265,7 +266,7 @@ public class files_Test {
 
     @Test
     public void createLongTextFile() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(ChannelsListRequest.builder().token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -278,7 +279,7 @@ public class files_Test {
         File file = new File("src/test/resources/sample_long.txt");
         com.github.seratch.jslack.api.model.File fileObj;
         {
-            FilesUploadResponse response = slack.methods().filesUpload(FilesUploadRequest.builder()
+            FilesUploadResponse response = slack.methods().filesUpload(r -> r
                     .token(token)
                     .channels(channels)
                     .file(file)
@@ -339,7 +340,7 @@ public class files_Test {
         }
 
         {
-            ChatDeleteResponse response = slack.methods().chatDelete(ChatDeleteRequest.builder()
+            ChatDeleteResponse response = slack.methods().chatDelete(r -> r
                     .token(token)
                     .channel(channelId)
                     .ts(fileObj
@@ -353,7 +354,7 @@ public class files_Test {
         }
 
         {
-            FilesDeleteResponse response = slack.methods().filesDelete(FilesDeleteRequest.builder()
+            FilesDeleteResponse response = slack.methods().filesDelete(r -> r
                     .token(token)
                     .file(fileObj.getId())
                     .build());
@@ -364,7 +365,7 @@ public class files_Test {
 
     @Test
     public void createImageFileAndComments() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(ChannelsListRequest.builder().token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -377,7 +378,7 @@ public class files_Test {
         File file = new File("src/test/resources/seratch.jpg");
         com.github.seratch.jslack.api.model.File fileObj;
         {
-            FilesUploadResponse response = slack.methods().filesUpload(FilesUploadRequest.builder()
+            FilesUploadResponse response = slack.methods().filesUpload(r -> r
                     .token(token)
                     .channels(channels)
                     .file(file)
@@ -579,31 +580,29 @@ public class files_Test {
         Conversation channel = channelGenerator.createNewPublicChannel("test" + System.currentTimeMillis());
 
         try {
-            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(
-                    ChatPostMessageRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .text("This is a test message posted by unit tests for jslack library")
-                            .replyBroadcast(false)
-                            .build());
+            ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .text("This is a test message posted by unit tests for jslack library")
+                    .replyBroadcast(false)
+                    .build());
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
 
-            ChatPostMessageResponse postThread1Response = slack.methods().chatPostMessage(
-                    ChatPostMessageRequest.builder()
-                            .token(token)
-                            .channel(channel.getId())
-                            .threadTs(postMessageResponse.getTs())
-                            .text("[thread 1] This is a test message posted by unit tests for jslack library")
-                            .replyBroadcast(false)
-                            .build());
+            ChatPostMessageResponse postThread1Response = slack.methods().chatPostMessage(r -> r
+                    .token(token)
+                    .channel(channel.getId())
+                    .threadTs(postMessageResponse.getTs())
+                    .text("[thread 1] This is a test message posted by unit tests for jslack library")
+                    .replyBroadcast(false)
+                    .build());
             assertThat(postThread1Response.getError(), is(nullValue()));
             assertThat(postThread1Response.isOk(), is(true));
 
             File file = new File("src/test/resources/sample.txt");
             com.github.seratch.jslack.api.model.File fileObj;
             {
-                FilesUploadResponse response = slack.methods().filesUpload(FilesUploadRequest.builder()
+                FilesUploadResponse response = slack.methods().filesUpload(r -> r
                         .token(token)
                         .file(file)
                         .filename("sample.txt")
@@ -617,7 +616,7 @@ public class files_Test {
             }
 
             {
-                FilesInfoResponse response = slack.methods().filesInfo(FilesInfoRequest.builder()
+                FilesInfoResponse response = slack.methods().filesInfo(r -> r
                         .token(token)
                         .file(fileObj.getId())
                         .build());

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/groups_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/groups_Test.java
@@ -2,9 +2,7 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
 import com.github.seratch.jslack.api.methods.request.groups.*;
-import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
 import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
 import com.github.seratch.jslack.api.methods.response.groups.*;
 import com.github.seratch.jslack.api.model.Group;
@@ -33,7 +31,7 @@ public class groups_Test {
 
         String name = "secret-" + System.currentTimeMillis();
         GroupsCreateResponse creationResponse = slack.methods().groupsCreate(
-                GroupsCreateRequest.builder().token(token).name(name).build());
+                r -> r.token(token).name(name).build());
         Group group = creationResponse.getGroup();
         {
             assertThat(creationResponse.getError(), is(nullValue()));
@@ -78,14 +76,14 @@ public class groups_Test {
 
         {
             String groupId = childCreationResponse.getGroup().getId();
-            ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+            ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(r -> r
                     .token(token)
                     .text("How are you?")
                     .channel(groupId)
                     .build());
             assertThat(postResponse.getError(), is(nullValue()));
 
-            ChatPostMessageResponse replyResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+            ChatPostMessageResponse replyResponse = slack.methods().chatPostMessage(r -> r
                     .token(token)
                     .threadTs(postResponse.getTs())
                     .text("Great! How are you?")
@@ -99,7 +97,7 @@ public class groups_Test {
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
 
-            GroupsRepliesResponse repliesResponse = slack.methods().groupsReplies(GroupsRepliesRequest.builder()
+            GroupsRepliesResponse repliesResponse = slack.methods().groupsReplies(r -> r
                     .token(token)
                     .channel(groupId)
                     .threadTs(postResponse.getTs())
@@ -129,7 +127,7 @@ public class groups_Test {
             assertThat(response.isOk(), is(true));
         }
         String userIdToInvite = null;
-        List<User> users = slack.methods().usersList(UsersListRequest.builder().token(token).limit(100).build()).getMembers();
+        List<User> users = slack.methods().usersList(r -> r.token(token).limit(100).build()).getMembers();
         for (User user : users) {
             boolean alreadyInTheGroup = false;
             for (String groupMember : group.getMembers()) {

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/im_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/im_Test.java
@@ -1,9 +1,6 @@
 package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
-import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
-import com.github.seratch.jslack.api.methods.request.im.*;
-import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
 import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
 import com.github.seratch.jslack.api.methods.response.im.*;
 import com.github.seratch.jslack.api.methods.response.users.UsersListResponse;
@@ -28,7 +25,7 @@ public class im_Test {
 
     @Test
     public void operations() throws Exception {
-        ImListResponse listResponse = slack.methods().imList(ImListRequest.builder()
+        ImListResponse listResponse = slack.methods().imList(r -> r
                 .token(token)
                 .limit(2)
                 .build());
@@ -36,14 +33,14 @@ public class im_Test {
         assertThat(listResponse.isOk(), is(true));
         assertThat(listResponse.getResponseMetadata(), is(notNullValue()));
 
-        UsersListResponse usersListResponse = slack.methods().usersList(UsersListRequest.builder()
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r
                 .token(token)
                 .presence(true)
                 .build());
         List<User> users = usersListResponse.getMembers();
-        String userId = users.get(0).getId();
+        final String userId = users.get(0).getId();
 
-        ImOpenResponse openResponse = slack.methods().imOpen(ImOpenRequest.builder()
+        ImOpenResponse openResponse = slack.methods().imOpen(r -> r
                 .token(token)
                 .user(userId)
                 .build());
@@ -54,7 +51,7 @@ public class im_Test {
 
         // without ts (worked before but it gets to fail because ts is required as of Jan 2019)
         {
-            ImMarkResponse markResponse = slack.methods().imMark(ImMarkRequest.builder()
+            ImMarkResponse markResponse = slack.methods().imMark(r -> r
                     .token(token)
                     .channel(channelId)
                     .build());
@@ -62,7 +59,7 @@ public class im_Test {
             assertThat(markResponse.getError(), is("invalid_timestamp"));
         }
 
-        ChatPostMessageResponse firstMessageResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+        ChatPostMessageResponse firstMessageResponse = slack.methods().chatPostMessage(r -> r
                 .token(token)
                 .channel(channelId)
                 .text("Hi!").build());
@@ -71,7 +68,7 @@ public class im_Test {
 
         // with ts
         {
-            ImMarkResponse markResponse = slack.methods().imMark(ImMarkRequest.builder()
+            ImMarkResponse markResponse = slack.methods().imMark(r -> r
                     .token(token)
                     .channel(channelId)
                     .ts(firstMessageResponse.getTs())
@@ -80,7 +77,7 @@ public class im_Test {
             assertThat(markResponse.isOk(), is(true));
         }
 
-        ChatPostMessageResponse threadReplyResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+        ChatPostMessageResponse threadReplyResponse = slack.methods().chatPostMessage(r -> r
                 .token(token)
                 .channel(channelId)
                 .threadTs(firstMessageResponse.getTs())
@@ -88,7 +85,7 @@ public class im_Test {
         assertThat(threadReplyResponse.getError(), is(nullValue()));
         assertThat(threadReplyResponse.isOk(), is(true));
 
-        ImRepliesResponse repliesResponse = slack.methods().imReplies(ImRepliesRequest.builder()
+        ImRepliesResponse repliesResponse = slack.methods().imReplies(r -> r
                 .token(token)
                 .channel(channelId)
                 .threadTs(threadReplyResponse.getMessage().getThreadTs())
@@ -96,7 +93,7 @@ public class im_Test {
         assertThat(repliesResponse.getError(), is(nullValue()));
         assertThat(repliesResponse.isOk(), is(true));
 
-        ImHistoryResponse historyResponse = slack.methods().imHistory(ImHistoryRequest.builder()
+        ImHistoryResponse historyResponse = slack.methods().imHistory(r -> r
                 .token(token)
                 .channel(channelId)
                 .count(10)
@@ -104,7 +101,7 @@ public class im_Test {
         assertThat(historyResponse.getError(), is(nullValue()));
         assertThat(historyResponse.isOk(), is(true));
 
-        ImCloseResponse closeResponse = slack.methods().imClose(ImCloseRequest.builder()
+        ImCloseResponse closeResponse = slack.methods().imClose(r -> r
                 .token(token)
                 .channel(channelId)
                 .build());

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/mpim_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/mpim_Test.java
@@ -2,8 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.mpim.*;
-import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
 import com.github.seratch.jslack.api.methods.response.mpim.*;
 import com.github.seratch.jslack.api.methods.response.users.UsersListResponse;
 import com.github.seratch.jslack.api.model.User;
@@ -28,10 +26,10 @@ public class mpim_Test {
 
     @Test
     public void operations() throws IOException, SlackApiException {
-        MpimListResponse listResponse = slack.methods().mpimList(MpimListRequest.builder().token(token).build());
+        MpimListResponse listResponse = slack.methods().mpimList(r -> r.token(token).build());
         assertThat(listResponse.isOk(), is(true));
 
-        UsersListResponse usersListResponse = slack.methods().usersList(UsersListRequest.builder().token(token).presence(true).build());
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(token).presence(true).build());
         List<User> users = usersListResponse.getMembers();
         List<String> userIds = new ArrayList<>();
         for (User u : users) {
@@ -42,21 +40,21 @@ public class mpim_Test {
             }
         }
 
-        MpimOpenResponse openResponse = slack.methods().mpimOpen(MpimOpenRequest.builder().token(token).users(userIds).build());
+        MpimOpenResponse openResponse = slack.methods().mpimOpen(r -> r.token(token).users(userIds).build());
         assertThat(openResponse.getError(), is(nullValue()));
         assertThat(openResponse.isOk(), is(true));
 
         String channelId = openResponse.getGroup().getId();
 
-        MpimMarkResponse markResponse = slack.methods().mpimMark(MpimMarkRequest.builder().token(token).channel(channelId).build());
+        MpimMarkResponse markResponse = slack.methods().mpimMark(r -> r.token(token).channel(channelId).build());
         assertThat(markResponse.getError(), is(nullValue()));
         assertThat(markResponse.isOk(), is(true));
 
-        MpimHistoryResponse historyResponse = slack.methods().mpimHistory(MpimHistoryRequest.builder().token(token).channel(channelId).count(10).build());
+        MpimHistoryResponse historyResponse = slack.methods().mpimHistory(r -> r.token(token).channel(channelId).count(10).build());
         assertThat(historyResponse.getError(), is(nullValue()));
         assertThat(historyResponse.isOk(), is(true));
 
-        MpimCloseResponse closeResponse = slack.methods().mpimClose(MpimCloseRequest.builder().token(token).channel(channelId).build());
+        MpimCloseResponse closeResponse = slack.methods().mpimClose(r -> r.token(token).channel(channelId).build());
         assertThat(closeResponse.getError(), is(nullValue()));
         assertThat(closeResponse.isOk(), is(true));
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/oauth_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/oauth_Test.java
@@ -2,8 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.oauth.OAuthAccessRequest;
-import com.github.seratch.jslack.api.methods.request.oauth.OAuthTokenRequest;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthTokenResponse;
 import config.SlackTestConfig;
@@ -24,7 +22,7 @@ public class oauth_Test {
     @Test
     public void access() throws IOException, SlackApiException {
         {
-            OAuthAccessResponse response = slack.methods().oauthAccess(OAuthAccessRequest.builder()
+            OAuthAccessResponse response = slack.methods().oauthAccess(r -> r
                     .clientId("3485157640.XXXX")
                     .clientSecret("XXXXX")
                     .code("")
@@ -39,7 +37,7 @@ public class oauth_Test {
     @Test
     public void token() throws IOException, SlackApiException {
         {
-            OAuthTokenResponse response = slack.methods().oauthToken(OAuthTokenRequest.builder()
+            OAuthTokenResponse response = slack.methods().oauthToken(r -> r
                     .clientId("3485157640.XXXX")
                     .clientSecret("XXXXX")
                     .code("")

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/pins_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/pins_Test.java
@@ -2,11 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.channels.ChannelsListRequest;
-import com.github.seratch.jslack.api.methods.request.files.FilesUploadRequest;
-import com.github.seratch.jslack.api.methods.request.pins.PinsAddRequest;
-import com.github.seratch.jslack.api.methods.request.pins.PinsListRequest;
-import com.github.seratch.jslack.api.methods.request.pins.PinsRemoveRequest;
 import com.github.seratch.jslack.api.methods.response.files.FilesUploadResponse;
 import com.github.seratch.jslack.api.methods.response.pins.PinsAddResponse;
 import com.github.seratch.jslack.api.methods.response.pins.PinsListResponse;
@@ -34,7 +29,7 @@ public class pins_Test {
 
     @Test
     public void list() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(ChannelsListRequest.builder().token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -44,7 +39,7 @@ public class pins_Test {
         }
 
         PinsListResponse response = slack.methods().pinsList(
-                PinsListRequest.builder().token(token).channel(channels.get(0)).build());
+                r -> r.token(token).channel(channels.get(0)).build());
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getItems(), is(notNullValue()));
@@ -52,7 +47,7 @@ public class pins_Test {
 
     @Test
     public void add() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(ChannelsListRequest.builder().token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -64,7 +59,7 @@ public class pins_Test {
         File file = new File("src/test/resources/sample.txt");
         com.github.seratch.jslack.api.model.File fileObj;
         {
-            FilesUploadResponse response = slack.methods().filesUpload(FilesUploadRequest.builder()
+            FilesUploadResponse response = slack.methods().filesUpload(r -> r
                     .token(token)
                     .channels(channels)
                     .file(file)
@@ -78,7 +73,7 @@ public class pins_Test {
         }
 
         {
-            PinsAddResponse response = slack.methods().pinsAdd(PinsAddRequest.builder()
+            PinsAddResponse response = slack.methods().pinsAdd(r -> r
                     .token(token)
                     .channel(channels.get(0))
                     .file(fileObj.getId())
@@ -87,7 +82,7 @@ public class pins_Test {
             assertThat(response.isOk(), is(true));
         }
         {
-            PinsRemoveResponse response = slack.methods().pinsRemove(PinsRemoveRequest.builder()
+            PinsRemoveResponse response = slack.methods().pinsRemove(r -> r
                     .token(token)
                     .channel(channels.get(0))
                     .file(fileObj.getId())
@@ -99,7 +94,7 @@ public class pins_Test {
         {
             // as of August 2018, File object no longer contains initialComment.
             if (fileObj.getInitialComment() != null) {
-                PinsAddResponse response = slack.methods().pinsAdd(PinsAddRequest.builder()
+                PinsAddResponse response = slack.methods().pinsAdd(r -> r
                         .token(token)
                         .channel(channels.get(0))
                         .fileComment(fileObj.getInitialComment().getId())

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/reactions_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/reactions_Test.java
@@ -2,13 +2,7 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.channels.ChannelsListRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
-import com.github.seratch.jslack.api.methods.request.reactions.ReactionsAddRequest;
-import com.github.seratch.jslack.api.methods.request.reactions.ReactionsGetRequest;
-import com.github.seratch.jslack.api.methods.request.reactions.ReactionsListRequest;
-import com.github.seratch.jslack.api.methods.request.reactions.ReactionsRemoveRequest;
-import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
 import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
 import com.github.seratch.jslack.api.methods.response.reactions.ReactionsAddResponse;
 import com.github.seratch.jslack.api.methods.response.reactions.ReactionsGetResponse;
@@ -33,7 +27,7 @@ public class reactions_Test {
 
     @Test
     public void test() throws IOException, SlackApiException {
-        String channel = slack.methods().channelsList(ChannelsListRequest.builder().token(token).excludeArchived(true).build())
+        String channel = slack.methods().channelsList(r -> r.token(token).excludeArchived(true).build())
                 .getChannels().get(0).getId();
 
         ChatPostMessageResponse postMessage = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
@@ -45,7 +39,7 @@ public class reactions_Test {
         assertThat(postMessage.isOk(), is(true));
 
         String timestamp = postMessage.getTs();
-        ReactionsAddResponse addResponse = slack.methods().reactionsAdd(ReactionsAddRequest.builder()
+        ReactionsAddResponse addResponse = slack.methods().reactionsAdd(r -> r
                 .token(token)
                 .name("smile")
                 .channel(channel)
@@ -54,7 +48,7 @@ public class reactions_Test {
         assertThat(addResponse.getError(), is(nullValue()));
         assertThat(addResponse.isOk(), is(true));
 
-        ReactionsGetResponse getResponse = slack.methods().reactionsGet(ReactionsGetRequest.builder()
+        ReactionsGetResponse getResponse = slack.methods().reactionsGet(r -> r
                 .token(token)
                 .channel(channel)
                 .timestamp(timestamp)
@@ -62,7 +56,7 @@ public class reactions_Test {
         assertThat(getResponse.getError(), is(nullValue()));
         assertThat(getResponse.isOk(), is(true));
 
-        ReactionsRemoveResponse removeResponse = slack.methods().reactionsRemove(ReactionsRemoveRequest.builder()
+        ReactionsRemoveResponse removeResponse = slack.methods().reactionsRemove(r -> r
                 .token(token)
                 .name("smile")
                 .channel(channel)
@@ -75,10 +69,10 @@ public class reactions_Test {
 
     @Test
     public void list() throws IOException, SlackApiException {
-        String user = slack.methods().usersList(UsersListRequest.builder().token(token).build())
+        String user = slack.methods().usersList(r -> r.token(token).build())
                 .getMembers().get(0).getId();
 
-        ReactionsListResponse response = slack.methods().reactionsList(ReactionsListRequest.builder()
+        ReactionsListResponse response = slack.methods().reactionsList(r -> r
                 .token(token)
                 .user(user)
                 .build());

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/reminders_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/reminders_Test.java
@@ -1,10 +1,6 @@
 package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
-import com.github.seratch.jslack.api.methods.request.reminders.RemindersAddRequest;
-import com.github.seratch.jslack.api.methods.request.reminders.RemindersCompleteRequest;
-import com.github.seratch.jslack.api.methods.request.reminders.RemindersDeleteRequest;
-import com.github.seratch.jslack.api.methods.request.reminders.RemindersInfoRequest;
 import com.github.seratch.jslack.api.methods.response.reminders.RemindersAddResponse;
 import com.github.seratch.jslack.api.methods.response.reminders.RemindersCompleteResponse;
 import com.github.seratch.jslack.api.methods.response.reminders.RemindersDeleteResponse;
@@ -25,7 +21,7 @@ public class reminders_Test {
 
     @Test
     public void test() throws Exception {
-        RemindersAddResponse addResponse = slack.methods().remindersAdd(RemindersAddRequest.builder()
+        RemindersAddResponse addResponse = slack.methods().remindersAdd(r -> r
                 .token(token)
                 .text("Don't forget it!")
                 .time("10")
@@ -35,21 +31,21 @@ public class reminders_Test {
 
         String reminderId = addResponse.getReminder().getId();
 
-        RemindersInfoResponse infoResponse = slack.methods().remindersInfo(RemindersInfoRequest.builder()
+        RemindersInfoResponse infoResponse = slack.methods().remindersInfo(r -> r
                 .token(token)
                 .reminder(reminderId)
                 .build());
         assertThat(infoResponse.getError(), is(nullValue()));
         assertThat(infoResponse.isOk(), is(true));
 
-        RemindersCompleteResponse completeResponse = slack.methods().remindersComplete(RemindersCompleteRequest.builder()
+        RemindersCompleteResponse completeResponse = slack.methods().remindersComplete(r -> r
                 .token(token)
                 .reminder(reminderId)
                 .build());
         assertThat(completeResponse.getError(), is(nullValue()));
         assertThat(completeResponse.isOk(), is(true));
 
-        RemindersDeleteResponse deleteResponse = slack.methods().remindersDelete(RemindersDeleteRequest.builder()
+        RemindersDeleteResponse deleteResponse = slack.methods().remindersDelete(r -> r
                 .token(token)
                 .reminder(reminderId)
                 .build());

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/scim_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/scim_Test.java
@@ -2,7 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.scim.request.UsersDeleteRequest;
 import com.github.seratch.jslack.api.scim.response.UsersDeleteResponse;
 import config.Constants;
 import config.SlackTestConfig;
@@ -24,11 +23,10 @@ public class scim_Test {
     public void deleteUserTest() throws IOException {
         final String userId = "1";
         try {
-            UsersDeleteResponse response = slack.scim().delete(
-                    UsersDeleteRequest.builder()
-                            .token(token)
-                            .id(userId)
-                            .build());
+            UsersDeleteResponse response = slack.scim().delete(r -> r
+                    .token(token)
+                    .id(userId)
+                    .build());
 
             // testing with an SCIM activated account
             assertThat(response.getError(), is(nullValue()));
@@ -36,7 +34,7 @@ public class scim_Test {
 
         } catch (SlackApiException apiError) {
             assertThat(apiError.getResponseBody(), is(notNullValue()));
-            assertThat(apiError.getError(), is(nullValue()));
+            assertThat(apiError.getError(), is(notNullValue()));
         }
     }
 

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/search_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/search_Test.java
@@ -2,9 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.search.SearchAllRequest;
-import com.github.seratch.jslack.api.methods.request.search.SearchFilesRequest;
-import com.github.seratch.jslack.api.methods.request.search.SearchMessagesRequest;
 import com.github.seratch.jslack.api.methods.response.search.SearchAllResponse;
 import com.github.seratch.jslack.api.methods.response.search.SearchFilesResponse;
 import com.github.seratch.jslack.api.methods.response.search.SearchMessagesResponse;
@@ -29,8 +26,7 @@ public class search_Test {
 
     @Test
     public void all() throws IOException, SlackApiException {
-        SearchAllResponse response = slack.methods().searchAll(
-                SearchAllRequest.builder().token(token).query("test").build());
+        SearchAllResponse response = slack.methods().searchAll(r -> r.token(token).query("test").build());
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -38,8 +34,7 @@ public class search_Test {
 
     @Test
     public void messages() throws IOException, SlackApiException {
-        SearchMessagesResponse response = slack.methods().searchMessages(
-                SearchMessagesRequest.builder().token(token).query("test").build());
+        SearchMessagesResponse response = slack.methods().searchMessages(r -> r.token(token).query("test").build());
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -51,8 +46,7 @@ public class search_Test {
 
     @Test
     public void files() throws IOException, SlackApiException {
-        SearchFilesResponse response = slack.methods().searchFiles(
-                SearchFilesRequest.builder().token(token).query("test").build());
+        SearchFilesResponse response = slack.methods().searchFiles(r -> r.token(token).query("test").build());
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/stars_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/stars_Test.java
@@ -2,11 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.channels.ChannelsListRequest;
-import com.github.seratch.jslack.api.methods.request.files.FilesUploadRequest;
-import com.github.seratch.jslack.api.methods.request.stars.StarsAddRequest;
-import com.github.seratch.jslack.api.methods.request.stars.StarsListRequest;
-import com.github.seratch.jslack.api.methods.request.stars.StarsRemoveRequest;
 import com.github.seratch.jslack.api.methods.response.files.FilesUploadResponse;
 import com.github.seratch.jslack.api.methods.response.stars.StarsAddResponse;
 import com.github.seratch.jslack.api.methods.response.stars.StarsListResponse;
@@ -34,7 +29,7 @@ public class stars_Test {
 
     @Test
     public void list() throws IOException, SlackApiException {
-        StarsListResponse response = slack.methods().starsList(StarsListRequest.builder().token(token).build());
+        StarsListResponse response = slack.methods().starsList(r -> r.token(token).build());
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getItems(), is(notNullValue()));
@@ -42,7 +37,7 @@ public class stars_Test {
 
     @Test
     public void add() throws IOException, SlackApiException {
-        List<Channel> channels = slack.methods().channelsList(ChannelsListRequest.builder().token(token).build()).getChannels();
+        List<Channel> channels = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
         List<String> channelIds = new ArrayList<>();
         for (Channel c : channels) {
             if (c.getName().equals("random")) {
@@ -54,7 +49,7 @@ public class stars_Test {
         File file = new File("src/test/resources/sample.txt");
         com.github.seratch.jslack.api.model.File fileObj;
         {
-            FilesUploadResponse response = slack.methods().filesUpload(FilesUploadRequest.builder()
+            FilesUploadResponse response = slack.methods().filesUpload(r -> r
                     .token(token)
                     .channels(channelIds)
                     .file(file)
@@ -68,7 +63,7 @@ public class stars_Test {
         }
 
         {
-            StarsAddResponse response = slack.methods().starsAdd(StarsAddRequest.builder()
+            StarsAddResponse response = slack.methods().starsAdd(r -> r
                     .token(token)
                     .channel(channelIds.get(0))
                     .file(fileObj.getId())
@@ -77,7 +72,7 @@ public class stars_Test {
             assertThat(response.isOk(), is(true));
         }
         {
-            StarsRemoveResponse response = slack.methods().starsRemove(StarsRemoveRequest.builder()
+            StarsRemoveResponse response = slack.methods().starsRemove(r -> r
                     .token(token)
                     .channel(channelIds.get(0))
                     .file(fileObj.getId())
@@ -89,7 +84,7 @@ public class stars_Test {
         {
             // as of August 2018, File object no longer contains initialComment.
             if (fileObj.getInitialComment() != null) {
-                StarsAddResponse response = slack.methods().starsAdd(StarsAddRequest.builder()
+                StarsAddResponse response = slack.methods().starsAdd(r -> r
                         .token(token)
                         .channel(channelIds.get(0))
                         .fileComment(fileObj.getInitialComment().getId())

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/team_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/team_Test.java
@@ -1,12 +1,6 @@
 package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
-import com.github.seratch.jslack.api.methods.request.team.TeamAccessLogsRequest;
-import com.github.seratch.jslack.api.methods.request.team.TeamBillableInfoRequest;
-import com.github.seratch.jslack.api.methods.request.team.TeamInfoRequest;
-import com.github.seratch.jslack.api.methods.request.team.TeamIntegrationLogsRequest;
-import com.github.seratch.jslack.api.methods.request.team.profile.TeamProfileGetRequest;
-import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
 import com.github.seratch.jslack.api.methods.response.team.TeamAccessLogsResponse;
 import com.github.seratch.jslack.api.methods.response.team.TeamBillableInfoResponse;
 import com.github.seratch.jslack.api.methods.response.team.TeamInfoResponse;
@@ -32,7 +26,7 @@ public class team_Test {
 
     @Test
     public void teamAccessLogs() throws Exception {
-        TeamAccessLogsResponse response = slack.methods().teamAccessLogs(TeamAccessLogsRequest.builder()
+        TeamAccessLogsResponse response = slack.methods().teamAccessLogs(r -> r
                 .token(token)
                 .build());
         if (response.isOk()) {
@@ -48,7 +42,7 @@ public class team_Test {
 
     @Test
     public void teamBillableInfo() throws Exception {
-        List<User> users = slack.methods().usersList(UsersListRequest.builder().token(token).build()).getMembers();
+        List<User> users = slack.methods().usersList(r -> r.token(token).build()).getMembers();
         User user = null;
         for (User u : users) {
             if (!u.isBot() && !"USLACKBOT".equals(u.getId())) {
@@ -57,7 +51,7 @@ public class team_Test {
             }
         }
         String userId = user.getId();
-        TeamBillableInfoResponse response = slack.methods().teamBillableInfo(TeamBillableInfoRequest.builder()
+        TeamBillableInfoResponse response = slack.methods().teamBillableInfo(r -> r
                 .token(token)
                 .user(userId)
                 .build());
@@ -67,7 +61,7 @@ public class team_Test {
 
     @Test
     public void teamInfo() throws Exception {
-        TeamInfoResponse response = slack.methods().teamInfo(TeamInfoRequest.builder()
+        TeamInfoResponse response = slack.methods().teamInfo(r -> r
                 .token(token)
                 .build());
         assertThat(response.getError(), is(nullValue()));
@@ -76,8 +70,8 @@ public class team_Test {
 
     @Test
     public void teamIntegrationLogs() throws Exception {
-        String user = slack.methods().usersList(UsersListRequest.builder().token(token).build()).getMembers().get(0).getId();
-        TeamIntegrationLogsResponse response = slack.methods().teamIntegrationLogs(TeamIntegrationLogsRequest.builder()
+        String user = slack.methods().usersList(r -> r.token(token).build()).getMembers().get(0).getId();
+        TeamIntegrationLogsResponse response = slack.methods().teamIntegrationLogs(r -> r
                 .token(token)
                 .user(user)
                 .build());
@@ -87,7 +81,7 @@ public class team_Test {
 
     @Test
     public void teamProfileGet() throws Exception {
-        TeamProfileGetResponse response = slack.methods().teamProfileGet(TeamProfileGetRequest.builder().token(token).build());
+        TeamProfileGetResponse response = slack.methods().teamProfileGet(r -> r.token(token).build());
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/usergroups_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/usergroups_Test.java
@@ -1,10 +1,7 @@
 package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
-import com.github.seratch.jslack.api.methods.request.usergroups.*;
 import com.github.seratch.jslack.api.methods.request.usergroups.users.UsergroupUsersListRequest;
-import com.github.seratch.jslack.api.methods.request.usergroups.users.UsergroupUsersUpdateRequest;
-import com.github.seratch.jslack.api.methods.request.users.UsersListRequest;
 import com.github.seratch.jslack.api.methods.response.usergroups.*;
 import com.github.seratch.jslack.api.methods.response.usergroups.users.UsergroupUsersListResponse;
 import com.github.seratch.jslack.api.methods.response.usergroups.users.UsergroupUsersUpdateResponse;
@@ -35,7 +32,7 @@ public class usergroups_Test {
     @Test
     public void create() throws Exception {
         String usergroupName = "usergroup-" + System.currentTimeMillis();
-        UsergroupsCreateResponse response = slack.methods().usergroupsCreate(UsergroupsCreateRequest.builder()
+        UsergroupsCreateResponse response = slack.methods().usergroupsCreate(r -> r
                 .token(token)
                 .name(usergroupName)
                 .build());
@@ -54,14 +51,14 @@ public class usergroups_Test {
 
     @Test
     public void list() throws Exception {
-        UsergroupsListResponse response = slack.methods().usergroupsList(UsergroupsListRequest.builder().token(token).build());
+        UsergroupsListResponse response = slack.methods().usergroupsList(r -> r.token(token).build());
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void usergroups() throws Exception {
-        UsergroupsListResponse usergroups = slack.methods().usergroupsList(UsergroupsListRequest.builder().token(token).build());
+        UsergroupsListResponse usergroups = slack.methods().usergroupsList(r -> r.token(token).build());
         if (usergroups.isOk() && usergroups.getUsergroups().size() > 0) {
             UsergroupUsersListResponse response = slack.methods().usergroupUsersList(
                     UsergroupUsersListRequest.builder()
@@ -72,32 +69,29 @@ public class usergroups_Test {
             assertThat(response.getError(), is(nullValue()));
         }
 
-        Usergroup usergroup = null;
+        UsergroupsCreateResponse creation = slack.methods().usergroupsCreate(r -> r
+                .token(token)
+                .name("usergroup-" + System.currentTimeMillis())
+                .description("Something wrong")
+                .build());
+        assertThat(creation.getError(), is(nullValue()));
+        final Usergroup usergroup = creation.getUsergroup();
         {
-            UsergroupsCreateResponse response = slack.methods().usergroupsCreate(UsergroupsCreateRequest.builder()
-                    .token(token)
-                    .name("usergroup-" + System.currentTimeMillis())
-                    .description("Something wrong")
-                    .build());
-            assertThat(response.getError(), is(nullValue()));
-            usergroup = response.getUsergroup();
-        }
-        {
-            UsergroupsDisableResponse response = slack.methods().usergroupsDisable(UsergroupsDisableRequest.builder()
+            UsergroupsDisableResponse response = slack.methods().usergroupsDisable(r -> r
                     .token(token)
                     .usergroup(usergroup.getId())
                     .build());
             assertThat(response.getError(), is(nullValue()));
         }
         {
-            UsergroupsEnableResponse response = slack.methods().usergroupsEnable(UsergroupsEnableRequest.builder()
+            UsergroupsEnableResponse response = slack.methods().usergroupsEnable(r -> r
                     .token(token)
                     .usergroup(usergroup.getId())
                     .build());
             assertThat(response.getError(), is(nullValue()));
         }
         {
-            UsergroupsUpdateResponse response = slack.methods().usergroupsUpdate(UsergroupsUpdateRequest.builder()
+            UsergroupsUpdateResponse response = slack.methods().usergroupsUpdate(r -> r
                     .token(token)
                     .usergroup(usergroup.getId())
                     .description("updated")
@@ -105,7 +99,7 @@ public class usergroups_Test {
             assertThat(response.getError(), is(nullValue()));
         }
         {
-            UsersListResponse usersListResponse = slack.methods().usersList(UsersListRequest.builder()
+            UsersListResponse usersListResponse = slack.methods().usersList(r -> r
                     .token(token)
                     .limit(3)
                     .build());
@@ -113,7 +107,7 @@ public class usergroups_Test {
             for (User member : usersListResponse.getMembers()) {
                 userIds.add(member.getId());
             }
-            UsergroupUsersUpdateResponse response = slack.methods().usergroupUsersUpdate(UsergroupUsersUpdateRequest.builder()
+            UsergroupUsersUpdateResponse response = slack.methods().usergroupUsersUpdate(r -> r
                     .token(token)
                     .usergroup(usergroup.getId())
                     .users(userIds)

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/users_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/users_Test.java
@@ -2,7 +2,8 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.users.*;
+import com.github.seratch.jslack.api.methods.request.users.UsersLookupByEmailRequest;
+import com.github.seratch.jslack.api.methods.request.users.UsersSetActiveRequest;
 import com.github.seratch.jslack.api.methods.response.channels.UsersLookupByEmailResponse;
 import com.github.seratch.jslack.api.methods.response.users.*;
 import com.github.seratch.jslack.api.model.User;
@@ -30,7 +31,7 @@ public class users_Test {
     @Test
     public void showUsers() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        UsersListResponse users = slack.methods().usersList(UsersListRequest.builder()
+        UsersListResponse users = slack.methods().usersList(r -> r
                 .token(token)
                 .limit(100)
                 .build());
@@ -44,8 +45,7 @@ public class users_Test {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
 
         {
-            UsersSetPresenceResponse response = slack.methods().usersSetPresence(
-                    UsersSetPresenceRequest.builder().token(token).presence("away").build());
+            UsersSetPresenceResponse response = slack.methods().usersSetPresence(r -> r.token(token).presence("away").build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -58,14 +58,14 @@ public class users_Test {
         }
 
         {
-            UsersIdentityResponse response = slack.methods().usersIdentity(UsersIdentityRequest.builder().token(token).build());
+            UsersIdentityResponse response = slack.methods().usersIdentity(r -> r.token(token).build());
             // TODO: test preparation?
             // {"ok":false,"error":"missing_scope","needed":"identity.basic","provided":"identify,read,post,client,apps,admin"}
             assertThat(response.getError(), is("missing_scope"));
             assertThat(response.isOk(), is(false));
         }
 
-        UsersListResponse usersListResponse = slack.methods().usersList(UsersListRequest.builder()
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r
                 .token(token)
                 .limit(2)
                 .presence(true)
@@ -100,22 +100,21 @@ public class users_Test {
         }
 
         {
-            UsersInfoResponse response = slack.methods().usersInfo(UsersInfoRequest.builder().token(token).user(userId).build());
+            UsersInfoResponse response = slack.methods().usersInfo(r -> r.token(token).user(userId).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getUser(), is(notNullValue()));
         }
 
         {
-            UsersGetPresenceResponse response = slack.methods().usersGetPresence(
-                    UsersGetPresenceRequest.builder().token(token).user(userId).build());
+            UsersGetPresenceResponse response = slack.methods().usersGetPresence(r -> r.token(token).user(userId).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getPresence(), is(notNullValue()));
         }
 
         {
-            UsersConversationsResponse response = slack.methods().usersConversations(UsersConversationsRequest.builder()
+            UsersConversationsResponse response = slack.methods().usersConversations(r -> r
                     .token(token)
                     .user(userId).build());
             assertThat(response.getError(), is(nullValue()));
@@ -123,15 +122,14 @@ public class users_Test {
         }
 
         {
-            UsersDeletePhotoResponse response = slack.methods().usersDeletePhoto(
-                    UsersDeletePhotoRequest.builder().token(token).build());
+            UsersDeletePhotoResponse response = slack.methods().usersDeletePhoto(r -> r.token(token).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         File image = new File("src/test/resources/user_photo.jpg");
         {
-            UsersSetPhotoResponse response = slack.methods().usersSetPhoto(UsersSetPhotoRequest.builder()
+            UsersSetPhotoResponse response = slack.methods().usersSetPhoto(r -> r
                     .token(token)
                     .image(image)
                     .build());
@@ -143,7 +141,7 @@ public class users_Test {
     @Test
     public void lookupByEMailSupported() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        UsersListResponse usersListResponse = slack.methods().usersList(UsersListRequest.builder()
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r
                 .token(token)
                 .presence(true)
                 .build());

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/users_profile_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/users_profile_Test.java
@@ -2,8 +2,6 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.users.profile.UsersProfileGetRequest;
-import com.github.seratch.jslack.api.methods.request.users.profile.UsersProfileSetRequest;
 import com.github.seratch.jslack.api.methods.response.users.profile.UsersProfileGetResponse;
 import com.github.seratch.jslack.api.methods.response.users.profile.UsersProfileSetResponse;
 import com.github.seratch.jslack.api.model.User;
@@ -29,7 +27,7 @@ public class users_profile_Test {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
 
         {
-            UsersProfileGetResponse response = slack.methods().usersProfileGet(UsersProfileGetRequest.builder().token(token).build());
+            UsersProfileGetResponse response = slack.methods().usersProfileGet(r -> r.token(token).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));
@@ -37,7 +35,7 @@ public class users_profile_Test {
 
         {
             UsersProfileSetResponse response = slack.methods().usersProfileSet(
-                    UsersProfileSetRequest.builder().token(token).name("skype").value("skype-" + System.currentTimeMillis()).build());
+                    r -> r.token(token).name("skype").value("skype-" + System.currentTimeMillis()).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));
@@ -47,7 +45,7 @@ public class users_profile_Test {
             User.Profile profile = new User.Profile();
             profile.setSkype("skype-" + System.currentTimeMillis());
             UsersProfileSetResponse response = slack.methods().usersProfileSet(
-                    UsersProfileSetRequest.builder().token(token).profile(profile).build());
+                    r -> r.token(token).profile(profile).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));

--- a/jslack-app-backend/pom.xml
+++ b/jslack-app-backend/pom.xml
@@ -18,12 +18,12 @@
         <dependency>
             <groupId>com.github.seratch</groupId>
             <artifactId>jslack-api-model</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.seratch</groupId>
             <artifactId>jslack-api-client</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -101,15 +101,6 @@
                 <version>2.8.2</version>
             </plugin>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
-                <configuration>
-                    <forkMode>pertest</forkMode>
-                    <argLine>-Xms64m -Xmx128m</argLine>
-                    <testFailureIgnore>true</testFailureIgnore>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
@@ -182,7 +173,7 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <configuration>
-                                    <additionalparam>-Xdoclint:none</additionalparam>
+                                    <additionalOptions>-Xdoclint:none</additionalOptions>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This pull request adds a number of overload methods to `MethodsClient` to provide handier ways to build requests. These changes enable library users both (1) and (2).

## (1) Existing style

This good old style is still available. We don't bring any breaking changes.

```java
ChatPostMessageResponse resp = slack.methods().chatPostMessage(
  ChatPostMessageRequest.builder()
    .token(token)
    .channel(channelId)
    .text(someText)
    .build());
```

## (2) Newly added style

With this style, library users no longer need to type long class names. It's not only handy but more readable than current one.

```java
ChatPostMessageResponse resp = slack.methods().chatPostMessage(req -> req
  .token(token)
  .channel(channelId)
  .text(someText)
  .build());
```