### PR TITLE
Remove .build() call from new request builder APIs

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
@@ -144,7 +144,7 @@ public interface MethodsClient {
 
     ApiTestResponse apiTest(ApiTestRequest req) throws IOException, SlackApiException;
 
-    ApiTestResponse apiTest(RequestBuilder<ApiTestRequest, ApiTestRequest.ApiTestRequestBuilder> req) throws IOException, SlackApiException;
+    ApiTestResponse apiTest(RequestConfigurator<ApiTestRequest.ApiTestRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // apps
@@ -152,7 +152,7 @@ public interface MethodsClient {
 
     AppsUninstallResponse appsUninstall(AppsUninstallRequest req) throws IOException, SlackApiException;
 
-    AppsUninstallResponse appsUninstall(RequestBuilder<AppsUninstallRequest, AppsUninstallRequest.AppsUninstallRequestBuilder> req) throws IOException, SlackApiException;
+    AppsUninstallResponse appsUninstall(RequestConfigurator<AppsUninstallRequest.AppsUninstallRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // apps.permissions
@@ -160,11 +160,11 @@ public interface MethodsClient {
 
     AppsPermissionsInfoResponse appsPermissionsInfo(AppsPermissionsInfoRequest req) throws IOException, SlackApiException;
 
-    AppsPermissionsInfoResponse appsPermissionsInfo(RequestBuilder<AppsPermissionsInfoRequest, AppsPermissionsInfoRequest.AppsPermissionsInfoRequestBuilder> req) throws IOException, SlackApiException;
+    AppsPermissionsInfoResponse appsPermissionsInfo(RequestConfigurator<AppsPermissionsInfoRequest.AppsPermissionsInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     AppsPermissionsRequestResponse appsPermissionsRequest(AppsPermissionsRequestRequest req) throws IOException, SlackApiException;
 
-    AppsPermissionsRequestResponse appsPermissionsRequest(RequestBuilder<AppsPermissionsRequestRequest, AppsPermissionsRequestRequest.AppsPermissionsRequestRequestBuilder> req) throws IOException, SlackApiException;
+    AppsPermissionsRequestResponse appsPermissionsRequest(RequestConfigurator<AppsPermissionsRequestRequest.AppsPermissionsRequestRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // apps.permissions.resources
@@ -212,11 +212,11 @@ public interface MethodsClient {
 
     AuthRevokeResponse authRevoke(AuthRevokeRequest req) throws IOException, SlackApiException;
 
-    AuthRevokeResponse authRevoke(RequestBuilder<AuthRevokeRequest, AuthRevokeRequest.AuthRevokeRequestBuilder> req) throws IOException, SlackApiException;
+    AuthRevokeResponse authRevoke(RequestConfigurator<AuthRevokeRequest.AuthRevokeRequestBuilder> req) throws IOException, SlackApiException;
 
     AuthTestResponse authTest(AuthTestRequest req) throws IOException, SlackApiException;
 
-    AuthTestResponse authTest(RequestBuilder<AuthTestRequest, AuthTestRequest.AuthTestRequestBuilder> req) throws IOException, SlackApiException;
+    AuthTestResponse authTest(RequestConfigurator<AuthTestRequest.AuthTestRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // bots
@@ -224,7 +224,7 @@ public interface MethodsClient {
 
     BotsInfoResponse botsInfo(BotsInfoRequest req) throws IOException, SlackApiException;
 
-    BotsInfoResponse botsInfo(RequestBuilder<BotsInfoRequest, BotsInfoRequest.BotsInfoRequestBuilder> req) throws IOException, SlackApiException;
+    BotsInfoResponse botsInfo(RequestConfigurator<BotsInfoRequest.BotsInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // channels
@@ -232,63 +232,63 @@ public interface MethodsClient {
 
     ChannelsArchiveResponse channelsArchive(ChannelsArchiveRequest req) throws IOException, SlackApiException;
 
-    ChannelsArchiveResponse channelsArchive(RequestBuilder<ChannelsArchiveRequest, ChannelsArchiveRequest.ChannelsArchiveRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsArchiveResponse channelsArchive(RequestConfigurator<ChannelsArchiveRequest.ChannelsArchiveRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsCreateResponse channelsCreate(ChannelsCreateRequest req) throws IOException, SlackApiException;
 
-    ChannelsCreateResponse channelsCreate(RequestBuilder<ChannelsCreateRequest, ChannelsCreateRequest.ChannelsCreateRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsCreateResponse channelsCreate(RequestConfigurator<ChannelsCreateRequest.ChannelsCreateRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsHistoryResponse channelsHistory(ChannelsHistoryRequest req) throws IOException, SlackApiException;
 
-    ChannelsHistoryResponse channelsHistory(RequestBuilder<ChannelsHistoryRequest, ChannelsHistoryRequest.ChannelsHistoryRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsHistoryResponse channelsHistory(RequestConfigurator<ChannelsHistoryRequest.ChannelsHistoryRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsRepliesResponse channelsReplies(ChannelsRepliesRequest req) throws IOException, SlackApiException;
 
-    ChannelsRepliesResponse channelsReplies(RequestBuilder<ChannelsRepliesRequest, ChannelsRepliesRequest.ChannelsRepliesRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsRepliesResponse channelsReplies(RequestConfigurator<ChannelsRepliesRequest.ChannelsRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsInfoResponse channelsInfo(ChannelsInfoRequest req) throws IOException, SlackApiException;
 
-    ChannelsInfoResponse channelsInfo(RequestBuilder<ChannelsInfoRequest, ChannelsInfoRequest.ChannelsInfoRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsInfoResponse channelsInfo(RequestConfigurator<ChannelsInfoRequest.ChannelsInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsListResponse channelsList(ChannelsListRequest req) throws IOException, SlackApiException;
 
-    ChannelsListResponse channelsList(RequestBuilder<ChannelsListRequest, ChannelsListRequest.ChannelsListRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsListResponse channelsList(RequestConfigurator<ChannelsListRequest.ChannelsListRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsInviteResponse channelsInvite(ChannelsInviteRequest req) throws IOException, SlackApiException;
 
-    ChannelsInviteResponse channelsInvite(RequestBuilder<ChannelsInviteRequest, ChannelsInviteRequest.ChannelsInviteRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsInviteResponse channelsInvite(RequestConfigurator<ChannelsInviteRequest.ChannelsInviteRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsJoinResponse channelsJoin(ChannelsJoinRequest req) throws IOException, SlackApiException;
 
-    ChannelsJoinResponse channelsJoin(RequestBuilder<ChannelsJoinRequest, ChannelsJoinRequest.ChannelsJoinRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsJoinResponse channelsJoin(RequestConfigurator<ChannelsJoinRequest.ChannelsJoinRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsKickResponse channelsKick(ChannelsKickRequest req) throws IOException, SlackApiException;
 
-    ChannelsKickResponse channelsKick(RequestBuilder<ChannelsKickRequest, ChannelsKickRequest.ChannelsKickRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsKickResponse channelsKick(RequestConfigurator<ChannelsKickRequest.ChannelsKickRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsLeaveResponse channelsLeave(ChannelsLeaveRequest req) throws IOException, SlackApiException;
 
-    ChannelsLeaveResponse channelsLeave(RequestBuilder<ChannelsLeaveRequest, ChannelsLeaveRequest.ChannelsLeaveRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsLeaveResponse channelsLeave(RequestConfigurator<ChannelsLeaveRequest.ChannelsLeaveRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsMarkResponse channelsMark(ChannelsMarkRequest req) throws IOException, SlackApiException;
 
-    ChannelsMarkResponse channelsMark(RequestBuilder<ChannelsMarkRequest, ChannelsMarkRequest.ChannelsMarkRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsMarkResponse channelsMark(RequestConfigurator<ChannelsMarkRequest.ChannelsMarkRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsRenameResponse channelsRename(ChannelsRenameRequest req) throws IOException, SlackApiException;
 
-    ChannelsRenameResponse channelsRename(RequestBuilder<ChannelsRenameRequest, ChannelsRenameRequest.ChannelsRenameRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsRenameResponse channelsRename(RequestConfigurator<ChannelsRenameRequest.ChannelsRenameRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsSetPurposeResponse channelsSetPurpose(ChannelsSetPurposeRequest req) throws IOException, SlackApiException;
 
-    ChannelsSetPurposeResponse channelsSetPurpose(RequestBuilder<ChannelsSetPurposeRequest, ChannelsSetPurposeRequest.ChannelsSetPurposeRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsSetPurposeResponse channelsSetPurpose(RequestConfigurator<ChannelsSetPurposeRequest.ChannelsSetPurposeRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsSetTopicResponse channelsSetTopic(ChannelsSetTopicRequest req) throws IOException, SlackApiException;
 
-    ChannelsSetTopicResponse channelsSetTopic(RequestBuilder<ChannelsSetTopicRequest, ChannelsSetTopicRequest.ChannelsSetTopicRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsSetTopicResponse channelsSetTopic(RequestConfigurator<ChannelsSetTopicRequest.ChannelsSetTopicRequestBuilder> req) throws IOException, SlackApiException;
 
     ChannelsUnarchiveResponse channelsUnarchive(ChannelsUnarchiveRequest req) throws IOException, SlackApiException;
 
-    ChannelsUnarchiveResponse channelsUnarchive(RequestBuilder<ChannelsUnarchiveRequest, ChannelsUnarchiveRequest.ChannelsUnarchiveRequestBuilder> req) throws IOException, SlackApiException;
+    ChannelsUnarchiveResponse channelsUnarchive(RequestConfigurator<ChannelsUnarchiveRequest.ChannelsUnarchiveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // chat
@@ -296,39 +296,39 @@ public interface MethodsClient {
 
     ChatGetPermalinkResponse chatGetPermalink(ChatGetPermalinkRequest req) throws IOException, SlackApiException;
 
-    ChatGetPermalinkResponse chatGetPermalink(RequestBuilder<ChatGetPermalinkRequest, ChatGetPermalinkRequest.ChatGetPermalinkRequestBuilder> req) throws IOException, SlackApiException;
+    ChatGetPermalinkResponse chatGetPermalink(RequestConfigurator<ChatGetPermalinkRequest.ChatGetPermalinkRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatDeleteResponse chatDelete(ChatDeleteRequest req) throws IOException, SlackApiException;
 
-    ChatDeleteResponse chatDelete(RequestBuilder<ChatDeleteRequest, ChatDeleteRequest.ChatDeleteRequestBuilder> req) throws IOException, SlackApiException;
+    ChatDeleteResponse chatDelete(RequestConfigurator<ChatDeleteRequest.ChatDeleteRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatDeleteScheduledMessageResponse chatDeleteScheduledMessage(ChatDeleteScheduledMessageRequest req) throws IOException, SlackApiException;
 
-    ChatDeleteScheduledMessageResponse chatDeleteScheduledMessage(RequestBuilder<ChatDeleteScheduledMessageRequest, ChatDeleteScheduledMessageRequest.ChatDeleteScheduledMessageRequestBuilder> req) throws IOException, SlackApiException;
+    ChatDeleteScheduledMessageResponse chatDeleteScheduledMessage(RequestConfigurator<ChatDeleteScheduledMessageRequest.ChatDeleteScheduledMessageRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatMeMessageResponse chatMeMessage(ChatMeMessageRequest req) throws IOException, SlackApiException;
 
-    ChatMeMessageResponse chatMeMessage(RequestBuilder<ChatMeMessageRequest, ChatMeMessageRequest.ChatMeMessageRequestBuilder> req) throws IOException, SlackApiException;
+    ChatMeMessageResponse chatMeMessage(RequestConfigurator<ChatMeMessageRequest.ChatMeMessageRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatPostEphemeralResponse chatPostEphemeral(ChatPostEphemeralRequest req) throws IOException, SlackApiException;
 
-    ChatPostEphemeralResponse chatPostEphemeral(RequestBuilder<ChatPostEphemeralRequest, ChatPostEphemeralRequest.ChatPostEphemeralRequestBuilder> req) throws IOException, SlackApiException;
+    ChatPostEphemeralResponse chatPostEphemeral(RequestConfigurator<ChatPostEphemeralRequest.ChatPostEphemeralRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest req) throws IOException, SlackApiException;
 
-    ChatPostMessageResponse chatPostMessage(RequestBuilder<ChatPostMessageRequest, ChatPostMessageRequest.ChatPostMessageRequestBuilder> req) throws IOException, SlackApiException;
+    ChatPostMessageResponse chatPostMessage(RequestConfigurator<ChatPostMessageRequest.ChatPostMessageRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatScheduleMessageResponse chatScheduleMessage(ChatScheduleMessageRequest req) throws IOException, SlackApiException;
 
-    ChatScheduleMessageResponse chatScheduleMessage(RequestBuilder<ChatScheduleMessageRequest, ChatScheduleMessageRequest.ChatScheduleMessageRequestBuilder> req) throws IOException, SlackApiException;
+    ChatScheduleMessageResponse chatScheduleMessage(RequestConfigurator<ChatScheduleMessageRequest.ChatScheduleMessageRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatUpdateResponse chatUpdate(ChatUpdateRequest req) throws IOException, SlackApiException;
 
-    ChatUpdateResponse chatUpdate(RequestBuilder<ChatUpdateRequest, ChatUpdateRequest.ChatUpdateRequestBuilder> req) throws IOException, SlackApiException;
+    ChatUpdateResponse chatUpdate(RequestConfigurator<ChatUpdateRequest.ChatUpdateRequestBuilder> req) throws IOException, SlackApiException;
 
     ChatUnfurlResponse chatUnfurl(ChatUnfurlRequest req) throws IOException, SlackApiException;
 
-    ChatUnfurlResponse chatUnfurl(RequestBuilder<ChatUnfurlRequest, ChatUnfurlRequest.ChatUnfurlRequestBuilder> req) throws IOException, SlackApiException;
+    ChatUnfurlResponse chatUnfurl(RequestConfigurator<ChatUnfurlRequest.ChatUnfurlRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // chat.scheduledMessages
@@ -336,7 +336,7 @@ public interface MethodsClient {
 
     ChatScheduleMessagesListResponse chatScheduleMessagesListMessage(ChatScheduleMessagesListRequest req) throws IOException, SlackApiException;
 
-    ChatScheduleMessagesListResponse chatScheduleMessagesListMessage(RequestBuilder<ChatScheduleMessagesListRequest, ChatScheduleMessagesListRequest.ChatScheduleMessagesListRequestBuilder> req) throws IOException, SlackApiException;
+    ChatScheduleMessagesListResponse chatScheduleMessagesListMessage(RequestConfigurator<ChatScheduleMessagesListRequest.ChatScheduleMessagesListRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // conversations
@@ -344,71 +344,71 @@ public interface MethodsClient {
 
     ConversationsArchiveResponse conversationsArchive(ConversationsArchiveRequest req) throws IOException, SlackApiException;
 
-    ConversationsArchiveResponse conversationsArchive(RequestBuilder<ConversationsArchiveRequest, ConversationsArchiveRequest.ConversationsArchiveRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsArchiveResponse conversationsArchive(RequestConfigurator<ConversationsArchiveRequest.ConversationsArchiveRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsCloseResponse conversationsClose(ConversationsCloseRequest req) throws IOException, SlackApiException;
 
-    ConversationsCloseResponse conversationsClose(RequestBuilder<ConversationsCloseRequest, ConversationsCloseRequest.ConversationsCloseRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsCloseResponse conversationsClose(RequestConfigurator<ConversationsCloseRequest.ConversationsCloseRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsCreateResponse conversationsCreate(ConversationsCreateRequest req) throws IOException, SlackApiException;
 
-    ConversationsCreateResponse conversationsCreate(RequestBuilder<ConversationsCreateRequest, ConversationsCreateRequest.ConversationsCreateRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsCreateResponse conversationsCreate(RequestConfigurator<ConversationsCreateRequest.ConversationsCreateRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsHistoryResponse conversationsHistory(ConversationsHistoryRequest req) throws IOException, SlackApiException;
 
-    ConversationsHistoryResponse conversationsHistory(RequestBuilder<ConversationsHistoryRequest, ConversationsHistoryRequest.ConversationsHistoryRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsHistoryResponse conversationsHistory(RequestConfigurator<ConversationsHistoryRequest.ConversationsHistoryRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsInfoResponse conversationsInfo(ConversationsInfoRequest req) throws IOException, SlackApiException;
 
-    ConversationsInfoResponse conversationsInfo(RequestBuilder<ConversationsInfoRequest, ConversationsInfoRequest.ConversationsInfoRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsInfoResponse conversationsInfo(RequestConfigurator<ConversationsInfoRequest.ConversationsInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsInviteResponse conversationsInvite(ConversationsInviteRequest req) throws IOException, SlackApiException;
 
-    ConversationsInviteResponse conversationsInvite(RequestBuilder<ConversationsInviteRequest, ConversationsInviteRequest.ConversationsInviteRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsInviteResponse conversationsInvite(RequestConfigurator<ConversationsInviteRequest.ConversationsInviteRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsJoinResponse conversationsJoin(ConversationsJoinRequest req) throws IOException, SlackApiException;
 
-    ConversationsJoinResponse conversationsJoin(RequestBuilder<ConversationsJoinRequest, ConversationsJoinRequest.ConversationsJoinRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsJoinResponse conversationsJoin(RequestConfigurator<ConversationsJoinRequest.ConversationsJoinRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsKickResponse conversationsKick(ConversationsKickRequest req) throws IOException, SlackApiException;
 
-    ConversationsKickResponse conversationsKick(RequestBuilder<ConversationsKickRequest, ConversationsKickRequest.ConversationsKickRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsKickResponse conversationsKick(RequestConfigurator<ConversationsKickRequest.ConversationsKickRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsLeaveResponse conversationsLeave(ConversationsLeaveRequest req) throws IOException, SlackApiException;
 
-    ConversationsLeaveResponse conversationsLeave(RequestBuilder<ConversationsLeaveRequest, ConversationsLeaveRequest.ConversationsLeaveRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsLeaveResponse conversationsLeave(RequestConfigurator<ConversationsLeaveRequest.ConversationsLeaveRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsListResponse conversationsList(ConversationsListRequest req) throws IOException, SlackApiException;
 
-    ConversationsListResponse conversationsList(RequestBuilder<ConversationsListRequest, ConversationsListRequest.ConversationsListRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsListResponse conversationsList(RequestConfigurator<ConversationsListRequest.ConversationsListRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsMembersResponse conversationsMembers(ConversationsMembersRequest req) throws IOException, SlackApiException;
 
-    ConversationsMembersResponse conversationsMembers(RequestBuilder<ConversationsMembersRequest, ConversationsMembersRequest.ConversationsMembersRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsMembersResponse conversationsMembers(RequestConfigurator<ConversationsMembersRequest.ConversationsMembersRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsOpenResponse conversationsOpen(ConversationsOpenRequest req) throws IOException, SlackApiException;
 
-    ConversationsOpenResponse conversationsOpen(RequestBuilder<ConversationsOpenRequest, ConversationsOpenRequest.ConversationsOpenRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsOpenResponse conversationsOpen(RequestConfigurator<ConversationsOpenRequest.ConversationsOpenRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsRenameResponse conversationsRename(ConversationsRenameRequest req) throws IOException, SlackApiException;
 
-    ConversationsRenameResponse conversationsRename(RequestBuilder<ConversationsRenameRequest, ConversationsRenameRequest.ConversationsRenameRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsRenameResponse conversationsRename(RequestConfigurator<ConversationsRenameRequest.ConversationsRenameRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsRepliesResponse conversationsReplies(ConversationsRepliesRequest req) throws IOException, SlackApiException;
 
-    ConversationsRepliesResponse conversationsReplies(RequestBuilder<ConversationsRepliesRequest, ConversationsRepliesRequest.ConversationsRepliesRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsRepliesResponse conversationsReplies(RequestConfigurator<ConversationsRepliesRequest.ConversationsRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsSetPurposeResponse conversationsSetPurpose(ConversationsSetPurposeRequest req) throws IOException, SlackApiException;
 
-    ConversationsSetPurposeResponse conversationsSetPurpose(RequestBuilder<ConversationsSetPurposeRequest, ConversationsSetPurposeRequest.ConversationsSetPurposeRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsSetPurposeResponse conversationsSetPurpose(RequestConfigurator<ConversationsSetPurposeRequest.ConversationsSetPurposeRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsSetTopicResponse conversationsSetTopic(ConversationsSetTopicRequest req) throws IOException, SlackApiException;
 
-    ConversationsSetTopicResponse conversationsSetTopic(RequestBuilder<ConversationsSetTopicRequest, ConversationsSetTopicRequest.ConversationsSetTopicRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsSetTopicResponse conversationsSetTopic(RequestConfigurator<ConversationsSetTopicRequest.ConversationsSetTopicRequestBuilder> req) throws IOException, SlackApiException;
 
     ConversationsUnarchiveResponse conversationsUnarchive(ConversationsUnarchiveRequest req) throws IOException, SlackApiException;
 
-    ConversationsUnarchiveResponse conversationsUnarchive(RequestBuilder<ConversationsUnarchiveRequest, ConversationsUnarchiveRequest.ConversationsUnarchiveRequestBuilder> req) throws IOException, SlackApiException;
+    ConversationsUnarchiveResponse conversationsUnarchive(RequestConfigurator<ConversationsUnarchiveRequest.ConversationsUnarchiveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // dialog
@@ -416,7 +416,7 @@ public interface MethodsClient {
 
     DialogOpenResponse dialogOpen(DialogOpenRequest req) throws IOException, SlackApiException;
 
-    DialogOpenResponse dialogOpen(RequestBuilder<DialogOpenRequest, DialogOpenRequest.DialogOpenRequestBuilder> req) throws IOException, SlackApiException;
+    DialogOpenResponse dialogOpen(RequestConfigurator<DialogOpenRequest.DialogOpenRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // dnd
@@ -424,23 +424,23 @@ public interface MethodsClient {
 
     DndEndDndResponse dndEndDnd(DndEndDndRequest req) throws IOException, SlackApiException;
 
-    DndEndDndResponse dndEndDnd(RequestBuilder<DndEndDndRequest, DndEndDndRequest.DndEndDndRequestBuilder> req) throws IOException, SlackApiException;
+    DndEndDndResponse dndEndDnd(RequestConfigurator<DndEndDndRequest.DndEndDndRequestBuilder> req) throws IOException, SlackApiException;
 
     DndEndSnoozeResponse dndEndSnooze(DndEndSnoozeRequest req) throws IOException, SlackApiException;
 
-    DndEndSnoozeResponse dndEndSnooze(RequestBuilder<DndEndSnoozeRequest, DndEndSnoozeRequest.DndEndSnoozeRequestBuilder> req) throws IOException, SlackApiException;
+    DndEndSnoozeResponse dndEndSnooze(RequestConfigurator<DndEndSnoozeRequest.DndEndSnoozeRequestBuilder> req) throws IOException, SlackApiException;
 
     DndInfoResponse dndInfo(DndInfoRequest req) throws IOException, SlackApiException;
 
-    DndInfoResponse dndInfo(RequestBuilder<DndInfoRequest, DndInfoRequest.DndInfoRequestBuilder> req) throws IOException, SlackApiException;
+    DndInfoResponse dndInfo(RequestConfigurator<DndInfoRequest.DndInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     DndSetSnoozeResponse dndSetSnooze(DndSetSnoozeRequest req) throws IOException, SlackApiException;
 
-    DndSetSnoozeResponse dndSetSnooze(RequestBuilder<DndSetSnoozeRequest, DndSetSnoozeRequest.DndSetSnoozeRequestBuilder> req) throws IOException, SlackApiException;
+    DndSetSnoozeResponse dndSetSnooze(RequestConfigurator<DndSetSnoozeRequest.DndSetSnoozeRequestBuilder> req) throws IOException, SlackApiException;
 
     DndTeamInfoResponse dndTeamInfo(DndTeamInfoRequest req) throws IOException, SlackApiException;
 
-    DndTeamInfoResponse dndTeamInfo(RequestBuilder<DndTeamInfoRequest, DndTeamInfoRequest.DndTeamInfoRequestBuilder> req) throws IOException, SlackApiException;
+    DndTeamInfoResponse dndTeamInfo(RequestConfigurator<DndTeamInfoRequest.DndTeamInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // emoji
@@ -448,7 +448,7 @@ public interface MethodsClient {
 
     EmojiListResponse emojiList(EmojiListRequest req) throws IOException, SlackApiException;
 
-    EmojiListResponse emojiList(RequestBuilder<EmojiListRequest, EmojiListRequest.EmojiListRequestBuilder> req) throws IOException, SlackApiException;
+    EmojiListResponse emojiList(RequestConfigurator<EmojiListRequest.EmojiListRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // files
@@ -456,27 +456,27 @@ public interface MethodsClient {
 
     FilesDeleteResponse filesDelete(FilesDeleteRequest req) throws IOException, SlackApiException;
 
-    FilesDeleteResponse filesDelete(RequestBuilder<FilesDeleteRequest, FilesDeleteRequest.FilesDeleteRequestBuilder> req) throws IOException, SlackApiException;
+    FilesDeleteResponse filesDelete(RequestConfigurator<FilesDeleteRequest.FilesDeleteRequestBuilder> req) throws IOException, SlackApiException;
 
     FilesInfoResponse filesInfo(FilesInfoRequest req) throws IOException, SlackApiException;
 
-    FilesInfoResponse filesInfo(RequestBuilder<FilesInfoRequest, FilesInfoRequest.FilesInfoRequestBuilder> req) throws IOException, SlackApiException;
+    FilesInfoResponse filesInfo(RequestConfigurator<FilesInfoRequest.FilesInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     FilesListResponse filesList(FilesListRequest req) throws IOException, SlackApiException;
 
-    FilesListResponse filesList(RequestBuilder<FilesListRequest, FilesListRequest.FilesListRequestBuilder> req) throws IOException, SlackApiException;
+    FilesListResponse filesList(RequestConfigurator<FilesListRequest.FilesListRequestBuilder> req) throws IOException, SlackApiException;
 
     FilesRevokePublicURLResponse filesRevokePublicURL(FilesRevokePublicURLRequest req) throws IOException, SlackApiException;
 
-    FilesRevokePublicURLResponse filesRevokePublicURL(RequestBuilder<FilesRevokePublicURLRequest, FilesRevokePublicURLRequest.FilesRevokePublicURLRequestBuilder> req) throws IOException, SlackApiException;
+    FilesRevokePublicURLResponse filesRevokePublicURL(RequestConfigurator<FilesRevokePublicURLRequest.FilesRevokePublicURLRequestBuilder> req) throws IOException, SlackApiException;
 
     FilesSharedPublicURLResponse filesSharedPublicURL(FilesSharedPublicURLRequest req) throws IOException, SlackApiException;
 
-    FilesSharedPublicURLResponse filesSharedPublicURL(RequestBuilder<FilesSharedPublicURLRequest, FilesSharedPublicURLRequest.FilesSharedPublicURLRequestBuilder> req) throws IOException, SlackApiException;
+    FilesSharedPublicURLResponse filesSharedPublicURL(RequestConfigurator<FilesSharedPublicURLRequest.FilesSharedPublicURLRequestBuilder> req) throws IOException, SlackApiException;
 
     FilesUploadResponse filesUpload(FilesUploadRequest req) throws IOException, SlackApiException;
 
-    FilesUploadResponse filesUpload(RequestBuilder<FilesUploadRequest, FilesUploadRequest.FilesUploadRequestBuilder> req) throws IOException, SlackApiException;
+    FilesUploadResponse filesUpload(RequestConfigurator<FilesUploadRequest.FilesUploadRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // files.comments
@@ -500,7 +500,7 @@ public interface MethodsClient {
 
     GroupsArchiveResponse groupsArchive(GroupsArchiveRequest req) throws IOException, SlackApiException;
 
-    GroupsArchiveResponse groupsArchive(RequestBuilder<GroupsArchiveRequest, GroupsArchiveRequest.GroupsArchiveRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsArchiveResponse groupsArchive(RequestConfigurator<GroupsArchiveRequest.GroupsArchiveRequestBuilder> req) throws IOException, SlackApiException;
 
     // https://github.com/slackapi/slack-api-specs/issues/12
     @Deprecated
@@ -508,63 +508,63 @@ public interface MethodsClient {
 
     GroupsCreateChildResponse groupsCreateChild(GroupsCreateChildRequest req) throws IOException, SlackApiException;
 
-    GroupsCreateChildResponse groupsCreateChild(RequestBuilder<GroupsCreateChildRequest, GroupsCreateChildRequest.GroupsCreateChildRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsCreateChildResponse groupsCreateChild(RequestConfigurator<GroupsCreateChildRequest.GroupsCreateChildRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsCreateResponse groupsCreate(GroupsCreateRequest req) throws IOException, SlackApiException;
 
-    GroupsCreateResponse groupsCreate(RequestBuilder<GroupsCreateRequest, GroupsCreateRequest.GroupsCreateRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsCreateResponse groupsCreate(RequestConfigurator<GroupsCreateRequest.GroupsCreateRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsHistoryResponse groupsHistory(GroupsHistoryRequest req) throws IOException, SlackApiException;
 
-    GroupsHistoryResponse groupsHistory(RequestBuilder<GroupsHistoryRequest, GroupsHistoryRequest.GroupsHistoryRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsHistoryResponse groupsHistory(RequestConfigurator<GroupsHistoryRequest.GroupsHistoryRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsInfoResponse groupsInfo(GroupsInfoRequest req) throws IOException, SlackApiException;
 
-    GroupsInfoResponse groupsInfo(RequestBuilder<GroupsInfoRequest, GroupsInfoRequest.GroupsInfoRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsInfoResponse groupsInfo(RequestConfigurator<GroupsInfoRequest.GroupsInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsInviteResponse groupsInvite(GroupsInviteRequest req) throws IOException, SlackApiException;
 
-    GroupsInviteResponse groupsInvite(RequestBuilder<GroupsInviteRequest, GroupsInviteRequest.GroupsInviteRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsInviteResponse groupsInvite(RequestConfigurator<GroupsInviteRequest.GroupsInviteRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsKickResponse groupsKick(GroupsKickRequest req) throws IOException, SlackApiException;
 
-    GroupsKickResponse groupsKick(RequestBuilder<GroupsKickRequest, GroupsKickRequest.GroupsKickRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsKickResponse groupsKick(RequestConfigurator<GroupsKickRequest.GroupsKickRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsLeaveResponse groupsLeave(GroupsLeaveRequest req) throws IOException, SlackApiException;
 
-    GroupsLeaveResponse groupsLeave(RequestBuilder<GroupsLeaveRequest, GroupsLeaveRequest.GroupsLeaveRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsLeaveResponse groupsLeave(RequestConfigurator<GroupsLeaveRequest.GroupsLeaveRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsListResponse groupsList(GroupsListRequest req) throws IOException, SlackApiException;
 
-    GroupsListResponse groupsList(RequestBuilder<GroupsListRequest, GroupsListRequest.GroupsListRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsListResponse groupsList(RequestConfigurator<GroupsListRequest.GroupsListRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsMarkResponse groupsMark(GroupsMarkRequest req) throws IOException, SlackApiException;
 
-    GroupsMarkResponse groupsMark(RequestBuilder<GroupsMarkRequest, GroupsMarkRequest.GroupsMarkRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsMarkResponse groupsMark(RequestConfigurator<GroupsMarkRequest.GroupsMarkRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsOpenResponse groupsOpen(GroupsOpenRequest req) throws IOException, SlackApiException;
 
-    GroupsOpenResponse groupsOpen(RequestBuilder<GroupsOpenRequest, GroupsOpenRequest.GroupsOpenRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsOpenResponse groupsOpen(RequestConfigurator<GroupsOpenRequest.GroupsOpenRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsRenameResponse groupsRename(GroupsRenameRequest req) throws IOException, SlackApiException;
 
-    GroupsRenameResponse groupsRename(RequestBuilder<GroupsRenameRequest, GroupsRenameRequest.GroupsRenameRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsRenameResponse groupsRename(RequestConfigurator<GroupsRenameRequest.GroupsRenameRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsSetPurposeResponse groupsSetPurpose(GroupsSetPurposeRequest req) throws IOException, SlackApiException;
 
-    GroupsSetPurposeResponse groupsSetPurpose(RequestBuilder<GroupsSetPurposeRequest, GroupsSetPurposeRequest.GroupsSetPurposeRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsSetPurposeResponse groupsSetPurpose(RequestConfigurator<GroupsSetPurposeRequest.GroupsSetPurposeRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsSetTopicResponse groupsSetTopic(GroupsSetTopicRequest req) throws IOException, SlackApiException;
 
-    GroupsSetTopicResponse groupsSetTopic(RequestBuilder<GroupsSetTopicRequest, GroupsSetTopicRequest.GroupsSetTopicRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsSetTopicResponse groupsSetTopic(RequestConfigurator<GroupsSetTopicRequest.GroupsSetTopicRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsUnarchiveResponse groupsUnarchive(GroupsUnarchiveRequest req) throws IOException, SlackApiException;
 
-    GroupsUnarchiveResponse groupsUnarchive(RequestBuilder<GroupsUnarchiveRequest, GroupsUnarchiveRequest.GroupsUnarchiveRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsUnarchiveResponse groupsUnarchive(RequestConfigurator<GroupsUnarchiveRequest.GroupsUnarchiveRequestBuilder> req) throws IOException, SlackApiException;
 
     GroupsRepliesResponse groupsReplies(GroupsRepliesRequest req) throws IOException, SlackApiException;
 
-    GroupsRepliesResponse groupsReplies(RequestBuilder<GroupsRepliesRequest, GroupsRepliesRequest.GroupsRepliesRequestBuilder> req) throws IOException, SlackApiException;
+    GroupsRepliesResponse groupsReplies(RequestConfigurator<GroupsRepliesRequest.GroupsRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // im
@@ -572,27 +572,27 @@ public interface MethodsClient {
 
     ImCloseResponse imClose(ImCloseRequest req) throws IOException, SlackApiException;
 
-    ImCloseResponse imClose(RequestBuilder<ImCloseRequest, ImCloseRequest.ImCloseRequestBuilder> req) throws IOException, SlackApiException;
+    ImCloseResponse imClose(RequestConfigurator<ImCloseRequest.ImCloseRequestBuilder> req) throws IOException, SlackApiException;
 
     ImHistoryResponse imHistory(ImHistoryRequest req) throws IOException, SlackApiException;
 
-    ImHistoryResponse imHistory(RequestBuilder<ImHistoryRequest, ImHistoryRequest.ImHistoryRequestBuilder> req) throws IOException, SlackApiException;
+    ImHistoryResponse imHistory(RequestConfigurator<ImHistoryRequest.ImHistoryRequestBuilder> req) throws IOException, SlackApiException;
 
     ImListResponse imList(ImListRequest req) throws IOException, SlackApiException;
 
-    ImListResponse imList(RequestBuilder<ImListRequest, ImListRequest.ImListRequestBuilder> req) throws IOException, SlackApiException;
+    ImListResponse imList(RequestConfigurator<ImListRequest.ImListRequestBuilder> req) throws IOException, SlackApiException;
 
     ImMarkResponse imMark(ImMarkRequest req) throws IOException, SlackApiException;
 
-    ImMarkResponse imMark(RequestBuilder<ImMarkRequest, ImMarkRequest.ImMarkRequestBuilder> req) throws IOException, SlackApiException;
+    ImMarkResponse imMark(RequestConfigurator<ImMarkRequest.ImMarkRequestBuilder> req) throws IOException, SlackApiException;
 
     ImOpenResponse imOpen(ImOpenRequest req) throws IOException, SlackApiException;
 
-    ImOpenResponse imOpen(RequestBuilder<ImOpenRequest, ImOpenRequest.ImOpenRequestBuilder> req) throws IOException, SlackApiException;
+    ImOpenResponse imOpen(RequestConfigurator<ImOpenRequest.ImOpenRequestBuilder> req) throws IOException, SlackApiException;
 
     ImRepliesResponse imReplies(ImRepliesRequest req) throws IOException, SlackApiException;
 
-    ImRepliesResponse imReplies(RequestBuilder<ImRepliesRequest, ImRepliesRequest.ImRepliesRequestBuilder> req) throws IOException, SlackApiException;
+    ImRepliesResponse imReplies(RequestConfigurator<ImRepliesRequest.ImRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // migration
@@ -600,7 +600,7 @@ public interface MethodsClient {
 
     MigrationExchangeResponse migrationExchange(MigrationExchangeRequest req) throws IOException, SlackApiException;
 
-    MigrationExchangeResponse migrationExchange(RequestBuilder<MigrationExchangeRequest, MigrationExchangeRequest.MigrationExchangeRequestBuilder> req) throws IOException, SlackApiException;
+    MigrationExchangeResponse migrationExchange(RequestConfigurator<MigrationExchangeRequest.MigrationExchangeRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // mpim
@@ -608,27 +608,27 @@ public interface MethodsClient {
 
     MpimCloseResponse mpimClose(MpimCloseRequest req) throws IOException, SlackApiException;
 
-    MpimCloseResponse mpimClose(RequestBuilder<MpimCloseRequest, MpimCloseRequest.MpimCloseRequestBuilder> req) throws IOException, SlackApiException;
+    MpimCloseResponse mpimClose(RequestConfigurator<MpimCloseRequest.MpimCloseRequestBuilder> req) throws IOException, SlackApiException;
 
     MpimHistoryResponse mpimHistory(MpimHistoryRequest req) throws IOException, SlackApiException;
 
-    MpimHistoryResponse mpimHistory(RequestBuilder<MpimHistoryRequest, MpimHistoryRequest.MpimHistoryRequestBuilder> req) throws IOException, SlackApiException;
+    MpimHistoryResponse mpimHistory(RequestConfigurator<MpimHistoryRequest.MpimHistoryRequestBuilder> req) throws IOException, SlackApiException;
 
     MpimListResponse mpimList(MpimListRequest req) throws IOException, SlackApiException;
 
-    MpimListResponse mpimList(RequestBuilder<MpimListRequest, MpimListRequest.MpimListRequestBuilder> req) throws IOException, SlackApiException;
+    MpimListResponse mpimList(RequestConfigurator<MpimListRequest.MpimListRequestBuilder> req) throws IOException, SlackApiException;
 
     MpimRepliesResponse mpimReplies(MpimRepliesRequest req) throws IOException, SlackApiException;
 
-    MpimRepliesResponse mpimReplies(RequestBuilder<MpimRepliesRequest, MpimRepliesRequest.MpimRepliesRequestBuilder> req) throws IOException, SlackApiException;
+    MpimRepliesResponse mpimReplies(RequestConfigurator<MpimRepliesRequest.MpimRepliesRequestBuilder> req) throws IOException, SlackApiException;
 
     MpimMarkResponse mpimMark(MpimMarkRequest req) throws IOException, SlackApiException;
 
-    MpimMarkResponse mpimMark(RequestBuilder<MpimMarkRequest, MpimMarkRequest.MpimMarkRequestBuilder> req) throws IOException, SlackApiException;
+    MpimMarkResponse mpimMark(RequestConfigurator<MpimMarkRequest.MpimMarkRequestBuilder> req) throws IOException, SlackApiException;
 
     MpimOpenResponse mpimOpen(MpimOpenRequest req) throws IOException, SlackApiException;
 
-    MpimOpenResponse mpimOpen(RequestBuilder<MpimOpenRequest, MpimOpenRequest.MpimOpenRequestBuilder> req) throws IOException, SlackApiException;
+    MpimOpenResponse mpimOpen(RequestConfigurator<MpimOpenRequest.MpimOpenRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // oauth
@@ -636,11 +636,11 @@ public interface MethodsClient {
 
     OAuthAccessResponse oauthAccess(OAuthAccessRequest req) throws IOException, SlackApiException;
 
-    OAuthAccessResponse oauthAccess(RequestBuilder<OAuthAccessRequest, OAuthAccessRequest.OAuthAccessRequestBuilder> req) throws IOException, SlackApiException;
+    OAuthAccessResponse oauthAccess(RequestConfigurator<OAuthAccessRequest.OAuthAccessRequestBuilder> req) throws IOException, SlackApiException;
 
     OAuthTokenResponse oauthToken(OAuthTokenRequest req) throws IOException, SlackApiException;
 
-    OAuthTokenResponse oauthToken(RequestBuilder<OAuthTokenRequest, OAuthTokenRequest.OAuthTokenRequestBuilder> req) throws IOException, SlackApiException;
+    OAuthTokenResponse oauthToken(RequestConfigurator<OAuthTokenRequest.OAuthTokenRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // pins
@@ -648,15 +648,15 @@ public interface MethodsClient {
 
     PinsAddResponse pinsAdd(PinsAddRequest req) throws IOException, SlackApiException;
 
-    PinsAddResponse pinsAdd(RequestBuilder<PinsAddRequest, PinsAddRequest.PinsAddRequestBuilder> req) throws IOException, SlackApiException;
+    PinsAddResponse pinsAdd(RequestConfigurator<PinsAddRequest.PinsAddRequestBuilder> req) throws IOException, SlackApiException;
 
     PinsListResponse pinsList(PinsListRequest req) throws IOException, SlackApiException;
 
-    PinsListResponse pinsList(RequestBuilder<PinsListRequest, PinsListRequest.PinsListRequestBuilder> req) throws IOException, SlackApiException;
+    PinsListResponse pinsList(RequestConfigurator<PinsListRequest.PinsListRequestBuilder> req) throws IOException, SlackApiException;
 
     PinsRemoveResponse pinsRemove(PinsRemoveRequest req) throws IOException, SlackApiException;
 
-    PinsRemoveResponse pinsRemove(RequestBuilder<PinsRemoveRequest, PinsRemoveRequest.PinsRemoveRequestBuilder> req) throws IOException, SlackApiException;
+    PinsRemoveResponse pinsRemove(RequestConfigurator<PinsRemoveRequest.PinsRemoveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // reactions
@@ -664,19 +664,19 @@ public interface MethodsClient {
 
     ReactionsAddResponse reactionsAdd(ReactionsAddRequest req) throws IOException, SlackApiException;
 
-    ReactionsAddResponse reactionsAdd(RequestBuilder<ReactionsAddRequest, ReactionsAddRequest.ReactionsAddRequestBuilder> req) throws IOException, SlackApiException;
+    ReactionsAddResponse reactionsAdd(RequestConfigurator<ReactionsAddRequest.ReactionsAddRequestBuilder> req) throws IOException, SlackApiException;
 
     ReactionsGetResponse reactionsGet(ReactionsGetRequest req) throws IOException, SlackApiException;
 
-    ReactionsGetResponse reactionsGet(RequestBuilder<ReactionsGetRequest, ReactionsGetRequest.ReactionsGetRequestBuilder> req) throws IOException, SlackApiException;
+    ReactionsGetResponse reactionsGet(RequestConfigurator<ReactionsGetRequest.ReactionsGetRequestBuilder> req) throws IOException, SlackApiException;
 
     ReactionsListResponse reactionsList(ReactionsListRequest req) throws IOException, SlackApiException;
 
-    ReactionsListResponse reactionsList(RequestBuilder<ReactionsListRequest, ReactionsListRequest.ReactionsListRequestBuilder> req) throws IOException, SlackApiException;
+    ReactionsListResponse reactionsList(RequestConfigurator<ReactionsListRequest.ReactionsListRequestBuilder> req) throws IOException, SlackApiException;
 
     ReactionsRemoveResponse reactionsRemove(ReactionsRemoveRequest req) throws IOException, SlackApiException;
 
-    ReactionsRemoveResponse reactionsRemove(RequestBuilder<ReactionsRemoveRequest, ReactionsRemoveRequest.ReactionsRemoveRequestBuilder> req) throws IOException, SlackApiException;
+    ReactionsRemoveResponse reactionsRemove(RequestConfigurator<ReactionsRemoveRequest.ReactionsRemoveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // reminders
@@ -684,23 +684,23 @@ public interface MethodsClient {
 
     RemindersAddResponse remindersAdd(RemindersAddRequest req) throws IOException, SlackApiException;
 
-    RemindersAddResponse remindersAdd(RequestBuilder<RemindersAddRequest, RemindersAddRequest.RemindersAddRequestBuilder> req) throws IOException, SlackApiException;
+    RemindersAddResponse remindersAdd(RequestConfigurator<RemindersAddRequest.RemindersAddRequestBuilder> req) throws IOException, SlackApiException;
 
     RemindersCompleteResponse remindersComplete(RemindersCompleteRequest req) throws IOException, SlackApiException;
 
-    RemindersCompleteResponse remindersComplete(RequestBuilder<RemindersCompleteRequest, RemindersCompleteRequest.RemindersCompleteRequestBuilder> req) throws IOException, SlackApiException;
+    RemindersCompleteResponse remindersComplete(RequestConfigurator<RemindersCompleteRequest.RemindersCompleteRequestBuilder> req) throws IOException, SlackApiException;
 
     RemindersDeleteResponse remindersDelete(RemindersDeleteRequest req) throws IOException, SlackApiException;
 
-    RemindersDeleteResponse remindersDelete(RequestBuilder<RemindersDeleteRequest, RemindersDeleteRequest.RemindersDeleteRequestBuilder> req) throws IOException, SlackApiException;
+    RemindersDeleteResponse remindersDelete(RequestConfigurator<RemindersDeleteRequest.RemindersDeleteRequestBuilder> req) throws IOException, SlackApiException;
 
     RemindersInfoResponse remindersInfo(RemindersInfoRequest req) throws IOException, SlackApiException;
 
-    RemindersInfoResponse remindersInfo(RequestBuilder<RemindersInfoRequest, RemindersInfoRequest.RemindersInfoRequestBuilder> req) throws IOException, SlackApiException;
+    RemindersInfoResponse remindersInfo(RequestConfigurator<RemindersInfoRequest.RemindersInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     RemindersListResponse remindersList(RemindersListRequest req) throws IOException, SlackApiException;
 
-    RemindersListResponse remindersList(RequestBuilder<RemindersListRequest, RemindersListRequest.RemindersListRequestBuilder> req) throws IOException, SlackApiException;
+    RemindersListResponse remindersList(RequestConfigurator<RemindersListRequest.RemindersListRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // rtm
@@ -708,11 +708,11 @@ public interface MethodsClient {
 
     RTMConnectResponse rtmConnect(RTMConnectRequest req) throws IOException, SlackApiException;
 
-    RTMConnectResponse rtmConnect(RequestBuilder<RTMConnectRequest, RTMConnectRequest.RTMConnectRequestBuilder> req) throws IOException, SlackApiException;
+    RTMConnectResponse rtmConnect(RequestConfigurator<RTMConnectRequest.RTMConnectRequestBuilder> req) throws IOException, SlackApiException;
 
     RTMStartResponse rtmStart(RTMStartRequest req) throws IOException, SlackApiException;
 
-    RTMStartResponse rtmStart(RequestBuilder<RTMStartRequest, RTMStartRequest.RTMStartRequestBuilder> req) throws IOException, SlackApiException;
+    RTMStartResponse rtmStart(RequestConfigurator<RTMStartRequest.RTMStartRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // search
@@ -720,15 +720,15 @@ public interface MethodsClient {
 
     SearchAllResponse searchAll(SearchAllRequest req) throws IOException, SlackApiException;
 
-    SearchAllResponse searchAll(RequestBuilder<SearchAllRequest, SearchAllRequest.SearchAllRequestBuilder> req) throws IOException, SlackApiException;
+    SearchAllResponse searchAll(RequestConfigurator<SearchAllRequest.SearchAllRequestBuilder> req) throws IOException, SlackApiException;
 
     SearchMessagesResponse searchMessages(SearchMessagesRequest req) throws IOException, SlackApiException;
 
-    SearchMessagesResponse searchMessages(RequestBuilder<SearchMessagesRequest, SearchMessagesRequest.SearchMessagesRequestBuilder> req) throws IOException, SlackApiException;
+    SearchMessagesResponse searchMessages(RequestConfigurator<SearchMessagesRequest.SearchMessagesRequestBuilder> req) throws IOException, SlackApiException;
 
     SearchFilesResponse searchFiles(SearchFilesRequest req) throws IOException, SlackApiException;
 
-    SearchFilesResponse searchFiles(RequestBuilder<SearchFilesRequest, SearchFilesRequest.SearchFilesRequestBuilder> req) throws IOException, SlackApiException;
+    SearchFilesResponse searchFiles(RequestConfigurator<SearchFilesRequest.SearchFilesRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // stars
@@ -736,15 +736,15 @@ public interface MethodsClient {
 
     StarsAddResponse starsAdd(StarsAddRequest req) throws IOException, SlackApiException;
 
-    StarsAddResponse starsAdd(RequestBuilder<StarsAddRequest, StarsAddRequest.StarsAddRequestBuilder> req) throws IOException, SlackApiException;
+    StarsAddResponse starsAdd(RequestConfigurator<StarsAddRequest.StarsAddRequestBuilder> req) throws IOException, SlackApiException;
 
     StarsListResponse starsList(StarsListRequest req) throws IOException, SlackApiException;
 
-    StarsListResponse starsList(RequestBuilder<StarsListRequest, StarsListRequest.StarsListRequestBuilder> req) throws IOException, SlackApiException;
+    StarsListResponse starsList(RequestConfigurator<StarsListRequest.StarsListRequestBuilder> req) throws IOException, SlackApiException;
 
     StarsRemoveResponse starsRemove(StarsRemoveRequest req) throws IOException, SlackApiException;
 
-    StarsRemoveResponse starsRemove(RequestBuilder<StarsRemoveRequest, StarsRemoveRequest.StarsRemoveRequestBuilder> req) throws IOException, SlackApiException;
+    StarsRemoveResponse starsRemove(RequestConfigurator<StarsRemoveRequest.StarsRemoveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // team
@@ -752,23 +752,23 @@ public interface MethodsClient {
 
     TeamAccessLogsResponse teamAccessLogs(TeamAccessLogsRequest req) throws IOException, SlackApiException;
 
-    TeamAccessLogsResponse teamAccessLogs(RequestBuilder<TeamAccessLogsRequest, TeamAccessLogsRequest.TeamAccessLogsRequestBuilder> req) throws IOException, SlackApiException;
+    TeamAccessLogsResponse teamAccessLogs(RequestConfigurator<TeamAccessLogsRequest.TeamAccessLogsRequestBuilder> req) throws IOException, SlackApiException;
 
     TeamBillableInfoResponse teamBillableInfo(TeamBillableInfoRequest req) throws IOException, SlackApiException;
 
-    TeamBillableInfoResponse teamBillableInfo(RequestBuilder<TeamBillableInfoRequest, TeamBillableInfoRequest.TeamBillableInfoRequestBuilder> req) throws IOException, SlackApiException;
+    TeamBillableInfoResponse teamBillableInfo(RequestConfigurator<TeamBillableInfoRequest.TeamBillableInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     TeamInfoResponse teamInfo(TeamInfoRequest req) throws IOException, SlackApiException;
 
-    TeamInfoResponse teamInfo(RequestBuilder<TeamInfoRequest, TeamInfoRequest.TeamInfoRequestBuilder> req) throws IOException, SlackApiException;
+    TeamInfoResponse teamInfo(RequestConfigurator<TeamInfoRequest.TeamInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     TeamIntegrationLogsResponse teamIntegrationLogs(TeamIntegrationLogsRequest req) throws IOException, SlackApiException;
 
-    TeamIntegrationLogsResponse teamIntegrationLogs(RequestBuilder<TeamIntegrationLogsRequest, TeamIntegrationLogsRequest.TeamIntegrationLogsRequestBuilder> req) throws IOException, SlackApiException;
+    TeamIntegrationLogsResponse teamIntegrationLogs(RequestConfigurator<TeamIntegrationLogsRequest.TeamIntegrationLogsRequestBuilder> req) throws IOException, SlackApiException;
 
     TeamProfileGetResponse teamProfileGet(TeamProfileGetRequest req) throws IOException, SlackApiException;
 
-    TeamProfileGetResponse teamProfileGet(RequestBuilder<TeamProfileGetRequest, TeamProfileGetRequest.TeamProfileGetRequestBuilder> req) throws IOException, SlackApiException;
+    TeamProfileGetResponse teamProfileGet(RequestConfigurator<TeamProfileGetRequest.TeamProfileGetRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // usergroups
@@ -776,31 +776,31 @@ public interface MethodsClient {
 
     UsergroupsCreateResponse usergroupsCreate(UsergroupsCreateRequest req) throws IOException, SlackApiException;
 
-    UsergroupsCreateResponse usergroupsCreate(RequestBuilder<UsergroupsCreateRequest, UsergroupsCreateRequest.UsergroupsCreateRequestBuilder> req) throws IOException, SlackApiException;
+    UsergroupsCreateResponse usergroupsCreate(RequestConfigurator<UsergroupsCreateRequest.UsergroupsCreateRequestBuilder> req) throws IOException, SlackApiException;
 
     UsergroupsDisableResponse usergroupsDisable(UsergroupsDisableRequest req) throws IOException, SlackApiException;
 
-    UsergroupsDisableResponse usergroupsDisable(RequestBuilder<UsergroupsDisableRequest, UsergroupsDisableRequest.UsergroupsDisableRequestBuilder> req) throws IOException, SlackApiException;
+    UsergroupsDisableResponse usergroupsDisable(RequestConfigurator<UsergroupsDisableRequest.UsergroupsDisableRequestBuilder> req) throws IOException, SlackApiException;
 
     UsergroupsEnableResponse usergroupsEnable(UsergroupsEnableRequest req) throws IOException, SlackApiException;
 
-    UsergroupsEnableResponse usergroupsEnable(RequestBuilder<UsergroupsEnableRequest, UsergroupsEnableRequest.UsergroupsEnableRequestBuilder> req) throws IOException, SlackApiException;
+    UsergroupsEnableResponse usergroupsEnable(RequestConfigurator<UsergroupsEnableRequest.UsergroupsEnableRequestBuilder> req) throws IOException, SlackApiException;
 
     UsergroupsListResponse usergroupsList(UsergroupsListRequest req) throws IOException, SlackApiException;
 
-    UsergroupsListResponse usergroupsList(RequestBuilder<UsergroupsListRequest, UsergroupsListRequest.UsergroupsListRequestBuilder> req) throws IOException, SlackApiException;
+    UsergroupsListResponse usergroupsList(RequestConfigurator<UsergroupsListRequest.UsergroupsListRequestBuilder> req) throws IOException, SlackApiException;
 
     UsergroupsUpdateResponse usergroupsUpdate(UsergroupsUpdateRequest req) throws IOException, SlackApiException;
 
-    UsergroupsUpdateResponse usergroupsUpdate(RequestBuilder<UsergroupsUpdateRequest, UsergroupsUpdateRequest.UsergroupsUpdateRequestBuilder> req) throws IOException, SlackApiException;
+    UsergroupsUpdateResponse usergroupsUpdate(RequestConfigurator<UsergroupsUpdateRequest.UsergroupsUpdateRequestBuilder> req) throws IOException, SlackApiException;
 
     UsergroupUsersListResponse usergroupUsersList(UsergroupUsersListRequest req) throws IOException, SlackApiException;
 
-    UsergroupUsersListResponse usergroupUsersList(RequestBuilder<UsergroupUsersListRequest, UsergroupUsersListRequest.UsergroupUsersListRequestBuilder> req) throws IOException, SlackApiException;
+    UsergroupUsersListResponse usergroupUsersList(RequestConfigurator<UsergroupUsersListRequest.UsergroupUsersListRequestBuilder> req) throws IOException, SlackApiException;
 
     UsergroupUsersUpdateResponse usergroupUsersUpdate(UsergroupUsersUpdateRequest req) throws IOException, SlackApiException;
 
-    UsergroupUsersUpdateResponse usergroupUsersUpdate(RequestBuilder<UsergroupUsersUpdateRequest, UsergroupUsersUpdateRequest.UsergroupUsersUpdateRequestBuilder> req) throws IOException, SlackApiException;
+    UsergroupUsersUpdateResponse usergroupUsersUpdate(RequestConfigurator<UsergroupUsersUpdateRequest.UsergroupUsersUpdateRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // users
@@ -808,43 +808,43 @@ public interface MethodsClient {
 
     UsersConversationsResponse usersConversations(UsersConversationsRequest req) throws IOException, SlackApiException;
 
-    UsersConversationsResponse usersConversations(RequestBuilder<UsersConversationsRequest, UsersConversationsRequest.UsersConversationsRequestBuilder> req) throws IOException, SlackApiException;
+    UsersConversationsResponse usersConversations(RequestConfigurator<UsersConversationsRequest.UsersConversationsRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersDeletePhotoResponse usersDeletePhoto(UsersDeletePhotoRequest req) throws IOException, SlackApiException;
 
-    UsersDeletePhotoResponse usersDeletePhoto(RequestBuilder<UsersDeletePhotoRequest, UsersDeletePhotoRequest.UsersDeletePhotoRequestBuilder> req) throws IOException, SlackApiException;
+    UsersDeletePhotoResponse usersDeletePhoto(RequestConfigurator<UsersDeletePhotoRequest.UsersDeletePhotoRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersGetPresenceResponse usersGetPresence(UsersGetPresenceRequest req) throws IOException, SlackApiException;
 
-    UsersGetPresenceResponse usersGetPresence(RequestBuilder<UsersGetPresenceRequest, UsersGetPresenceRequest.UsersGetPresenceRequestBuilder> req) throws IOException, SlackApiException;
+    UsersGetPresenceResponse usersGetPresence(RequestConfigurator<UsersGetPresenceRequest.UsersGetPresenceRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersIdentityResponse usersIdentity(UsersIdentityRequest req) throws IOException, SlackApiException;
 
-    UsersIdentityResponse usersIdentity(RequestBuilder<UsersIdentityRequest, UsersIdentityRequest.UsersIdentityRequestBuilder> req) throws IOException, SlackApiException;
+    UsersIdentityResponse usersIdentity(RequestConfigurator<UsersIdentityRequest.UsersIdentityRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersInfoResponse usersInfo(UsersInfoRequest req) throws IOException, SlackApiException;
 
-    UsersInfoResponse usersInfo(RequestBuilder<UsersInfoRequest, UsersInfoRequest.UsersInfoRequestBuilder> req) throws IOException, SlackApiException;
+    UsersInfoResponse usersInfo(RequestConfigurator<UsersInfoRequest.UsersInfoRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersListResponse usersList(UsersListRequest req) throws IOException, SlackApiException;
 
-    UsersListResponse usersList(RequestBuilder<UsersListRequest, UsersListRequest.UsersListRequestBuilder> req) throws IOException, SlackApiException;
+    UsersListResponse usersList(RequestConfigurator<UsersListRequest.UsersListRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersLookupByEmailResponse usersLookupByEmail(UsersLookupByEmailRequest req) throws IOException, SlackApiException;
 
-    UsersLookupByEmailResponse usersLookupByEmail(RequestBuilder<UsersLookupByEmailRequest, UsersLookupByEmailRequest.UsersLookupByEmailRequestBuilder> req) throws IOException, SlackApiException;
+    UsersLookupByEmailResponse usersLookupByEmail(RequestConfigurator<UsersLookupByEmailRequest.UsersLookupByEmailRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersSetActiveResponse usersSetActive(UsersSetActiveRequest req) throws IOException, SlackApiException;
 
-    UsersSetActiveResponse usersSetActive(RequestBuilder<UsersSetActiveRequest, UsersSetActiveRequest.UsersSetActiveRequestBuilder> req) throws IOException, SlackApiException;
+    UsersSetActiveResponse usersSetActive(RequestConfigurator<UsersSetActiveRequest.UsersSetActiveRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersSetPhotoResponse usersSetPhoto(UsersSetPhotoRequest req) throws IOException, SlackApiException;
 
-    UsersSetPhotoResponse usersSetPhoto(RequestBuilder<UsersSetPhotoRequest, UsersSetPhotoRequest.UsersSetPhotoRequestBuilder> req) throws IOException, SlackApiException;
+    UsersSetPhotoResponse usersSetPhoto(RequestConfigurator<UsersSetPhotoRequest.UsersSetPhotoRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersSetPresenceResponse usersSetPresence(UsersSetPresenceRequest req) throws IOException, SlackApiException;
 
-    UsersSetPresenceResponse usersSetPresence(RequestBuilder<UsersSetPresenceRequest, UsersSetPresenceRequest.UsersSetPresenceRequestBuilder> req) throws IOException, SlackApiException;
+    UsersSetPresenceResponse usersSetPresence(RequestConfigurator<UsersSetPresenceRequest.UsersSetPresenceRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // users.profile
@@ -852,10 +852,10 @@ public interface MethodsClient {
 
     UsersProfileGetResponse usersProfileGet(UsersProfileGetRequest req) throws IOException, SlackApiException;
 
-    UsersProfileGetResponse usersProfileGet(RequestBuilder<UsersProfileGetRequest, UsersProfileGetRequest.UsersProfileGetRequestBuilder> req) throws IOException, SlackApiException;
+    UsersProfileGetResponse usersProfileGet(RequestConfigurator<UsersProfileGetRequest.UsersProfileGetRequestBuilder> req) throws IOException, SlackApiException;
 
     UsersProfileSetResponse usersProfileSet(UsersProfileSetRequest req) throws IOException, SlackApiException;
 
-    UsersProfileSetResponse usersProfileSet(RequestBuilder<UsersProfileSetRequest, UsersProfileSetRequest.UsersProfileSetRequestBuilder> req) throws IOException, SlackApiException;
+    UsersProfileSetResponse usersProfileSet(RequestConfigurator<UsersProfileSetRequest.UsersProfileSetRequestBuilder> req) throws IOException, SlackApiException;
 
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/RequestBuilder.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/RequestBuilder.java
@@ -1,8 +1,0 @@
-package com.github.seratch.jslack.api.methods;
-
-@FunctionalInterface
-public interface RequestBuilder<R extends SlackApiRequest, Builder> {
-
-    R build(Builder builder);
-
-}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/RequestConfigurator.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/RequestConfigurator.java
@@ -1,0 +1,8 @@
+package com.github.seratch.jslack.api.methods;
+
+@FunctionalInterface
+public interface RequestConfigurator<Builder> {
+
+    Builder configure(Builder builder);
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
@@ -2,7 +2,7 @@ package com.github.seratch.jslack.api.methods.impl;
 
 import com.github.seratch.jslack.api.methods.Methods;
 import com.github.seratch.jslack.api.methods.MethodsClient;
-import com.github.seratch.jslack.api.methods.RequestBuilder;
+import com.github.seratch.jslack.api.methods.RequestConfigurator;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.request.api.ApiTestRequest;
 import com.github.seratch.jslack.api.methods.request.apps.AppsUninstallRequest;
@@ -151,8 +151,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ApiTestResponse apiTest(RequestBuilder<ApiTestRequest, ApiTestRequest.ApiTestRequestBuilder> req) throws IOException, SlackApiException {
-        return apiTest(req.build(ApiTestRequest.builder()));
+    public ApiTestResponse apiTest(RequestConfigurator<ApiTestRequest.ApiTestRequestBuilder> req) throws IOException, SlackApiException {
+        return apiTest(req.configure(ApiTestRequest.builder()).build());
     }
 
     @Override
@@ -161,8 +161,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public AppsUninstallResponse appsUninstall(RequestBuilder<AppsUninstallRequest, AppsUninstallRequest.AppsUninstallRequestBuilder> req) throws IOException, SlackApiException {
-        return appsUninstall(req.build(AppsUninstallRequest.builder()));
+    public AppsUninstallResponse appsUninstall(RequestConfigurator<AppsUninstallRequest.AppsUninstallRequestBuilder> req) throws IOException, SlackApiException {
+        return appsUninstall(req.configure(AppsUninstallRequest.builder()).build());
     }
 
     @Override
@@ -171,8 +171,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public AppsPermissionsInfoResponse appsPermissionsInfo(RequestBuilder<AppsPermissionsInfoRequest, AppsPermissionsInfoRequest.AppsPermissionsInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return appsPermissionsInfo(req.build(AppsPermissionsInfoRequest.builder()));
+    public AppsPermissionsInfoResponse appsPermissionsInfo(RequestConfigurator<AppsPermissionsInfoRequest.AppsPermissionsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return appsPermissionsInfo(req.configure(AppsPermissionsInfoRequest.builder()).build());
     }
 
     @Override
@@ -181,8 +181,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public AppsPermissionsRequestResponse appsPermissionsRequest(RequestBuilder<AppsPermissionsRequestRequest, AppsPermissionsRequestRequest.AppsPermissionsRequestRequestBuilder> req) throws IOException, SlackApiException {
-        return appsPermissionsRequest(req.build(AppsPermissionsRequestRequest.builder()));
+    public AppsPermissionsRequestResponse appsPermissionsRequest(RequestConfigurator<AppsPermissionsRequestRequest.AppsPermissionsRequestRequestBuilder> req) throws IOException, SlackApiException {
+        return appsPermissionsRequest(req.configure(AppsPermissionsRequestRequest.builder()).build());
     }
 
     @Override
@@ -211,8 +211,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public AuthRevokeResponse authRevoke(RequestBuilder<AuthRevokeRequest, AuthRevokeRequest.AuthRevokeRequestBuilder> req) throws IOException, SlackApiException {
-        return authRevoke(req.build(AuthRevokeRequest.builder()));
+    public AuthRevokeResponse authRevoke(RequestConfigurator<AuthRevokeRequest.AuthRevokeRequestBuilder> req) throws IOException, SlackApiException {
+        return authRevoke(req.configure(AuthRevokeRequest.builder()).build());
     }
 
     @Override
@@ -221,8 +221,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public AuthTestResponse authTest(RequestBuilder<AuthTestRequest, AuthTestRequest.AuthTestRequestBuilder> req) throws IOException, SlackApiException {
-        return authTest(req.build(AuthTestRequest.builder()));
+    public AuthTestResponse authTest(RequestConfigurator<AuthTestRequest.AuthTestRequestBuilder> req) throws IOException, SlackApiException {
+        return authTest(req.configure(AuthTestRequest.builder()).build());
     }
 
     @Override
@@ -231,8 +231,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public BotsInfoResponse botsInfo(RequestBuilder<BotsInfoRequest, BotsInfoRequest.BotsInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return botsInfo(req.build(BotsInfoRequest.builder()));
+    public BotsInfoResponse botsInfo(RequestConfigurator<BotsInfoRequest.BotsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return botsInfo(req.configure(BotsInfoRequest.builder()).build());
     }
 
     @Override
@@ -241,8 +241,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsArchiveResponse channelsArchive(RequestBuilder<ChannelsArchiveRequest, ChannelsArchiveRequest.ChannelsArchiveRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsArchive(req.build(ChannelsArchiveRequest.builder()));
+    public ChannelsArchiveResponse channelsArchive(RequestConfigurator<ChannelsArchiveRequest.ChannelsArchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsArchive(req.configure(ChannelsArchiveRequest.builder()).build());
     }
 
     @Override
@@ -251,8 +251,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsCreateResponse channelsCreate(RequestBuilder<ChannelsCreateRequest, ChannelsCreateRequest.ChannelsCreateRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsCreate(req.build(ChannelsCreateRequest.builder()));
+    public ChannelsCreateResponse channelsCreate(RequestConfigurator<ChannelsCreateRequest.ChannelsCreateRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsCreate(req.configure(ChannelsCreateRequest.builder()).build());
     }
 
     @Override
@@ -261,8 +261,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsHistoryResponse channelsHistory(RequestBuilder<ChannelsHistoryRequest, ChannelsHistoryRequest.ChannelsHistoryRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsHistory(req.build(ChannelsHistoryRequest.builder()));
+    public ChannelsHistoryResponse channelsHistory(RequestConfigurator<ChannelsHistoryRequest.ChannelsHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsHistory(req.configure(ChannelsHistoryRequest.builder()).build());
     }
 
     @Override
@@ -271,8 +271,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsRepliesResponse channelsReplies(RequestBuilder<ChannelsRepliesRequest, ChannelsRepliesRequest.ChannelsRepliesRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsReplies(req.build(ChannelsRepliesRequest.builder()));
+    public ChannelsRepliesResponse channelsReplies(RequestConfigurator<ChannelsRepliesRequest.ChannelsRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsReplies(req.configure(ChannelsRepliesRequest.builder()).build());
     }
 
     @Override
@@ -281,8 +281,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsInfoResponse channelsInfo(RequestBuilder<ChannelsInfoRequest, ChannelsInfoRequest.ChannelsInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsInfo(req.build(ChannelsInfoRequest.builder()));
+    public ChannelsInfoResponse channelsInfo(RequestConfigurator<ChannelsInfoRequest.ChannelsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsInfo(req.configure(ChannelsInfoRequest.builder()).build());
     }
 
     @Override
@@ -291,8 +291,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsListResponse channelsList(RequestBuilder<ChannelsListRequest, ChannelsListRequest.ChannelsListRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsList(req.build(ChannelsListRequest.builder()));
+    public ChannelsListResponse channelsList(RequestConfigurator<ChannelsListRequest.ChannelsListRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsList(req.configure(ChannelsListRequest.builder()).build());
     }
 
     @Override
@@ -301,8 +301,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsInviteResponse channelsInvite(RequestBuilder<ChannelsInviteRequest, ChannelsInviteRequest.ChannelsInviteRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsInvite(req.build(ChannelsInviteRequest.builder()));
+    public ChannelsInviteResponse channelsInvite(RequestConfigurator<ChannelsInviteRequest.ChannelsInviteRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsInvite(req.configure(ChannelsInviteRequest.builder()).build());
     }
 
     @Override
@@ -311,8 +311,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsJoinResponse channelsJoin(RequestBuilder<ChannelsJoinRequest, ChannelsJoinRequest.ChannelsJoinRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsJoin(req.build(ChannelsJoinRequest.builder()));
+    public ChannelsJoinResponse channelsJoin(RequestConfigurator<ChannelsJoinRequest.ChannelsJoinRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsJoin(req.configure(ChannelsJoinRequest.builder()).build());
     }
 
     @Override
@@ -321,8 +321,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsKickResponse channelsKick(RequestBuilder<ChannelsKickRequest, ChannelsKickRequest.ChannelsKickRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsKick(req.build(ChannelsKickRequest.builder()));
+    public ChannelsKickResponse channelsKick(RequestConfigurator<ChannelsKickRequest.ChannelsKickRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsKick(req.configure(ChannelsKickRequest.builder()).build());
     }
 
     @Override
@@ -331,8 +331,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsLeaveResponse channelsLeave(RequestBuilder<ChannelsLeaveRequest, ChannelsLeaveRequest.ChannelsLeaveRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsLeave(req.build(ChannelsLeaveRequest.builder()));
+    public ChannelsLeaveResponse channelsLeave(RequestConfigurator<ChannelsLeaveRequest.ChannelsLeaveRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsLeave(req.configure(ChannelsLeaveRequest.builder()).build());
     }
 
     @Override
@@ -341,8 +341,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsMarkResponse channelsMark(RequestBuilder<ChannelsMarkRequest, ChannelsMarkRequest.ChannelsMarkRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsMark(req.build(ChannelsMarkRequest.builder()));
+    public ChannelsMarkResponse channelsMark(RequestConfigurator<ChannelsMarkRequest.ChannelsMarkRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsMark(req.configure(ChannelsMarkRequest.builder()).build());
     }
 
     @Override
@@ -351,8 +351,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsRenameResponse channelsRename(RequestBuilder<ChannelsRenameRequest, ChannelsRenameRequest.ChannelsRenameRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsRename(req.build(ChannelsRenameRequest.builder()));
+    public ChannelsRenameResponse channelsRename(RequestConfigurator<ChannelsRenameRequest.ChannelsRenameRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsRename(req.configure(ChannelsRenameRequest.builder()).build());
     }
 
     @Override
@@ -361,8 +361,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsSetPurposeResponse channelsSetPurpose(RequestBuilder<ChannelsSetPurposeRequest, ChannelsSetPurposeRequest.ChannelsSetPurposeRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsSetPurpose(req.build(ChannelsSetPurposeRequest.builder()));
+    public ChannelsSetPurposeResponse channelsSetPurpose(RequestConfigurator<ChannelsSetPurposeRequest.ChannelsSetPurposeRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsSetPurpose(req.configure(ChannelsSetPurposeRequest.builder()).build());
     }
 
     @Override
@@ -371,8 +371,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsSetTopicResponse channelsSetTopic(RequestBuilder<ChannelsSetTopicRequest, ChannelsSetTopicRequest.ChannelsSetTopicRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsSetTopic(req.build(ChannelsSetTopicRequest.builder()));
+    public ChannelsSetTopicResponse channelsSetTopic(RequestConfigurator<ChannelsSetTopicRequest.ChannelsSetTopicRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsSetTopic(req.configure(ChannelsSetTopicRequest.builder()).build());
     }
 
     @Override
@@ -381,8 +381,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChannelsUnarchiveResponse channelsUnarchive(RequestBuilder<ChannelsUnarchiveRequest, ChannelsUnarchiveRequest.ChannelsUnarchiveRequestBuilder> req) throws IOException, SlackApiException {
-        return channelsUnarchive(req.build(ChannelsUnarchiveRequest.builder()));
+    public ChannelsUnarchiveResponse channelsUnarchive(RequestConfigurator<ChannelsUnarchiveRequest.ChannelsUnarchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return channelsUnarchive(req.configure(ChannelsUnarchiveRequest.builder()).build());
     }
 
     @Override
@@ -391,8 +391,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatGetPermalinkResponse chatGetPermalink(RequestBuilder<ChatGetPermalinkRequest, ChatGetPermalinkRequest.ChatGetPermalinkRequestBuilder> req) throws IOException, SlackApiException {
-        return chatGetPermalink(req.build(ChatGetPermalinkRequest.builder()));
+    public ChatGetPermalinkResponse chatGetPermalink(RequestConfigurator<ChatGetPermalinkRequest.ChatGetPermalinkRequestBuilder> req) throws IOException, SlackApiException {
+        return chatGetPermalink(req.configure(ChatGetPermalinkRequest.builder()).build());
     }
 
     @Override
@@ -401,8 +401,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatDeleteResponse chatDelete(RequestBuilder<ChatDeleteRequest, ChatDeleteRequest.ChatDeleteRequestBuilder> req) throws IOException, SlackApiException {
-        return chatDelete(req.build(ChatDeleteRequest.builder()));
+    public ChatDeleteResponse chatDelete(RequestConfigurator<ChatDeleteRequest.ChatDeleteRequestBuilder> req) throws IOException, SlackApiException {
+        return chatDelete(req.configure(ChatDeleteRequest.builder()).build());
     }
 
     @Override
@@ -411,8 +411,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatDeleteScheduledMessageResponse chatDeleteScheduledMessage(RequestBuilder<ChatDeleteScheduledMessageRequest, ChatDeleteScheduledMessageRequest.ChatDeleteScheduledMessageRequestBuilder> req) throws IOException, SlackApiException {
-        return chatDeleteScheduledMessage(req.build(ChatDeleteScheduledMessageRequest.builder()));
+    public ChatDeleteScheduledMessageResponse chatDeleteScheduledMessage(RequestConfigurator<ChatDeleteScheduledMessageRequest.ChatDeleteScheduledMessageRequestBuilder> req) throws IOException, SlackApiException {
+        return chatDeleteScheduledMessage(req.configure(ChatDeleteScheduledMessageRequest.builder()).build());
     }
 
     @Override
@@ -421,8 +421,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatMeMessageResponse chatMeMessage(RequestBuilder<ChatMeMessageRequest, ChatMeMessageRequest.ChatMeMessageRequestBuilder> req) throws IOException, SlackApiException {
-        return chatMeMessage(req.build(ChatMeMessageRequest.builder()));
+    public ChatMeMessageResponse chatMeMessage(RequestConfigurator<ChatMeMessageRequest.ChatMeMessageRequestBuilder> req) throws IOException, SlackApiException {
+        return chatMeMessage(req.configure(ChatMeMessageRequest.builder()).build());
     }
 
     @Override
@@ -431,8 +431,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatPostEphemeralResponse chatPostEphemeral(RequestBuilder<ChatPostEphemeralRequest, ChatPostEphemeralRequest.ChatPostEphemeralRequestBuilder> req) throws IOException, SlackApiException {
-        return chatPostEphemeral(req.build(ChatPostEphemeralRequest.builder()));
+    public ChatPostEphemeralResponse chatPostEphemeral(RequestConfigurator<ChatPostEphemeralRequest.ChatPostEphemeralRequestBuilder> req) throws IOException, SlackApiException {
+        return chatPostEphemeral(req.configure(ChatPostEphemeralRequest.builder()).build());
     }
 
     @Override
@@ -441,8 +441,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatPostMessageResponse chatPostMessage(RequestBuilder<ChatPostMessageRequest, ChatPostMessageRequest.ChatPostMessageRequestBuilder> req) throws IOException, SlackApiException {
-        return chatPostMessage(req.build(ChatPostMessageRequest.builder()));
+    public ChatPostMessageResponse chatPostMessage(RequestConfigurator<ChatPostMessageRequest.ChatPostMessageRequestBuilder> req) throws IOException, SlackApiException {
+        return chatPostMessage(req.configure(ChatPostMessageRequest.builder()).build());
     }
 
     @Override
@@ -451,8 +451,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatScheduleMessageResponse chatScheduleMessage(RequestBuilder<ChatScheduleMessageRequest, ChatScheduleMessageRequest.ChatScheduleMessageRequestBuilder> req) throws IOException, SlackApiException {
-        return chatScheduleMessage(req.build(ChatScheduleMessageRequest.builder()));
+    public ChatScheduleMessageResponse chatScheduleMessage(RequestConfigurator<ChatScheduleMessageRequest.ChatScheduleMessageRequestBuilder> req) throws IOException, SlackApiException {
+        return chatScheduleMessage(req.configure(ChatScheduleMessageRequest.builder()).build());
     }
 
     @Override
@@ -461,8 +461,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatUpdateResponse chatUpdate(RequestBuilder<ChatUpdateRequest, ChatUpdateRequest.ChatUpdateRequestBuilder> req) throws IOException, SlackApiException {
-        return chatUpdate(req.build(ChatUpdateRequest.builder()));
+    public ChatUpdateResponse chatUpdate(RequestConfigurator<ChatUpdateRequest.ChatUpdateRequestBuilder> req) throws IOException, SlackApiException {
+        return chatUpdate(req.configure(ChatUpdateRequest.builder()).build());
     }
 
     @Override
@@ -471,8 +471,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatUnfurlResponse chatUnfurl(RequestBuilder<ChatUnfurlRequest, ChatUnfurlRequest.ChatUnfurlRequestBuilder> req) throws IOException, SlackApiException {
-        return chatUnfurl(req.build(ChatUnfurlRequest.builder()));
+    public ChatUnfurlResponse chatUnfurl(RequestConfigurator<ChatUnfurlRequest.ChatUnfurlRequestBuilder> req) throws IOException, SlackApiException {
+        return chatUnfurl(req.configure(ChatUnfurlRequest.builder()).build());
     }
 
     @Override
@@ -481,8 +481,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ChatScheduleMessagesListResponse chatScheduleMessagesListMessage(RequestBuilder<ChatScheduleMessagesListRequest, ChatScheduleMessagesListRequest.ChatScheduleMessagesListRequestBuilder> req) throws IOException, SlackApiException {
-        return chatScheduleMessagesListMessage(req.build(ChatScheduleMessagesListRequest.builder()));
+    public ChatScheduleMessagesListResponse chatScheduleMessagesListMessage(RequestConfigurator<ChatScheduleMessagesListRequest.ChatScheduleMessagesListRequestBuilder> req) throws IOException, SlackApiException {
+        return chatScheduleMessagesListMessage(req.configure(ChatScheduleMessagesListRequest.builder()).build());
     }
 
     @Override
@@ -492,8 +492,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsArchiveResponse conversationsArchive(RequestBuilder<ConversationsArchiveRequest, ConversationsArchiveRequest.ConversationsArchiveRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsArchive(req.build(ConversationsArchiveRequest.builder()));
+    public ConversationsArchiveResponse conversationsArchive(RequestConfigurator<ConversationsArchiveRequest.ConversationsArchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsArchive(req.configure(ConversationsArchiveRequest.builder()).build());
     }
 
     @Override
@@ -503,8 +503,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsCloseResponse conversationsClose(RequestBuilder<ConversationsCloseRequest, ConversationsCloseRequest.ConversationsCloseRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsClose(req.build(ConversationsCloseRequest.builder()));
+    public ConversationsCloseResponse conversationsClose(RequestConfigurator<ConversationsCloseRequest.ConversationsCloseRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsClose(req.configure(ConversationsCloseRequest.builder()).build());
     }
 
     @Override
@@ -514,8 +514,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsCreateResponse conversationsCreate(RequestBuilder<ConversationsCreateRequest, ConversationsCreateRequest.ConversationsCreateRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsCreate(req.build(ConversationsCreateRequest.builder()));
+    public ConversationsCreateResponse conversationsCreate(RequestConfigurator<ConversationsCreateRequest.ConversationsCreateRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsCreate(req.configure(ConversationsCreateRequest.builder()).build());
     }
 
     @Override
@@ -525,8 +525,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsHistoryResponse conversationsHistory(RequestBuilder<ConversationsHistoryRequest, ConversationsHistoryRequest.ConversationsHistoryRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsHistory(req.build(ConversationsHistoryRequest.builder()));
+    public ConversationsHistoryResponse conversationsHistory(RequestConfigurator<ConversationsHistoryRequest.ConversationsHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsHistory(req.configure(ConversationsHistoryRequest.builder()).build());
     }
 
     @Override
@@ -536,8 +536,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsInfoResponse conversationsInfo(RequestBuilder<ConversationsInfoRequest, ConversationsInfoRequest.ConversationsInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsInfo(req.build(ConversationsInfoRequest.builder()));
+    public ConversationsInfoResponse conversationsInfo(RequestConfigurator<ConversationsInfoRequest.ConversationsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsInfo(req.configure(ConversationsInfoRequest.builder()).build());
     }
 
     @Override
@@ -547,8 +547,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsInviteResponse conversationsInvite(RequestBuilder<ConversationsInviteRequest, ConversationsInviteRequest.ConversationsInviteRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsInvite(req.build(ConversationsInviteRequest.builder()));
+    public ConversationsInviteResponse conversationsInvite(RequestConfigurator<ConversationsInviteRequest.ConversationsInviteRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsInvite(req.configure(ConversationsInviteRequest.builder()).build());
     }
 
     @Override
@@ -558,8 +558,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsJoinResponse conversationsJoin(RequestBuilder<ConversationsJoinRequest, ConversationsJoinRequest.ConversationsJoinRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsJoin(req.build(ConversationsJoinRequest.builder()));
+    public ConversationsJoinResponse conversationsJoin(RequestConfigurator<ConversationsJoinRequest.ConversationsJoinRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsJoin(req.configure(ConversationsJoinRequest.builder()).build());
     }
 
     @Override
@@ -569,8 +569,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsKickResponse conversationsKick(RequestBuilder<ConversationsKickRequest, ConversationsKickRequest.ConversationsKickRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsKick(req.build(ConversationsKickRequest.builder()));
+    public ConversationsKickResponse conversationsKick(RequestConfigurator<ConversationsKickRequest.ConversationsKickRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsKick(req.configure(ConversationsKickRequest.builder()).build());
     }
 
     @Override
@@ -580,8 +580,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsLeaveResponse conversationsLeave(RequestBuilder<ConversationsLeaveRequest, ConversationsLeaveRequest.ConversationsLeaveRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsLeave(req.build(ConversationsLeaveRequest.builder()));
+    public ConversationsLeaveResponse conversationsLeave(RequestConfigurator<ConversationsLeaveRequest.ConversationsLeaveRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsLeave(req.configure(ConversationsLeaveRequest.builder()).build());
     }
 
     @Override
@@ -591,8 +591,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsListResponse conversationsList(RequestBuilder<ConversationsListRequest, ConversationsListRequest.ConversationsListRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsList(req.build(ConversationsListRequest.builder()));
+    public ConversationsListResponse conversationsList(RequestConfigurator<ConversationsListRequest.ConversationsListRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsList(req.configure(ConversationsListRequest.builder()).build());
     }
 
     @Override
@@ -602,8 +602,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsMembersResponse conversationsMembers(RequestBuilder<ConversationsMembersRequest, ConversationsMembersRequest.ConversationsMembersRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsMembers(req.build(ConversationsMembersRequest.builder()));
+    public ConversationsMembersResponse conversationsMembers(RequestConfigurator<ConversationsMembersRequest.ConversationsMembersRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsMembers(req.configure(ConversationsMembersRequest.builder()).build());
     }
 
     @Override
@@ -613,8 +613,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsOpenResponse conversationsOpen(RequestBuilder<ConversationsOpenRequest, ConversationsOpenRequest.ConversationsOpenRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsOpen(req.build(ConversationsOpenRequest.builder()));
+    public ConversationsOpenResponse conversationsOpen(RequestConfigurator<ConversationsOpenRequest.ConversationsOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsOpen(req.configure(ConversationsOpenRequest.builder()).build());
     }
 
     @Override
@@ -624,8 +624,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsRenameResponse conversationsRename(RequestBuilder<ConversationsRenameRequest, ConversationsRenameRequest.ConversationsRenameRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsRename(req.build(ConversationsRenameRequest.builder()));
+    public ConversationsRenameResponse conversationsRename(RequestConfigurator<ConversationsRenameRequest.ConversationsRenameRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsRename(req.configure(ConversationsRenameRequest.builder()).build());
     }
 
     @Override
@@ -635,8 +635,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsRepliesResponse conversationsReplies(RequestBuilder<ConversationsRepliesRequest, ConversationsRepliesRequest.ConversationsRepliesRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsReplies(req.build(ConversationsRepliesRequest.builder()));
+    public ConversationsRepliesResponse conversationsReplies(RequestConfigurator<ConversationsRepliesRequest.ConversationsRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsReplies(req.configure(ConversationsRepliesRequest.builder()).build());
     }
 
     @Override
@@ -646,8 +646,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsSetPurposeResponse conversationsSetPurpose(RequestBuilder<ConversationsSetPurposeRequest, ConversationsSetPurposeRequest.ConversationsSetPurposeRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsSetPurpose(req.build(ConversationsSetPurposeRequest.builder()));
+    public ConversationsSetPurposeResponse conversationsSetPurpose(RequestConfigurator<ConversationsSetPurposeRequest.ConversationsSetPurposeRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsSetPurpose(req.configure(ConversationsSetPurposeRequest.builder()).build());
     }
 
     @Override
@@ -657,8 +657,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsSetTopicResponse conversationsSetTopic(RequestBuilder<ConversationsSetTopicRequest, ConversationsSetTopicRequest.ConversationsSetTopicRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsSetTopic(req.build(ConversationsSetTopicRequest.builder()));
+    public ConversationsSetTopicResponse conversationsSetTopic(RequestConfigurator<ConversationsSetTopicRequest.ConversationsSetTopicRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsSetTopic(req.configure(ConversationsSetTopicRequest.builder()).build());
     }
 
     @Override
@@ -668,8 +668,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ConversationsUnarchiveResponse conversationsUnarchive(RequestBuilder<ConversationsUnarchiveRequest, ConversationsUnarchiveRequest.ConversationsUnarchiveRequestBuilder> req) throws IOException, SlackApiException {
-        return conversationsUnarchive(req.build(ConversationsUnarchiveRequest.builder()));
+    public ConversationsUnarchiveResponse conversationsUnarchive(RequestConfigurator<ConversationsUnarchiveRequest.ConversationsUnarchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return conversationsUnarchive(req.configure(ConversationsUnarchiveRequest.builder()).build());
     }
 
     @Override
@@ -679,8 +679,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public DialogOpenResponse dialogOpen(RequestBuilder<DialogOpenRequest, DialogOpenRequest.DialogOpenRequestBuilder> req) throws IOException, SlackApiException {
-        return dialogOpen(req.build(DialogOpenRequest.builder()));
+    public DialogOpenResponse dialogOpen(RequestConfigurator<DialogOpenRequest.DialogOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return dialogOpen(req.configure(DialogOpenRequest.builder()).build());
     }
 
     @Override
@@ -689,8 +689,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public DndEndDndResponse dndEndDnd(RequestBuilder<DndEndDndRequest, DndEndDndRequest.DndEndDndRequestBuilder> req) throws IOException, SlackApiException {
-        return dndEndDnd(req.build(DndEndDndRequest.builder()));
+    public DndEndDndResponse dndEndDnd(RequestConfigurator<DndEndDndRequest.DndEndDndRequestBuilder> req) throws IOException, SlackApiException {
+        return dndEndDnd(req.configure(DndEndDndRequest.builder()).build());
     }
 
     @Override
@@ -699,8 +699,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public DndEndSnoozeResponse dndEndSnooze(RequestBuilder<DndEndSnoozeRequest, DndEndSnoozeRequest.DndEndSnoozeRequestBuilder> req) throws IOException, SlackApiException {
-        return dndEndSnooze(req.build(DndEndSnoozeRequest.builder()));
+    public DndEndSnoozeResponse dndEndSnooze(RequestConfigurator<DndEndSnoozeRequest.DndEndSnoozeRequestBuilder> req) throws IOException, SlackApiException {
+        return dndEndSnooze(req.configure(DndEndSnoozeRequest.builder()).build());
     }
 
     @Override
@@ -709,8 +709,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public DndInfoResponse dndInfo(RequestBuilder<DndInfoRequest, DndInfoRequest.DndInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return dndInfo(req.build(DndInfoRequest.builder()));
+    public DndInfoResponse dndInfo(RequestConfigurator<DndInfoRequest.DndInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return dndInfo(req.configure(DndInfoRequest.builder()).build());
     }
 
     @Override
@@ -719,8 +719,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public DndSetSnoozeResponse dndSetSnooze(RequestBuilder<DndSetSnoozeRequest, DndSetSnoozeRequest.DndSetSnoozeRequestBuilder> req) throws IOException, SlackApiException {
-        return dndSetSnooze(req.build(DndSetSnoozeRequest.builder()));
+    public DndSetSnoozeResponse dndSetSnooze(RequestConfigurator<DndSetSnoozeRequest.DndSetSnoozeRequestBuilder> req) throws IOException, SlackApiException {
+        return dndSetSnooze(req.configure(DndSetSnoozeRequest.builder()).build());
     }
 
     @Override
@@ -729,8 +729,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public DndTeamInfoResponse dndTeamInfo(RequestBuilder<DndTeamInfoRequest, DndTeamInfoRequest.DndTeamInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return dndTeamInfo(req.build(DndTeamInfoRequest.builder()));
+    public DndTeamInfoResponse dndTeamInfo(RequestConfigurator<DndTeamInfoRequest.DndTeamInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return dndTeamInfo(req.configure(DndTeamInfoRequest.builder()).build());
     }
 
     @Override
@@ -739,8 +739,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public EmojiListResponse emojiList(RequestBuilder<EmojiListRequest, EmojiListRequest.EmojiListRequestBuilder> req) throws IOException, SlackApiException {
-        return emojiList(req.build(EmojiListRequest.builder()));
+    public EmojiListResponse emojiList(RequestConfigurator<EmojiListRequest.EmojiListRequestBuilder> req) throws IOException, SlackApiException {
+        return emojiList(req.configure(EmojiListRequest.builder()).build());
     }
 
     @Override
@@ -749,8 +749,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public FilesDeleteResponse filesDelete(RequestBuilder<FilesDeleteRequest, FilesDeleteRequest.FilesDeleteRequestBuilder> req) throws IOException, SlackApiException {
-        return filesDelete(req.build(FilesDeleteRequest.builder()));
+    public FilesDeleteResponse filesDelete(RequestConfigurator<FilesDeleteRequest.FilesDeleteRequestBuilder> req) throws IOException, SlackApiException {
+        return filesDelete(req.configure(FilesDeleteRequest.builder()).build());
     }
 
     @Override
@@ -759,8 +759,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public FilesInfoResponse filesInfo(RequestBuilder<FilesInfoRequest, FilesInfoRequest.FilesInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return filesInfo(req.build(FilesInfoRequest.builder()));
+    public FilesInfoResponse filesInfo(RequestConfigurator<FilesInfoRequest.FilesInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return filesInfo(req.configure(FilesInfoRequest.builder()).build());
     }
 
     @Override
@@ -769,8 +769,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public FilesListResponse filesList(RequestBuilder<FilesListRequest, FilesListRequest.FilesListRequestBuilder> req) throws IOException, SlackApiException {
-        return filesList(req.build(FilesListRequest.builder()));
+    public FilesListResponse filesList(RequestConfigurator<FilesListRequest.FilesListRequestBuilder> req) throws IOException, SlackApiException {
+        return filesList(req.configure(FilesListRequest.builder()).build());
     }
 
     @Override
@@ -779,8 +779,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public FilesRevokePublicURLResponse filesRevokePublicURL(RequestBuilder<FilesRevokePublicURLRequest, FilesRevokePublicURLRequest.FilesRevokePublicURLRequestBuilder> req) throws IOException, SlackApiException {
-        return filesRevokePublicURL(req.build(FilesRevokePublicURLRequest.builder()));
+    public FilesRevokePublicURLResponse filesRevokePublicURL(RequestConfigurator<FilesRevokePublicURLRequest.FilesRevokePublicURLRequestBuilder> req) throws IOException, SlackApiException {
+        return filesRevokePublicURL(req.configure(FilesRevokePublicURLRequest.builder()).build());
     }
 
     @Override
@@ -789,8 +789,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public FilesSharedPublicURLResponse filesSharedPublicURL(RequestBuilder<FilesSharedPublicURLRequest, FilesSharedPublicURLRequest.FilesSharedPublicURLRequestBuilder> req) throws IOException, SlackApiException {
-        return filesSharedPublicURL(req.build(FilesSharedPublicURLRequest.builder()));
+    public FilesSharedPublicURLResponse filesSharedPublicURL(RequestConfigurator<FilesSharedPublicURLRequest.FilesSharedPublicURLRequestBuilder> req) throws IOException, SlackApiException {
+        return filesSharedPublicURL(req.configure(FilesSharedPublicURLRequest.builder()).build());
     }
 
     @Override
@@ -803,8 +803,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public FilesUploadResponse filesUpload(RequestBuilder<FilesUploadRequest, FilesUploadRequest.FilesUploadRequestBuilder> req) throws IOException, SlackApiException {
-        return filesUpload(req.build(FilesUploadRequest.builder()));
+    public FilesUploadResponse filesUpload(RequestConfigurator<FilesUploadRequest.FilesUploadRequestBuilder> req) throws IOException, SlackApiException {
+        return filesUpload(req.configure(FilesUploadRequest.builder()).build());
     }
 
     @Override
@@ -828,8 +828,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsArchiveResponse groupsArchive(RequestBuilder<GroupsArchiveRequest, GroupsArchiveRequest.GroupsArchiveRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsArchive(req.build(GroupsArchiveRequest.builder()));
+    public GroupsArchiveResponse groupsArchive(RequestConfigurator<GroupsArchiveRequest.GroupsArchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsArchive(req.configure(GroupsArchiveRequest.builder()).build());
     }
 
     @Override
@@ -843,8 +843,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsCreateChildResponse groupsCreateChild(RequestBuilder<GroupsCreateChildRequest, GroupsCreateChildRequest.GroupsCreateChildRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsCreateChild(req.build(GroupsCreateChildRequest.builder()));
+    public GroupsCreateChildResponse groupsCreateChild(RequestConfigurator<GroupsCreateChildRequest.GroupsCreateChildRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsCreateChild(req.configure(GroupsCreateChildRequest.builder()).build());
     }
 
     @Override
@@ -853,8 +853,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsCreateResponse groupsCreate(RequestBuilder<GroupsCreateRequest, GroupsCreateRequest.GroupsCreateRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsCreate(req.build(GroupsCreateRequest.builder()));
+    public GroupsCreateResponse groupsCreate(RequestConfigurator<GroupsCreateRequest.GroupsCreateRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsCreate(req.configure(GroupsCreateRequest.builder()).build());
     }
 
     @Override
@@ -863,8 +863,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsHistoryResponse groupsHistory(RequestBuilder<GroupsHistoryRequest, GroupsHistoryRequest.GroupsHistoryRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsHistory(req.build(GroupsHistoryRequest.builder()));
+    public GroupsHistoryResponse groupsHistory(RequestConfigurator<GroupsHistoryRequest.GroupsHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsHistory(req.configure(GroupsHistoryRequest.builder()).build());
     }
 
     @Override
@@ -873,8 +873,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsRepliesResponse groupsReplies(RequestBuilder<GroupsRepliesRequest, GroupsRepliesRequest.GroupsRepliesRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsReplies(req.build(GroupsRepliesRequest.builder()));
+    public GroupsRepliesResponse groupsReplies(RequestConfigurator<GroupsRepliesRequest.GroupsRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsReplies(req.configure(GroupsRepliesRequest.builder()).build());
     }
 
     @Override
@@ -883,8 +883,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsInfoResponse groupsInfo(RequestBuilder<GroupsInfoRequest, GroupsInfoRequest.GroupsInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsInfo(req.build(GroupsInfoRequest.builder()));
+    public GroupsInfoResponse groupsInfo(RequestConfigurator<GroupsInfoRequest.GroupsInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsInfo(req.configure(GroupsInfoRequest.builder()).build());
     }
 
     @Override
@@ -893,8 +893,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsInviteResponse groupsInvite(RequestBuilder<GroupsInviteRequest, GroupsInviteRequest.GroupsInviteRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsInvite(req.build(GroupsInviteRequest.builder()));
+    public GroupsInviteResponse groupsInvite(RequestConfigurator<GroupsInviteRequest.GroupsInviteRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsInvite(req.configure(GroupsInviteRequest.builder()).build());
     }
 
     @Override
@@ -903,8 +903,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsKickResponse groupsKick(RequestBuilder<GroupsKickRequest, GroupsKickRequest.GroupsKickRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsKick(req.build(GroupsKickRequest.builder()));
+    public GroupsKickResponse groupsKick(RequestConfigurator<GroupsKickRequest.GroupsKickRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsKick(req.configure(GroupsKickRequest.builder()).build());
     }
 
     @Override
@@ -913,8 +913,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsLeaveResponse groupsLeave(RequestBuilder<GroupsLeaveRequest, GroupsLeaveRequest.GroupsLeaveRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsLeave(req.build(GroupsLeaveRequest.builder()));
+    public GroupsLeaveResponse groupsLeave(RequestConfigurator<GroupsLeaveRequest.GroupsLeaveRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsLeave(req.configure(GroupsLeaveRequest.builder()).build());
     }
 
     @Override
@@ -923,8 +923,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsListResponse groupsList(RequestBuilder<GroupsListRequest, GroupsListRequest.GroupsListRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsList(req.build(GroupsListRequest.builder()));
+    public GroupsListResponse groupsList(RequestConfigurator<GroupsListRequest.GroupsListRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsList(req.configure(GroupsListRequest.builder()).build());
     }
 
     @Override
@@ -933,8 +933,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsMarkResponse groupsMark(RequestBuilder<GroupsMarkRequest, GroupsMarkRequest.GroupsMarkRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsMark(req.build(GroupsMarkRequest.builder()));
+    public GroupsMarkResponse groupsMark(RequestConfigurator<GroupsMarkRequest.GroupsMarkRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsMark(req.configure(GroupsMarkRequest.builder()).build());
     }
 
     @Override
@@ -943,8 +943,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsOpenResponse groupsOpen(RequestBuilder<GroupsOpenRequest, GroupsOpenRequest.GroupsOpenRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsOpen(req.build(GroupsOpenRequest.builder()));
+    public GroupsOpenResponse groupsOpen(RequestConfigurator<GroupsOpenRequest.GroupsOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsOpen(req.configure(GroupsOpenRequest.builder()).build());
     }
 
     @Override
@@ -953,8 +953,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsRenameResponse groupsRename(RequestBuilder<GroupsRenameRequest, GroupsRenameRequest.GroupsRenameRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsRename(req.build(GroupsRenameRequest.builder()));
+    public GroupsRenameResponse groupsRename(RequestConfigurator<GroupsRenameRequest.GroupsRenameRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsRename(req.configure(GroupsRenameRequest.builder()).build());
     }
 
     @Override
@@ -963,8 +963,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsSetPurposeResponse groupsSetPurpose(RequestBuilder<GroupsSetPurposeRequest, GroupsSetPurposeRequest.GroupsSetPurposeRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsSetPurpose(req.build(GroupsSetPurposeRequest.builder()));
+    public GroupsSetPurposeResponse groupsSetPurpose(RequestConfigurator<GroupsSetPurposeRequest.GroupsSetPurposeRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsSetPurpose(req.configure(GroupsSetPurposeRequest.builder()).build());
     }
 
     @Override
@@ -973,8 +973,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsSetTopicResponse groupsSetTopic(RequestBuilder<GroupsSetTopicRequest, GroupsSetTopicRequest.GroupsSetTopicRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsSetTopic(req.build(GroupsSetTopicRequest.builder()));
+    public GroupsSetTopicResponse groupsSetTopic(RequestConfigurator<GroupsSetTopicRequest.GroupsSetTopicRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsSetTopic(req.configure(GroupsSetTopicRequest.builder()).build());
     }
 
     @Override
@@ -983,8 +983,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public GroupsUnarchiveResponse groupsUnarchive(RequestBuilder<GroupsUnarchiveRequest, GroupsUnarchiveRequest.GroupsUnarchiveRequestBuilder> req) throws IOException, SlackApiException {
-        return groupsUnarchive(req.build(GroupsUnarchiveRequest.builder()));
+    public GroupsUnarchiveResponse groupsUnarchive(RequestConfigurator<GroupsUnarchiveRequest.GroupsUnarchiveRequestBuilder> req) throws IOException, SlackApiException {
+        return groupsUnarchive(req.configure(GroupsUnarchiveRequest.builder()).build());
     }
 
     @Override
@@ -993,8 +993,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ImCloseResponse imClose(RequestBuilder<ImCloseRequest, ImCloseRequest.ImCloseRequestBuilder> req) throws IOException, SlackApiException {
-        return imClose(req.build(ImCloseRequest.builder()));
+    public ImCloseResponse imClose(RequestConfigurator<ImCloseRequest.ImCloseRequestBuilder> req) throws IOException, SlackApiException {
+        return imClose(req.configure(ImCloseRequest.builder()).build());
     }
 
     @Override
@@ -1003,8 +1003,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ImHistoryResponse imHistory(RequestBuilder<ImHistoryRequest, ImHistoryRequest.ImHistoryRequestBuilder> req) throws IOException, SlackApiException {
-        return imHistory(req.build(ImHistoryRequest.builder()));
+    public ImHistoryResponse imHistory(RequestConfigurator<ImHistoryRequest.ImHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return imHistory(req.configure(ImHistoryRequest.builder()).build());
     }
 
     @Override
@@ -1013,8 +1013,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ImListResponse imList(RequestBuilder<ImListRequest, ImListRequest.ImListRequestBuilder> req) throws IOException, SlackApiException {
-        return imList(req.build(ImListRequest.builder()));
+    public ImListResponse imList(RequestConfigurator<ImListRequest.ImListRequestBuilder> req) throws IOException, SlackApiException {
+        return imList(req.configure(ImListRequest.builder()).build());
     }
 
     @Override
@@ -1023,8 +1023,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ImMarkResponse imMark(RequestBuilder<ImMarkRequest, ImMarkRequest.ImMarkRequestBuilder> req) throws IOException, SlackApiException {
-        return imMark(req.build(ImMarkRequest.builder()));
+    public ImMarkResponse imMark(RequestConfigurator<ImMarkRequest.ImMarkRequestBuilder> req) throws IOException, SlackApiException {
+        return imMark(req.configure(ImMarkRequest.builder()).build());
     }
 
     @Override
@@ -1033,8 +1033,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ImOpenResponse imOpen(RequestBuilder<ImOpenRequest, ImOpenRequest.ImOpenRequestBuilder> req) throws IOException, SlackApiException {
-        return imOpen(req.build(ImOpenRequest.builder()));
+    public ImOpenResponse imOpen(RequestConfigurator<ImOpenRequest.ImOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return imOpen(req.configure(ImOpenRequest.builder()).build());
     }
 
     @Override
@@ -1043,8 +1043,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ImRepliesResponse imReplies(RequestBuilder<ImRepliesRequest, ImRepliesRequest.ImRepliesRequestBuilder> req) throws IOException, SlackApiException {
-        return imReplies(req.build(ImRepliesRequest.builder()));
+    public ImRepliesResponse imReplies(RequestConfigurator<ImRepliesRequest.ImRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return imReplies(req.configure(ImRepliesRequest.builder()).build());
     }
 
     @Override
@@ -1053,8 +1053,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public MigrationExchangeResponse migrationExchange(RequestBuilder<MigrationExchangeRequest, MigrationExchangeRequest.MigrationExchangeRequestBuilder> req) throws IOException, SlackApiException {
-        return migrationExchange(req.build(MigrationExchangeRequest.builder()));
+    public MigrationExchangeResponse migrationExchange(RequestConfigurator<MigrationExchangeRequest.MigrationExchangeRequestBuilder> req) throws IOException, SlackApiException {
+        return migrationExchange(req.configure(MigrationExchangeRequest.builder()).build());
     }
 
     @Override
@@ -1063,8 +1063,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public MpimCloseResponse mpimClose(RequestBuilder<MpimCloseRequest, MpimCloseRequest.MpimCloseRequestBuilder> req) throws IOException, SlackApiException {
-        return mpimClose(req.build(MpimCloseRequest.builder()));
+    public MpimCloseResponse mpimClose(RequestConfigurator<MpimCloseRequest.MpimCloseRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimClose(req.configure(MpimCloseRequest.builder()).build());
     }
 
     @Override
@@ -1073,8 +1073,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public MpimHistoryResponse mpimHistory(RequestBuilder<MpimHistoryRequest, MpimHistoryRequest.MpimHistoryRequestBuilder> req) throws IOException, SlackApiException {
-        return mpimHistory(req.build(MpimHistoryRequest.builder()));
+    public MpimHistoryResponse mpimHistory(RequestConfigurator<MpimHistoryRequest.MpimHistoryRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimHistory(req.configure(MpimHistoryRequest.builder()).build());
     }
 
     @Override
@@ -1083,8 +1083,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public MpimListResponse mpimList(RequestBuilder<MpimListRequest, MpimListRequest.MpimListRequestBuilder> req) throws IOException, SlackApiException {
-        return mpimList(req.build(MpimListRequest.builder()));
+    public MpimListResponse mpimList(RequestConfigurator<MpimListRequest.MpimListRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimList(req.configure(MpimListRequest.builder()).build());
     }
 
     @Override
@@ -1093,8 +1093,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public MpimRepliesResponse mpimReplies(RequestBuilder<MpimRepliesRequest, MpimRepliesRequest.MpimRepliesRequestBuilder> req) throws IOException, SlackApiException {
-        return mpimReplies(req.build(MpimRepliesRequest.builder()));
+    public MpimRepliesResponse mpimReplies(RequestConfigurator<MpimRepliesRequest.MpimRepliesRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimReplies(req.configure(MpimRepliesRequest.builder()).build());
     }
 
     @Override
@@ -1103,8 +1103,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public MpimMarkResponse mpimMark(RequestBuilder<MpimMarkRequest, MpimMarkRequest.MpimMarkRequestBuilder> req) throws IOException, SlackApiException {
-        return mpimMark(req.build(MpimMarkRequest.builder()));
+    public MpimMarkResponse mpimMark(RequestConfigurator<MpimMarkRequest.MpimMarkRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimMark(req.configure(MpimMarkRequest.builder()).build());
     }
 
     @Override
@@ -1113,8 +1113,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public MpimOpenResponse mpimOpen(RequestBuilder<MpimOpenRequest, MpimOpenRequest.MpimOpenRequestBuilder> req) throws IOException, SlackApiException {
-        return mpimOpen(req.build(MpimOpenRequest.builder()));
+    public MpimOpenResponse mpimOpen(RequestConfigurator<MpimOpenRequest.MpimOpenRequestBuilder> req) throws IOException, SlackApiException {
+        return mpimOpen(req.configure(MpimOpenRequest.builder()).build());
     }
 
     @Override
@@ -1123,8 +1123,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public OAuthAccessResponse oauthAccess(RequestBuilder<OAuthAccessRequest, OAuthAccessRequest.OAuthAccessRequestBuilder> req) throws IOException, SlackApiException {
-        return oauthAccess(req.build(OAuthAccessRequest.builder()));
+    public OAuthAccessResponse oauthAccess(RequestConfigurator<OAuthAccessRequest.OAuthAccessRequestBuilder> req) throws IOException, SlackApiException {
+        return oauthAccess(req.configure(OAuthAccessRequest.builder()).build());
     }
 
     @Override
@@ -1133,8 +1133,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public OAuthTokenResponse oauthToken(RequestBuilder<OAuthTokenRequest, OAuthTokenRequest.OAuthTokenRequestBuilder> req) throws IOException, SlackApiException {
-        return oauthToken(req.build(OAuthTokenRequest.builder()));
+    public OAuthTokenResponse oauthToken(RequestConfigurator<OAuthTokenRequest.OAuthTokenRequestBuilder> req) throws IOException, SlackApiException {
+        return oauthToken(req.configure(OAuthTokenRequest.builder()).build());
     }
 
     @Override
@@ -1143,8 +1143,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public PinsAddResponse pinsAdd(RequestBuilder<PinsAddRequest, PinsAddRequest.PinsAddRequestBuilder> req) throws IOException, SlackApiException {
-        return pinsAdd(req.build(PinsAddRequest.builder()));
+    public PinsAddResponse pinsAdd(RequestConfigurator<PinsAddRequest.PinsAddRequestBuilder> req) throws IOException, SlackApiException {
+        return pinsAdd(req.configure(PinsAddRequest.builder()).build());
     }
 
     @Override
@@ -1153,8 +1153,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public PinsListResponse pinsList(RequestBuilder<PinsListRequest, PinsListRequest.PinsListRequestBuilder> req) throws IOException, SlackApiException {
-        return pinsList(req.build(PinsListRequest.builder()));
+    public PinsListResponse pinsList(RequestConfigurator<PinsListRequest.PinsListRequestBuilder> req) throws IOException, SlackApiException {
+        return pinsList(req.configure(PinsListRequest.builder()).build());
     }
 
     @Override
@@ -1163,8 +1163,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public PinsRemoveResponse pinsRemove(RequestBuilder<PinsRemoveRequest, PinsRemoveRequest.PinsRemoveRequestBuilder> req) throws IOException, SlackApiException {
-        return pinsRemove(req.build(PinsRemoveRequest.builder()));
+    public PinsRemoveResponse pinsRemove(RequestConfigurator<PinsRemoveRequest.PinsRemoveRequestBuilder> req) throws IOException, SlackApiException {
+        return pinsRemove(req.configure(PinsRemoveRequest.builder()).build());
     }
 
     @Override
@@ -1173,8 +1173,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ReactionsAddResponse reactionsAdd(RequestBuilder<ReactionsAddRequest, ReactionsAddRequest.ReactionsAddRequestBuilder> req) throws IOException, SlackApiException {
-        return reactionsAdd(req.build(ReactionsAddRequest.builder()));
+    public ReactionsAddResponse reactionsAdd(RequestConfigurator<ReactionsAddRequest.ReactionsAddRequestBuilder> req) throws IOException, SlackApiException {
+        return reactionsAdd(req.configure(ReactionsAddRequest.builder()).build());
     }
 
     @Override
@@ -1183,8 +1183,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ReactionsGetResponse reactionsGet(RequestBuilder<ReactionsGetRequest, ReactionsGetRequest.ReactionsGetRequestBuilder> req) throws IOException, SlackApiException {
-        return reactionsGet(req.build(ReactionsGetRequest.builder()));
+    public ReactionsGetResponse reactionsGet(RequestConfigurator<ReactionsGetRequest.ReactionsGetRequestBuilder> req) throws IOException, SlackApiException {
+        return reactionsGet(req.configure(ReactionsGetRequest.builder()).build());
     }
 
     @Override
@@ -1193,8 +1193,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ReactionsListResponse reactionsList(RequestBuilder<ReactionsListRequest, ReactionsListRequest.ReactionsListRequestBuilder> req) throws IOException, SlackApiException {
-        return reactionsList(req.build(ReactionsListRequest.builder()));
+    public ReactionsListResponse reactionsList(RequestConfigurator<ReactionsListRequest.ReactionsListRequestBuilder> req) throws IOException, SlackApiException {
+        return reactionsList(req.configure(ReactionsListRequest.builder()).build());
     }
 
     @Override
@@ -1203,8 +1203,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public ReactionsRemoveResponse reactionsRemove(RequestBuilder<ReactionsRemoveRequest, ReactionsRemoveRequest.ReactionsRemoveRequestBuilder> req) throws IOException, SlackApiException {
-        return reactionsRemove(req.build(ReactionsRemoveRequest.builder()));
+    public ReactionsRemoveResponse reactionsRemove(RequestConfigurator<ReactionsRemoveRequest.ReactionsRemoveRequestBuilder> req) throws IOException, SlackApiException {
+        return reactionsRemove(req.configure(ReactionsRemoveRequest.builder()).build());
     }
 
     @Override
@@ -1213,8 +1213,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public RemindersAddResponse remindersAdd(RequestBuilder<RemindersAddRequest, RemindersAddRequest.RemindersAddRequestBuilder> req) throws IOException, SlackApiException {
-        return remindersAdd(req.build(RemindersAddRequest.builder()));
+    public RemindersAddResponse remindersAdd(RequestConfigurator<RemindersAddRequest.RemindersAddRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersAdd(req.configure(RemindersAddRequest.builder()).build());
     }
 
     @Override
@@ -1223,8 +1223,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public RemindersCompleteResponse remindersComplete(RequestBuilder<RemindersCompleteRequest, RemindersCompleteRequest.RemindersCompleteRequestBuilder> req) throws IOException, SlackApiException {
-        return remindersComplete(req.build(RemindersCompleteRequest.builder()));
+    public RemindersCompleteResponse remindersComplete(RequestConfigurator<RemindersCompleteRequest.RemindersCompleteRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersComplete(req.configure(RemindersCompleteRequest.builder()).build());
     }
 
     @Override
@@ -1233,8 +1233,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public RemindersDeleteResponse remindersDelete(RequestBuilder<RemindersDeleteRequest, RemindersDeleteRequest.RemindersDeleteRequestBuilder> req) throws IOException, SlackApiException {
-        return remindersDelete(req.build(RemindersDeleteRequest.builder()));
+    public RemindersDeleteResponse remindersDelete(RequestConfigurator<RemindersDeleteRequest.RemindersDeleteRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersDelete(req.configure(RemindersDeleteRequest.builder()).build());
     }
 
     @Override
@@ -1243,8 +1243,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public RemindersInfoResponse remindersInfo(RequestBuilder<RemindersInfoRequest, RemindersInfoRequest.RemindersInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return remindersInfo(req.build(RemindersInfoRequest.builder()));
+    public RemindersInfoResponse remindersInfo(RequestConfigurator<RemindersInfoRequest.RemindersInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersInfo(req.configure(RemindersInfoRequest.builder()).build());
     }
 
     @Override
@@ -1253,8 +1253,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public RemindersListResponse remindersList(RequestBuilder<RemindersListRequest, RemindersListRequest.RemindersListRequestBuilder> req) throws IOException, SlackApiException {
-        return remindersList(req.build(RemindersListRequest.builder()));
+    public RemindersListResponse remindersList(RequestConfigurator<RemindersListRequest.RemindersListRequestBuilder> req) throws IOException, SlackApiException {
+        return remindersList(req.configure(RemindersListRequest.builder()).build());
     }
 
     @Override
@@ -1263,8 +1263,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public RTMConnectResponse rtmConnect(RequestBuilder<RTMConnectRequest, RTMConnectRequest.RTMConnectRequestBuilder> req) throws IOException, SlackApiException {
-        return rtmConnect(req.build(RTMConnectRequest.builder()));
+    public RTMConnectResponse rtmConnect(RequestConfigurator<RTMConnectRequest.RTMConnectRequestBuilder> req) throws IOException, SlackApiException {
+        return rtmConnect(req.configure(RTMConnectRequest.builder()).build());
     }
 
     @Override
@@ -1273,8 +1273,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public RTMStartResponse rtmStart(RequestBuilder<RTMStartRequest, RTMStartRequest.RTMStartRequestBuilder> req) throws IOException, SlackApiException {
-        return rtmStart(req.build(RTMStartRequest.builder()));
+    public RTMStartResponse rtmStart(RequestConfigurator<RTMStartRequest.RTMStartRequestBuilder> req) throws IOException, SlackApiException {
+        return rtmStart(req.configure(RTMStartRequest.builder()).build());
     }
 
     @Override
@@ -1283,8 +1283,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public SearchAllResponse searchAll(RequestBuilder<SearchAllRequest, SearchAllRequest.SearchAllRequestBuilder> req) throws IOException, SlackApiException {
-        return searchAll(req.build(SearchAllRequest.builder()));
+    public SearchAllResponse searchAll(RequestConfigurator<SearchAllRequest.SearchAllRequestBuilder> req) throws IOException, SlackApiException {
+        return searchAll(req.configure(SearchAllRequest.builder()).build());
     }
 
     @Override
@@ -1293,8 +1293,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public SearchMessagesResponse searchMessages(RequestBuilder<SearchMessagesRequest, SearchMessagesRequest.SearchMessagesRequestBuilder> req) throws IOException, SlackApiException {
-        return searchMessages(req.build(SearchMessagesRequest.builder()));
+    public SearchMessagesResponse searchMessages(RequestConfigurator<SearchMessagesRequest.SearchMessagesRequestBuilder> req) throws IOException, SlackApiException {
+        return searchMessages(req.configure(SearchMessagesRequest.builder()).build());
     }
 
     @Override
@@ -1303,8 +1303,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public SearchFilesResponse searchFiles(RequestBuilder<SearchFilesRequest, SearchFilesRequest.SearchFilesRequestBuilder> req) throws IOException, SlackApiException {
-        return searchFiles(req.build(SearchFilesRequest.builder()));
+    public SearchFilesResponse searchFiles(RequestConfigurator<SearchFilesRequest.SearchFilesRequestBuilder> req) throws IOException, SlackApiException {
+        return searchFiles(req.configure(SearchFilesRequest.builder()).build());
     }
 
     @Override
@@ -1313,8 +1313,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public StarsAddResponse starsAdd(RequestBuilder<StarsAddRequest, StarsAddRequest.StarsAddRequestBuilder> req) throws IOException, SlackApiException {
-        return starsAdd(req.build(StarsAddRequest.builder()));
+    public StarsAddResponse starsAdd(RequestConfigurator<StarsAddRequest.StarsAddRequestBuilder> req) throws IOException, SlackApiException {
+        return starsAdd(req.configure(StarsAddRequest.builder()).build());
     }
 
     @Override
@@ -1323,8 +1323,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public StarsListResponse starsList(RequestBuilder<StarsListRequest, StarsListRequest.StarsListRequestBuilder> req) throws IOException, SlackApiException {
-        return starsList(req.build(StarsListRequest.builder()));
+    public StarsListResponse starsList(RequestConfigurator<StarsListRequest.StarsListRequestBuilder> req) throws IOException, SlackApiException {
+        return starsList(req.configure(StarsListRequest.builder()).build());
     }
 
     @Override
@@ -1333,8 +1333,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public StarsRemoveResponse starsRemove(RequestBuilder<StarsRemoveRequest, StarsRemoveRequest.StarsRemoveRequestBuilder> req) throws IOException, SlackApiException {
-        return starsRemove(req.build(StarsRemoveRequest.builder()));
+    public StarsRemoveResponse starsRemove(RequestConfigurator<StarsRemoveRequest.StarsRemoveRequestBuilder> req) throws IOException, SlackApiException {
+        return starsRemove(req.configure(StarsRemoveRequest.builder()).build());
     }
 
     @Override
@@ -1343,8 +1343,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public TeamAccessLogsResponse teamAccessLogs(RequestBuilder<TeamAccessLogsRequest, TeamAccessLogsRequest.TeamAccessLogsRequestBuilder> req) throws IOException, SlackApiException {
-        return teamAccessLogs(req.build(TeamAccessLogsRequest.builder()));
+    public TeamAccessLogsResponse teamAccessLogs(RequestConfigurator<TeamAccessLogsRequest.TeamAccessLogsRequestBuilder> req) throws IOException, SlackApiException {
+        return teamAccessLogs(req.configure(TeamAccessLogsRequest.builder()).build());
     }
 
     @Override
@@ -1353,8 +1353,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public TeamBillableInfoResponse teamBillableInfo(RequestBuilder<TeamBillableInfoRequest, TeamBillableInfoRequest.TeamBillableInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return teamBillableInfo(req.build(TeamBillableInfoRequest.builder()));
+    public TeamBillableInfoResponse teamBillableInfo(RequestConfigurator<TeamBillableInfoRequest.TeamBillableInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return teamBillableInfo(req.configure(TeamBillableInfoRequest.builder()).build());
     }
 
     @Override
@@ -1363,8 +1363,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public TeamInfoResponse teamInfo(RequestBuilder<TeamInfoRequest, TeamInfoRequest.TeamInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return teamInfo(req.build(TeamInfoRequest.builder()));
+    public TeamInfoResponse teamInfo(RequestConfigurator<TeamInfoRequest.TeamInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return teamInfo(req.configure(TeamInfoRequest.builder()).build());
     }
 
     @Override
@@ -1373,8 +1373,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public TeamIntegrationLogsResponse teamIntegrationLogs(RequestBuilder<TeamIntegrationLogsRequest, TeamIntegrationLogsRequest.TeamIntegrationLogsRequestBuilder> req) throws IOException, SlackApiException {
-        return teamIntegrationLogs(req.build(TeamIntegrationLogsRequest.builder()));
+    public TeamIntegrationLogsResponse teamIntegrationLogs(RequestConfigurator<TeamIntegrationLogsRequest.TeamIntegrationLogsRequestBuilder> req) throws IOException, SlackApiException {
+        return teamIntegrationLogs(req.configure(TeamIntegrationLogsRequest.builder()).build());
     }
 
     @Override
@@ -1383,8 +1383,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public TeamProfileGetResponse teamProfileGet(RequestBuilder<TeamProfileGetRequest, TeamProfileGetRequest.TeamProfileGetRequestBuilder> req) throws IOException, SlackApiException {
-        return teamProfileGet(req.build(TeamProfileGetRequest.builder()));
+    public TeamProfileGetResponse teamProfileGet(RequestConfigurator<TeamProfileGetRequest.TeamProfileGetRequestBuilder> req) throws IOException, SlackApiException {
+        return teamProfileGet(req.configure(TeamProfileGetRequest.builder()).build());
     }
 
     @Override
@@ -1393,8 +1393,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsergroupsCreateResponse usergroupsCreate(RequestBuilder<UsergroupsCreateRequest, UsergroupsCreateRequest.UsergroupsCreateRequestBuilder> req) throws IOException, SlackApiException {
-        return usergroupsCreate(req.build(UsergroupsCreateRequest.builder()));
+    public UsergroupsCreateResponse usergroupsCreate(RequestConfigurator<UsergroupsCreateRequest.UsergroupsCreateRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsCreate(req.configure(UsergroupsCreateRequest.builder()).build());
     }
 
     @Override
@@ -1403,8 +1403,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsergroupsDisableResponse usergroupsDisable(RequestBuilder<UsergroupsDisableRequest, UsergroupsDisableRequest.UsergroupsDisableRequestBuilder> req) throws IOException, SlackApiException {
-        return usergroupsDisable(req.build(UsergroupsDisableRequest.builder()));
+    public UsergroupsDisableResponse usergroupsDisable(RequestConfigurator<UsergroupsDisableRequest.UsergroupsDisableRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsDisable(req.configure(UsergroupsDisableRequest.builder()).build());
     }
 
     @Override
@@ -1413,8 +1413,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsergroupsEnableResponse usergroupsEnable(RequestBuilder<UsergroupsEnableRequest, UsergroupsEnableRequest.UsergroupsEnableRequestBuilder> req) throws IOException, SlackApiException {
-        return usergroupsEnable(req.build(UsergroupsEnableRequest.builder()));
+    public UsergroupsEnableResponse usergroupsEnable(RequestConfigurator<UsergroupsEnableRequest.UsergroupsEnableRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsEnable(req.configure(UsergroupsEnableRequest.builder()).build());
     }
 
     @Override
@@ -1423,8 +1423,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsergroupsListResponse usergroupsList(RequestBuilder<UsergroupsListRequest, UsergroupsListRequest.UsergroupsListRequestBuilder> req) throws IOException, SlackApiException {
-        return usergroupsList(req.build(UsergroupsListRequest.builder()));
+    public UsergroupsListResponse usergroupsList(RequestConfigurator<UsergroupsListRequest.UsergroupsListRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsList(req.configure(UsergroupsListRequest.builder()).build());
     }
 
     @Override
@@ -1433,8 +1433,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsergroupsUpdateResponse usergroupsUpdate(RequestBuilder<UsergroupsUpdateRequest, UsergroupsUpdateRequest.UsergroupsUpdateRequestBuilder> req) throws IOException, SlackApiException {
-        return usergroupsUpdate(req.build(UsergroupsUpdateRequest.builder()));
+    public UsergroupsUpdateResponse usergroupsUpdate(RequestConfigurator<UsergroupsUpdateRequest.UsergroupsUpdateRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupsUpdate(req.configure(UsergroupsUpdateRequest.builder()).build());
     }
 
     @Override
@@ -1443,8 +1443,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsergroupUsersListResponse usergroupUsersList(RequestBuilder<UsergroupUsersListRequest, UsergroupUsersListRequest.UsergroupUsersListRequestBuilder> req) throws IOException, SlackApiException {
-        return usergroupUsersList(req.build(UsergroupUsersListRequest.builder()));
+    public UsergroupUsersListResponse usergroupUsersList(RequestConfigurator<UsergroupUsersListRequest.UsergroupUsersListRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupUsersList(req.configure(UsergroupUsersListRequest.builder()).build());
     }
 
     @Override
@@ -1453,8 +1453,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsergroupUsersUpdateResponse usergroupUsersUpdate(RequestBuilder<UsergroupUsersUpdateRequest, UsergroupUsersUpdateRequest.UsergroupUsersUpdateRequestBuilder> req) throws IOException, SlackApiException {
-        return usergroupUsersUpdate(req.build(UsergroupUsersUpdateRequest.builder()));
+    public UsergroupUsersUpdateResponse usergroupUsersUpdate(RequestConfigurator<UsergroupUsersUpdateRequest.UsergroupUsersUpdateRequestBuilder> req) throws IOException, SlackApiException {
+        return usergroupUsersUpdate(req.configure(UsergroupUsersUpdateRequest.builder()).build());
     }
 
     @Override
@@ -1463,8 +1463,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersConversationsResponse usersConversations(RequestBuilder<UsersConversationsRequest, UsersConversationsRequest.UsersConversationsRequestBuilder> req) throws IOException, SlackApiException {
-        return usersConversations(req.build(UsersConversationsRequest.builder()));
+    public UsersConversationsResponse usersConversations(RequestConfigurator<UsersConversationsRequest.UsersConversationsRequestBuilder> req) throws IOException, SlackApiException {
+        return usersConversations(req.configure(UsersConversationsRequest.builder()).build());
     }
 
     @Override
@@ -1473,8 +1473,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersDeletePhotoResponse usersDeletePhoto(RequestBuilder<UsersDeletePhotoRequest, UsersDeletePhotoRequest.UsersDeletePhotoRequestBuilder> req) throws IOException, SlackApiException {
-        return usersDeletePhoto(req.build(UsersDeletePhotoRequest.builder()));
+    public UsersDeletePhotoResponse usersDeletePhoto(RequestConfigurator<UsersDeletePhotoRequest.UsersDeletePhotoRequestBuilder> req) throws IOException, SlackApiException {
+        return usersDeletePhoto(req.configure(UsersDeletePhotoRequest.builder()).build());
     }
 
     @Override
@@ -1483,8 +1483,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersGetPresenceResponse usersGetPresence(RequestBuilder<UsersGetPresenceRequest, UsersGetPresenceRequest.UsersGetPresenceRequestBuilder> req) throws IOException, SlackApiException {
-        return usersGetPresence(req.build(UsersGetPresenceRequest.builder()));
+    public UsersGetPresenceResponse usersGetPresence(RequestConfigurator<UsersGetPresenceRequest.UsersGetPresenceRequestBuilder> req) throws IOException, SlackApiException {
+        return usersGetPresence(req.configure(UsersGetPresenceRequest.builder()).build());
     }
 
     @Override
@@ -1493,8 +1493,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersIdentityResponse usersIdentity(RequestBuilder<UsersIdentityRequest, UsersIdentityRequest.UsersIdentityRequestBuilder> req) throws IOException, SlackApiException {
-        return usersIdentity(req.build(UsersIdentityRequest.builder()));
+    public UsersIdentityResponse usersIdentity(RequestConfigurator<UsersIdentityRequest.UsersIdentityRequestBuilder> req) throws IOException, SlackApiException {
+        return usersIdentity(req.configure(UsersIdentityRequest.builder()).build());
     }
 
     @Override
@@ -1503,8 +1503,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersInfoResponse usersInfo(RequestBuilder<UsersInfoRequest, UsersInfoRequest.UsersInfoRequestBuilder> req) throws IOException, SlackApiException {
-        return usersInfo(req.build(UsersInfoRequest.builder()));
+    public UsersInfoResponse usersInfo(RequestConfigurator<UsersInfoRequest.UsersInfoRequestBuilder> req) throws IOException, SlackApiException {
+        return usersInfo(req.configure(UsersInfoRequest.builder()).build());
     }
 
     @Override
@@ -1513,8 +1513,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersListResponse usersList(RequestBuilder<UsersListRequest, UsersListRequest.UsersListRequestBuilder> req) throws IOException, SlackApiException {
-        return usersList(req.build(UsersListRequest.builder()));
+    public UsersListResponse usersList(RequestConfigurator<UsersListRequest.UsersListRequestBuilder> req) throws IOException, SlackApiException {
+        return usersList(req.configure(UsersListRequest.builder()).build());
     }
 
     @Override
@@ -1523,8 +1523,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersLookupByEmailResponse usersLookupByEmail(RequestBuilder<UsersLookupByEmailRequest, UsersLookupByEmailRequest.UsersLookupByEmailRequestBuilder> req) throws IOException, SlackApiException {
-        return usersLookupByEmail(req.build(UsersLookupByEmailRequest.builder()));
+    public UsersLookupByEmailResponse usersLookupByEmail(RequestConfigurator<UsersLookupByEmailRequest.UsersLookupByEmailRequestBuilder> req) throws IOException, SlackApiException {
+        return usersLookupByEmail(req.configure(UsersLookupByEmailRequest.builder()).build());
     }
 
     @Override
@@ -1533,8 +1533,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersSetActiveResponse usersSetActive(RequestBuilder<UsersSetActiveRequest, UsersSetActiveRequest.UsersSetActiveRequestBuilder> req) throws IOException, SlackApiException {
-        return usersSetActive(req.build(UsersSetActiveRequest.builder()));
+    public UsersSetActiveResponse usersSetActive(RequestConfigurator<UsersSetActiveRequest.UsersSetActiveRequestBuilder> req) throws IOException, SlackApiException {
+        return usersSetActive(req.configure(UsersSetActiveRequest.builder()).build());
     }
 
     @Override
@@ -1543,8 +1543,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersSetPhotoResponse usersSetPhoto(RequestBuilder<UsersSetPhotoRequest, UsersSetPhotoRequest.UsersSetPhotoRequestBuilder> req) throws IOException, SlackApiException {
-        return usersSetPhoto(req.build(UsersSetPhotoRequest.builder()));
+    public UsersSetPhotoResponse usersSetPhoto(RequestConfigurator<UsersSetPhotoRequest.UsersSetPhotoRequestBuilder> req) throws IOException, SlackApiException {
+        return usersSetPhoto(req.configure(UsersSetPhotoRequest.builder()).build());
     }
 
     @Override
@@ -1553,8 +1553,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersSetPresenceResponse usersSetPresence(RequestBuilder<UsersSetPresenceRequest, UsersSetPresenceRequest.UsersSetPresenceRequestBuilder> req) throws IOException, SlackApiException {
-        return usersSetPresence(req.build(UsersSetPresenceRequest.builder()));
+    public UsersSetPresenceResponse usersSetPresence(RequestConfigurator<UsersSetPresenceRequest.UsersSetPresenceRequestBuilder> req) throws IOException, SlackApiException {
+        return usersSetPresence(req.configure(UsersSetPresenceRequest.builder()).build());
     }
 
     @Override
@@ -1563,8 +1563,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersProfileGetResponse usersProfileGet(RequestBuilder<UsersProfileGetRequest, UsersProfileGetRequest.UsersProfileGetRequestBuilder> req) throws IOException, SlackApiException {
-        return usersProfileGet(req.build(UsersProfileGetRequest.builder()));
+    public UsersProfileGetResponse usersProfileGet(RequestConfigurator<UsersProfileGetRequest.UsersProfileGetRequestBuilder> req) throws IOException, SlackApiException {
+        return usersProfileGet(req.configure(UsersProfileGetRequest.builder()).build());
     }
 
     @Override
@@ -1573,8 +1573,8 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
-    public UsersProfileSetResponse usersProfileSet(RequestBuilder<UsersProfileSetRequest, UsersProfileSetRequest.UsersProfileSetRequestBuilder> req) throws IOException, SlackApiException {
-        return usersProfileSet(req.build(UsersProfileSetRequest.builder()));
+    public UsersProfileSetResponse usersProfileSet(RequestConfigurator<UsersProfileSetRequest.UsersProfileSetRequestBuilder> req) throws IOException, SlackApiException {
+        return usersProfileSet(req.configure(UsersProfileSetRequest.builder()).build());
     }
 
     protected <T> T doPostForm(

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClient.java
@@ -1,6 +1,6 @@
 package com.github.seratch.jslack.api.scim;
 
-import com.github.seratch.jslack.api.methods.RequestBuilder;
+import com.github.seratch.jslack.api.methods.RequestConfigurator;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.scim.request.UsersDeleteRequest;
 import com.github.seratch.jslack.api.scim.response.UsersDeleteResponse;
@@ -16,6 +16,6 @@ public interface SCIMClient {
 
     UsersDeleteResponse delete(UsersDeleteRequest req) throws IOException, SlackApiException;
 
-    UsersDeleteResponse delete(RequestBuilder<UsersDeleteRequest, UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SlackApiException;
+    UsersDeleteResponse delete(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SlackApiException;
 
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClientImpl.java
@@ -1,6 +1,6 @@
 package com.github.seratch.jslack.api.scim;
 
-import com.github.seratch.jslack.api.methods.RequestBuilder;
+import com.github.seratch.jslack.api.methods.RequestConfigurator;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.scim.request.UsersDeleteRequest;
 import com.github.seratch.jslack.api.scim.response.UsersDeleteResponse;
@@ -32,8 +32,8 @@ public class SCIMClientImpl implements SCIMClient {
     }
 
     @Override
-    public UsersDeleteResponse delete(RequestBuilder<UsersDeleteRequest, UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SlackApiException {
-        return delete(req.build(UsersDeleteRequest.builder()));
+    public UsersDeleteResponse delete(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SlackApiException {
+        return delete(req.configure(UsersDeleteRequest.builder()).build());
     }
 
     private <T> T doDeleteRequest(Request.Builder requestBuilder, Class<T> clazz) throws IOException, SlackApiException {

--- a/jslack-api-client/src/test/java/test_with_remote_apis/ExamplesTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/ExamplesTest.java
@@ -30,10 +30,10 @@ public class ExamplesTest {
     public void postAMessageToRandomChannel() throws IOException, SlackApiException, InterruptedException {
 
         // find all channels in the team
-        ChannelsListResponse channelsResponse = slack.methods().channelsList(r -> r.token(token).build());
+        ChannelsListResponse channelsResponse = slack.methods().channelsList(r -> r.token(token));
         assertThat(channelsResponse.isOk(), is(true));
         // find #random
-        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token)).getChannels();
         Channel random = null;
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {

--- a/jslack-api-client/src/test/java/test_with_remote_apis/UnnecessaryChannelsCleanerTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/UnnecessaryChannelsCleanerTest.java
@@ -30,14 +30,13 @@ public class UnnecessaryChannelsCleanerTest {
         for (Channel channel : slack.methods().channelsList(r -> r
                 .token(token)
                 .excludeArchived(true)
-                .limit(1000)
-                .build()).getChannels()) {
+                .limit(1000)).getChannels()) {
 
             log.info(channel.toString());
 
             if (channel.getName().startsWith("test") && !channel.isGeneral()) {
                 ChannelsArchiveResponse resp = slack.methods().channelsArchive(r -> r
-                        .token(token).channel(channel.getId()).build());
+                        .token(token).channel(channel.getId()));
                 assertThat(resp.getError(), is(nullValue()));
             }
         }
@@ -51,8 +50,7 @@ public class UnnecessaryChannelsCleanerTest {
                 .token(token)
                 .excludeArchived(true)
                 .limit(1000)
-                .types(Arrays.asList(ConversationType.PRIVATE_CHANNEL))
-                .build()).getChannels()) {
+                .types(Arrays.asList(ConversationType.PRIVATE_CHANNEL))).getChannels()) {
 
             log.info(channel.toString());
 
@@ -60,8 +58,7 @@ public class UnnecessaryChannelsCleanerTest {
                     && !channel.isGeneral()) {
                 ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
                         .token(token)
-                        .channel(channel.getId())
-                        .build());
+                        .channel(channel.getId()));
                 assertThat(resp.getError(), is(nullValue()));
             }
         }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/BlockKit_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/BlockKit_Test.java
@@ -49,7 +49,7 @@ public class BlockKit_Test {
             ChannelsListResponse channelsListResponse = slack.methods().channelsList(req -> req
                     .token(token)
                     .excludeArchived(true)
-                    .limit(100).build());
+                    .limit(100));
             assertThat(channelsListResponse.getError(), is(nullValue()));
             for (Channel channel : channelsListResponse.getChannels()) {
                 if (channel.getName().equals("random")) {

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/api_test_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/api_test_Test.java
@@ -29,7 +29,7 @@ public class api_test_Test {
 
     @Test
     public void ok() throws IOException, SlackApiException {
-        ApiTestResponse response = slack.methods().apiTest(req -> req.foo("fine").build());
+        ApiTestResponse response = slack.methods().apiTest(req -> req.foo("fine"));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getArgs().getFoo(), is("fine"));
@@ -37,7 +37,7 @@ public class api_test_Test {
 
     @Test
     public void error() throws IOException, SlackApiException {
-        ApiTestResponse response = slack.methods().apiTest(req -> req.error("error").build());
+        ApiTestResponse response = slack.methods().apiTest(req -> req.error("error"));
         assertThat(response.isOk(), is(false));
         assertThat(response.getError(), is("error"));
         assertThat(response.getArgs().getError(), is("error"));
@@ -51,7 +51,7 @@ public class api_test_Test {
         SlackHttpClient slackHttpClient = new SlackHttpClient(okHttpClient);
         Slack slack = Slack.getInstance(SlackTestConfig.get(), slackHttpClient);
 
-        ApiTestResponse response = slack.methods().apiTest(req -> req.foo("proxy?").build());
+        ApiTestResponse response = slack.methods().apiTest(req -> req.foo("proxy?"));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getArgs().getFoo(), is("proxy?"));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/apps_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/apps_Test.java
@@ -34,8 +34,7 @@ public class apps_Test {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         AppsPermissionsRequestResponse response = slack.methods().appsPermissionsRequest(req -> req
                 .token(token)
-                .triggerId("dummy")
-                .build());
+                .triggerId("dummy"));
         assertThat(response.getError(), is("not_allowed_token_type"));
         assertThat(response.isOk(), is(false));
     }
@@ -44,8 +43,7 @@ public class apps_Test {
     public void appsPermissionsInfo() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         AppsPermissionsInfoResponse response = slack.methods().appsPermissionsInfo(req -> req
-                .token(token)
-                .build());
+                .token(token));
         assertThat(response.getError(), is("not_allowed_token_type"));
         assertThat(response.isOk(), is(false));
     }
@@ -54,8 +52,7 @@ public class apps_Test {
     public void appsUninstall() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         AppsUninstallResponse response = slack.methods().appsUninstall(req -> req
-                .token(token)
-                .build());
+                .token(token));
         assertThat(response.getError(), is("not_allowed_token_type"));
         assertThat(response.isOk(), is(false));
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/auth_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/auth_Test.java
@@ -23,7 +23,7 @@ public class auth_Test {
 
     @Test
     public void authRevoke() throws IOException, SlackApiException {
-        AuthRevokeResponse response = slack.methods().authRevoke(req -> req.token("dummy").test(true).build());
+        AuthRevokeResponse response = slack.methods().authRevoke(req -> req.token("dummy").test(true));
         assertThat(response.isOk(), is(false));
         assertThat(response.getError(), is("invalid_auth"));
         assertThat(response.isRevoked(), is(false));
@@ -32,7 +32,7 @@ public class auth_Test {
     @Test
     public void authTest() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AuthTestResponse response = slack.methods().authTest(req -> req.token(token).build());
+        AuthTestResponse response = slack.methods().authTest(req -> req.token(token));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/bots_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/bots_Test.java
@@ -24,7 +24,7 @@ public class bots_Test {
 
     @Test
     public void botsInfoError() throws IOException, SlackApiException {
-        BotsInfoResponse response = slack.methods().botsInfo(req -> req.build());
+        BotsInfoResponse response = slack.methods().botsInfo(req -> req);
         assertThat(response.getError(), is(notNullValue()));
         assertThat(response.isOk(), is(false));
     }
@@ -33,7 +33,7 @@ public class bots_Test {
     public void botsInfo() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
 
-        List<User> users = slack.methods().usersList(req -> req.token(token).build()).getMembers();
+        List<User> users = slack.methods().usersList(req -> req.token(token)).getMembers();
         User user = null;
         for (User u : users) {
             if (u.isBot() && !"USLACKBOT".equals(u.getId())) {
@@ -43,7 +43,7 @@ public class bots_Test {
         }
         String bot = user.getProfile().getBotId();
 
-        BotsInfoResponse response = slack.methods().botsInfo(req -> req.token(token).bot(bot).build());
+        BotsInfoResponse response = slack.methods().botsInfo(req -> req.token(token).bot(bot));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getBot(), is(notNullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/chat_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/chat_Test.java
@@ -49,7 +49,7 @@ public class chat_Test {
     void loadRandomChannelId() throws IOException, SlackApiException {
         if (randomChannelId == null) {
             ChannelsListResponse channelsListResponse = slack.methods().channelsList(r ->
-                    r.token(token).excludeArchived(true).limit(100).build());
+                    r.token(token).excludeArchived(true).limit(100));
             assertThat(channelsListResponse.getError(), is(nullValue()));
             for (Channel channel : channelsListResponse.getChannels()) {
                 if (channel.getName().equals("random")) {
@@ -74,8 +74,7 @@ public class chat_Test {
                                 .callbackId("callback")
                                 .title("hi")
                                 .blocks(Arrays.asList(DividerBlock.builder().blockId("123").build()))
-                                .build()))
-                .build());
+                                .build())));
         assertThat(firstMessageCreation.getError(), is("invalid_attachments"));
     }
 
@@ -87,8 +86,7 @@ public class chat_Test {
                 .channel(randomChannelId)
                 .token(token)
                 .text("[thread] This is a test message posted by unit tests for jslack library")
-                .replyBroadcast(false)
-                .build());
+                .replyBroadcast(false));
         assertThat(firstMessageCreation.getError(), is(nullValue()));
         assertThat(firstMessageCreation.isOk(), is(true));
 
@@ -100,15 +98,14 @@ public class chat_Test {
                 .iconEmoji(":smile:")
                 .threadTs(firstMessageCreation.getTs())
                 //.replyBroadcast(true)
-                .build());
+                );
         assertThat(reply1.getError(), is(nullValue()));
         assertThat(reply1.isOk(), is(true));
 
         ChatGetPermalinkResponse permalink = slack.methods().chatGetPermalink(req -> req
                 .token(token)
                 .channel(randomChannelId)
-                .messageTs(reply1.getTs())
-                .build());
+                .messageTs(reply1.getTs()));
         assertThat(permalink.getError(), is(nullValue()));
         assertThat(permalink.isOk(), is(true));
         assertThat(permalink.getPermalink(), is(notNullValue()));
@@ -120,8 +117,7 @@ public class chat_Test {
                 .text("replied to " + permalink.getPermalink())
                 .threadTs(reply1.getTs())
                 .unfurlLinks(true)
-                .replyBroadcast(true)
-                .build());
+                .replyBroadcast(true));
         assertThat(reply2.isOk(), is(true));
 
         // Ideally, this message must contain an attachment which shows the preview for reply1
@@ -133,8 +129,7 @@ public class chat_Test {
             ChannelsHistoryResponse history = slack.methods().channelsHistory(req -> req
                     .token(token)
                     .channel(randomChannelId)
-                    .count(20)
-                    .build());
+                    .count(20));
             assertThat(history.isOk(), is(true));
 
             Message firstReply = history.getMessages().get(1);
@@ -162,8 +157,7 @@ public class chat_Test {
             ConversationsHistoryResponse history = slack.methods().conversationsHistory(req -> req
                     .token(token)
                     .channel(randomChannelId)
-                    .limit(20)
-                    .build());
+                    .limit(20));
             assertThat(history.isOk(), is(true));
 
             Message firstReply = history.getMessages().get(1);
@@ -192,8 +186,7 @@ public class chat_Test {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         ChannelsListResponse channels = slack.methods().channelsList(req -> req
                 .token(token)
-                .excludeArchived(true)
-                .build());
+                .excludeArchived(true));
         assertThat(channels.getError(), is(nullValue()));
         assertThat(channels.isOk(), is(true));
 
@@ -203,16 +196,14 @@ public class chat_Test {
                 .channel(channelId)
                 .token(token)
                 .text("Hi, this is a test message from jSlack library's unit tests")
-                .linkNames(true)
-                .build());
+                .linkNames(true));
         assertThat(postResponse.getError(), is(nullValue()));
         assertThat(postResponse.isOk(), is(true));
 
         ChatGetPermalinkResponse permalink = slack.methods().chatGetPermalink(req -> req
                 .token(token)
                 .channel(channelId)
-                .messageTs(postResponse.getTs())
-                .build());
+                .messageTs(postResponse.getTs()));
         assertThat(permalink.getError(), is(nullValue()));
         assertThat(permalink.isOk(), is(true));
         assertThat(permalink.getPermalink(), is(notNullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/conversations_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/conversations_Test.java
@@ -54,8 +54,7 @@ public class conversations_Test {
         ConversationsCreateResponse createPublicResponse = slack.methods().conversationsCreate(r -> r
                 .token(token)
                 .name("test" + System.currentTimeMillis())
-                .isPrivate(false)
-                .build());
+                .isPrivate(false));
         assertThat(createPublicResponse.getError(), is(nullValue()));
         assertThat(createPublicResponse.isOk(), is(true));
         assertThat(createPublicResponse.getChannel(), is(notNullValue()));
@@ -66,8 +65,7 @@ public class conversations_Test {
         ConversationsCreateResponse createPrivateResponse = slack.methods().conversationsCreate(r -> r
                 .token(token)
                 .name("test" + System.currentTimeMillis())
-                .isPrivate(true)
-                .build());
+                .isPrivate(true));
         assertThat(createPrivateResponse.getError(), is(nullValue()));
         assertThat(createPrivateResponse.isOk(), is(true));
         assertThat(createPrivateResponse.getChannel(), is(notNullValue()));
@@ -76,28 +74,24 @@ public class conversations_Test {
         {
             ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
                     .token(token)
-                    .channel(createPrivateResponse.getChannel().getId())
-                    .build());
+                    .channel(createPrivateResponse.getChannel().getId()));
             assertThat(resp.getError(), is(nullValue()));
         }
         {
             ConversationsUnarchiveResponse resp = slack.methods().conversationsUnarchive(r -> r
                     //.token(token)
-                    .channel(createPrivateResponse.getChannel().getId())
-                    .build());
+                    .channel(createPrivateResponse.getChannel().getId()));
             assertThat(resp.getError(), is(notNullValue()));
 
             resp = slack.methods().conversationsUnarchive(r -> r
                     .token(token)
-                    .channel(createPrivateResponse.getChannel().getId())
-                    .build());
+                    .channel(createPrivateResponse.getChannel().getId()));
             assertThat(resp.getError(), is(nullValue()));
         }
         {
             ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
                     .token(token)
-                    .channel(createPrivateResponse.getChannel().getId())
-                    .build());
+                    .channel(createPrivateResponse.getChannel().getId()));
             assertThat(resp.getError(), is(nullValue()));
         }
 
@@ -106,8 +100,7 @@ public class conversations_Test {
                     .token(token)
                     .channel(createPublicResponse.getChannel().getId())
                     .text("This is a test message posted by unit tests for jslack library")
-                    .replyBroadcast(false)
-                    .build());
+                    .replyBroadcast(false));
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
 
@@ -116,8 +109,7 @@ public class conversations_Test {
                     .channel(createPublicResponse.getChannel().getId())
                     .threadTs(postMessageResponse.getTs())
                     .text("[thread 1] This is a test message posted by unit tests for jslack library")
-                    .replyBroadcast(false)
-                    .build());
+                    .replyBroadcast(false));
             assertThat(postThread1Response.getError(), is(nullValue()));
             assertThat(postThread1Response.isOk(), is(true));
 
@@ -126,8 +118,7 @@ public class conversations_Test {
                     .channel(createPublicResponse.getChannel().getId())
                     .threadTs(postMessageResponse.getTs())
                     .text("[thread 2] This is a test message posted by unit tests for jslack library")
-                    .replyBroadcast(false)
-                    .build());
+                    .replyBroadcast(false));
             assertThat(postThread2Response.getError(), is(nullValue()));
             assertThat(postThread2Response.isOk(), is(true));
 
@@ -135,8 +126,7 @@ public class conversations_Test {
                     .token(token)
                     .channel(createPublicResponse.getChannel().getId())
                     .ts(postMessageResponse.getTs())
-                    .limit(1)
-                    .build());
+                    .limit(1));
             assertThat(repliesResponse.getError(), is(nullValue()));
             assertThat(repliesResponse.isOk(), is(true));
             assertThat(repliesResponse.getResponseMetadata(), is(notNullValue()));
@@ -146,8 +136,7 @@ public class conversations_Test {
             ConversationsInfoResponse infoResponse = slack.methods().conversationsInfo(r -> r
                     .token(token)
                     .channel(channel.getId())
-                    .includeLocale(true)
-                    .build());
+                    .includeLocale(true));
             assertThat(infoResponse.isOk(), is(true));
             Conversation fetchedConversation = infoResponse.getChannel();
             assertThat(fetchedConversation.isMember(), is(true));
@@ -163,8 +152,7 @@ public class conversations_Test {
             ConversationsSetPurposeResponse setPurposeResponse = slack.methods().conversationsSetPurpose(r -> r
                     .token(token)
                     .channel(channel.getId())
-                    .purpose("purpose")
-                    .build());
+                    .purpose("purpose"));
             assertThat(setPurposeResponse.getError(), is(nullValue()));
             assertThat(setPurposeResponse.isOk(), is(true));
             assertThat(setPurposeResponse.getChannel().getPurpose().getValue(), is("purpose"));
@@ -174,8 +162,7 @@ public class conversations_Test {
             ConversationsSetTopicResponse setTopicResponse = slack.methods().conversationsSetTopic(r -> r
                     .token(token)
                     .channel(channel.getId())
-                    .topic("topic")
-                    .build());
+                    .topic("topic"));
             assertThat(setTopicResponse.getError(), is(nullValue()));
             assertThat(setTopicResponse.isOk(), is(true));
             assertThat(setTopicResponse.getChannel().getTopic().getValue(), is("topic"));
@@ -185,8 +172,7 @@ public class conversations_Test {
             ConversationsHistoryResponse historyResponse = slack.methods().conversationsHistory(r -> r
                     .token(token)
                     .channel(channel.getId())
-                    .limit(2)
-                    .build());
+                    .limit(2));
             assertThat(historyResponse.getError(), is(nullValue()));
             assertThat(historyResponse.isOk(), is(true));
             // The outcome depends on data
@@ -198,16 +184,14 @@ public class conversations_Test {
             ConversationsMembersResponse membersResponse = slack.methods().conversationsMembers(r -> r
                     .token(token)
                     .channel(channel.getId())
-                    .limit(2)
-                    .build());
+                    .limit(2));
             assertThat(membersResponse.isOk(), is(true));
             assertThat(membersResponse.getMembers(), is(notNullValue()));
             assertThat(membersResponse.getMembers().isEmpty(), is(false));
             assertThat(membersResponse.getResponseMetadata(), is(notNullValue()));
 
             UsersListResponse usersListResponse = slack.methods().usersList(r -> r
-                    .token(token)
-                    .build());
+                    .token(token));
             String invitee_ = null;
             for (User u : usersListResponse.getMembers()) {
                 if (!"USLACKBOT".equals(u.getId()) && !membersResponse.getMembers().contains(u.getId())) {
@@ -219,16 +203,14 @@ public class conversations_Test {
             ConversationsInviteResponse inviteResponse = slack.methods().conversationsInvite(r -> r
                     .token(token)
                     .channel(channel.getId())
-                    .users(Arrays.asList(invitee))
-                    .build());
+                    .users(Arrays.asList(invitee)));
             assertThat(inviteResponse.getError(), is(nullValue()));
             assertThat(inviteResponse.isOk(), is(true));
 
             ConversationsKickResponse kickResponse = slack.methods().conversationsKick(r -> r
                     .token(token)
                     .channel(channel.getId())
-                    .user(invitee)
-                    .build());
+                    .user(invitee));
             assertThat(kickResponse.getError(), is(nullValue()));
             assertThat(kickResponse.isOk(), is(true));
         }
@@ -236,8 +218,7 @@ public class conversations_Test {
         {
             ConversationsLeaveResponse leaveResponse = slack.methods().conversationsLeave(r -> r
                     .token(token)
-                    .channel(channel.getId())
-                    .build());
+                    .channel(channel.getId()));
             assertThat(leaveResponse.getError(), is(nullValue()));
             assertThat(leaveResponse.isOk(), is(true));
         }
@@ -245,8 +226,7 @@ public class conversations_Test {
         {
             ConversationsJoinResponse joinResponse = slack.methods().conversationsJoin(r -> r
                     .token(token)
-                    .channel(channel.getId())
-                    .build());
+                    .channel(channel.getId()));
             assertThat(joinResponse.getError(), is(nullValue()));
             assertThat(joinResponse.isOk(), is(true));
         }
@@ -255,8 +235,7 @@ public class conversations_Test {
             ConversationsRenameResponse renameResponse = slack.methods().conversationsRename(r -> r
                     .token(token)
                     .channel(channel.getId())
-                    .name(channel.getName() + "-1")
-                    .build());
+                    .name(channel.getName() + "-1"));
             assertThat(renameResponse.getError(), is(nullValue()));
             assertThat(renameResponse.isOk(), is(true));
         }
@@ -264,8 +243,7 @@ public class conversations_Test {
         {
             ConversationsArchiveResponse archiveResponse = slack.methods().conversationsArchive(r -> r
                     .token(token)
-                    .channel(channel.getId())
-                    .build());
+                    .channel(channel.getId()));
             assertThat(archiveResponse.getError(), is(nullValue()));
             assertThat(archiveResponse.isOk(), is(true));
         }
@@ -273,8 +251,7 @@ public class conversations_Test {
         {
             ConversationsInfoResponse infoResponse = slack.methods().conversationsInfo(r -> r
                     .token(token)
-                    .channel(channel.getId())
-                    .build());
+                    .channel(channel.getId()));
             assertThat(infoResponse.getError(), is(nullValue()));
             assertThat(infoResponse.isOk(), is(true));
             Conversation fetchedChannel = infoResponse.getChannel();
@@ -287,29 +264,27 @@ public class conversations_Test {
     @Test
     public void imConversation() throws IOException, SlackApiException {
 
-        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(token).build());
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(token));
         List<User> users = usersListResponse.getMembers();
         String userId = users.get(0).getId();
 
         ConversationsOpenResponse openResponse = slack.methods().conversationsOpen(r -> r
                 .token(token)
                 .users(Arrays.asList(userId))
-                .returnIm(true)
-                .build());
+                .returnIm(true));
         assertThat(openResponse.getError(), is(nullValue()));
         assertThat(openResponse.isOk(), is(true));
 
         ConversationsMembersResponse membersResponse = slack.methods().conversationsMembers(r -> r
                 .token(token)
-                .channel(openResponse.getChannel().getId())
-                .build());
+                .channel(openResponse.getChannel().getId()));
         assertThat(membersResponse.getError(), is(nullValue()));
         assertThat(membersResponse.isOk(), is(true));
         assertThat(membersResponse.getMembers(), is(notNullValue()));
         assertThat(membersResponse.getMembers().isEmpty(), is(false));
 
         ConversationsCloseResponse closeResponse = slack.methods().conversationsClose(r ->
-                r.token(token).channel(openResponse.getChannel().getId()).build());
+                r.token(token).channel(openResponse.getChannel().getId()));
         assertThat(closeResponse.isOk(), is(true));
     }
 
@@ -337,8 +312,7 @@ public class conversations_Test {
                     .token(token)
                     .channel(channel.getId())
                     .text(longText)
-                    .replyBroadcast(false)
-                    .build());
+                    .replyBroadcast(false));
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
         }
@@ -349,8 +323,7 @@ public class conversations_Test {
                     .token(token)
                     .channel(channel.getId())
                     .attachments(Arrays.asList(Attachment.builder().text(longText).build()))
-                    .replyBroadcast(false)
-                    .build());
+                    .replyBroadcast(false));
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
         }
@@ -368,8 +341,7 @@ public class conversations_Test {
                                     (ContextBlockElement) MarkdownTextObject.builder().text(longText).build()
                             )).build()
                     ))
-                    .replyBroadcast(false)
-                    .build());
+                    .replyBroadcast(false));
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
         }
@@ -391,8 +363,7 @@ public class conversations_Test {
                         .token(token)
                         .channel(channel.getId())
                         .text(longText)
-                        .replyBroadcast(false)
-                        .build());
+                        .replyBroadcast(false));
                 assertThat(postMessageResponse.getError(), is(nullValue()));
                 assertThat(postMessageResponse.isOk(), is(true));
                 threadTs = postMessageResponse.getMessage().getTs();
@@ -405,8 +376,7 @@ public class conversations_Test {
                             .channel(channel.getId())
                             .threadTs(threadTs)
                             .text("Say something at " + new Date())
-                            .replyBroadcast(false)
-                            .build());
+                            .replyBroadcast(false));
                     assertThat(postMessageResponse.getError(), is(nullValue()));
                     assertThat(postMessageResponse.isOk(), is(true));
                 }
@@ -417,8 +387,7 @@ public class conversations_Test {
                 ChannelsRepliesResponse response = slack.methods().channelsReplies(r -> r
                         .token(token)
                         .threadTs(threadTs)
-                        .channel(channel.getId())
-                        .build());
+                        .channel(channel.getId()));
                 assertThat(response.getError(), is(nullValue()));
                 assertThat(response.isOk(), is(true));
 
@@ -435,8 +404,7 @@ public class conversations_Test {
                 ConversationsRepliesResponse response = slack.methods().conversationsReplies(r -> r
                         .token(token)
                         .ts(threadTs)
-                        .channel(channel.getId())
-                        .build());
+                        .channel(channel.getId()));
                 assertThat(response.getError(), is(nullValue()));
                 assertThat(response.isOk(), is(true));
 

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/dialogs_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/dialogs_Test.java
@@ -55,8 +55,7 @@ public class dialogs_Test {
         DialogOpenResponse dialogOpenResponse = slack.methods().dialogOpen(r -> r
                 .token(token)
                 .triggerId("FAKE_TRIGGER_ID")
-                .dialog(dialog)
-                .build());
+                .dialog(dialog));
         assertThat(dialogOpenResponse.isOk(), is(false));
         assertThat(dialogOpenResponse.getError(), is("invalid_trigger"));
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/dnd_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/dnd_Test.java
@@ -26,10 +26,10 @@ public class dnd_Test {
 
     @Test
     public void dnd() throws IOException, SlackApiException {
-        List<User> members = slack.methods().usersList(r -> r.token(token).presence(true).build()).getMembers();
+        List<User> members = slack.methods().usersList(r -> r.token(token).presence(true)).getMembers();
         {
             String user = members.get(0).getId();
-            DndInfoResponse response = slack.methods().dndInfo(r -> r.token(token).user(user).build());
+            DndInfoResponse response = slack.methods().dndInfo(r -> r.token(token).user(user));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getNextDndStartTs(), is(notNullValue()));
@@ -40,7 +40,7 @@ public class dnd_Test {
             for (User member : members) {
                 users.add(member.getId());
             }
-            DndTeamInfoResponse response = slack.methods().dndTeamInfo(r -> r.token(token).users(users).build());
+            DndTeamInfoResponse response = slack.methods().dndTeamInfo(r -> r.token(token).users(users));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getUsers(), is(notNullValue()));
@@ -52,14 +52,13 @@ public class dnd_Test {
         {
             DndEndDndResponse response = slack.methods().dndEndDnd(r -> r
                     //.token(token)
-                    .build());
+                    );
             assertThat(response.getError(), is(notNullValue()));
             assertThat(response.isOk(), is(false));
         }
         {
             DndEndDndResponse response = slack.methods().dndEndDnd(r -> r
-                    .token(token)
-                    .build());
+                    .token(token));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -70,14 +69,13 @@ public class dnd_Test {
         {
             DndEndSnoozeResponse response = slack.methods().dndEndSnooze(r -> r
                     //.token(token)
-                    .build());
+                    );
             assertThat(response.getError(), is(notNullValue()));
             assertThat(response.isOk(), is(false));
         }
         {
             DndEndSnoozeResponse response = slack.methods().dndEndSnooze(r -> r
-                    .token(token)
-                    .build());
+                    .token(token));
             assertThat(response.getError(), is("snooze_not_active"));
             assertThat(response.isOk(), is(false));
         }
@@ -85,23 +83,20 @@ public class dnd_Test {
         {
             DndSetSnoozeResponse response = slack.methods().dndSetSnooze(r -> r
                     //.token(token)
-                    .numMinutes(10)
-                    .build());
+                    .numMinutes(10));
             assertThat(response.getError(), is(notNullValue()));
             assertThat(response.isOk(), is(false));
         }
         {
             DndSetSnoozeResponse response = slack.methods().dndSetSnooze(r -> r
                     .token(token)
-                    .numMinutes(10)
-                    .build());
+                    .numMinutes(10));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
         {
             DndEndSnoozeResponse response = slack.methods().dndEndSnooze(r -> r
-                    .token(token)
-                    .build());
+                    .token(token));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/emoji_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/emoji_Test.java
@@ -24,7 +24,7 @@ public class emoji_Test {
     public void emojiList() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         {
-            EmojiListResponse response = slack.methods().emojiList(r -> r.token(token).build());
+            EmojiListResponse response = slack.methods().emojiList(r -> r.token(token));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getEmoji(), is(notNullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/files_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/files_Test.java
@@ -43,7 +43,7 @@ public class files_Test {
     @Test
     public void describe() throws IOException, SlackApiException {
         {
-            FilesListResponse response = slack.methods().filesList(r -> r.token(token).build());
+            FilesListResponse response = slack.methods().filesList(r -> r.token(token));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getFiles(), is(notNullValue()));
@@ -52,7 +52,7 @@ public class files_Test {
 
     @Test
     public void createTextFileAndComments() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token)).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -71,8 +71,7 @@ public class files_Test {
                     .file(file)
                     .filename("sample.txt")
                     .initialComment("initial comment")
-                    .title("file title")
-                    .build());
+                    .title("file title"));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             fileObj = response.getFile();
@@ -175,15 +174,14 @@ public class files_Test {
         {
             FilesInfoResponse response = slack.methods().filesInfo(r -> r
                     .token(token)
-                    .file(fileObj.getId())
-                    .build());
+                    .file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
             FilesSharedPublicURLResponse response = slack.methods().filesSharedPublicURL(
-                    r -> r.token(token).file(fileObj.getId()).build());
+                    r -> r.token(token).file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -249,7 +247,6 @@ public class files_Test {
                             .getShares()
                             .getPublicChannels().get(channelId).get(0)
                             .getTs())
-                    .build()
             );
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
@@ -257,8 +254,7 @@ public class files_Test {
         {
             FilesDeleteResponse response = slack.methods().filesDelete(r -> r
                     .token(token)
-                    .file(fileObj.getId())
-                    .build());
+                    .file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -266,7 +262,7 @@ public class files_Test {
 
     @Test
     public void createLongTextFile() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token)).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -285,8 +281,7 @@ public class files_Test {
                     .file(file)
                     .filename("sample.txt")
                     .initialComment("initial comment")
-                    .title("file title")
-                    .build());
+                    .title("file title"));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             fileObj = response.getFile();
@@ -347,7 +342,6 @@ public class files_Test {
                             .getShares()
                             .getPublicChannels().get(channelId).get(0)
                             .getTs())
-                    .build()
             );
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
@@ -356,8 +350,7 @@ public class files_Test {
         {
             FilesDeleteResponse response = slack.methods().filesDelete(r -> r
                     .token(token)
-                    .file(fileObj.getId())
-                    .build());
+                    .file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -365,7 +358,7 @@ public class files_Test {
 
     @Test
     public void createImageFileAndComments() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token)).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -384,8 +377,7 @@ public class files_Test {
                     .file(file)
                     .filename("seratch.jpg")
                     .initialComment("This is me!")
-                    .title("@seratch")
-                    .build());
+                    .title("@seratch"));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             fileObj = response.getFile();
@@ -584,8 +576,7 @@ public class files_Test {
                     .token(token)
                     .channel(channel.getId())
                     .text("This is a test message posted by unit tests for jslack library")
-                    .replyBroadcast(false)
-                    .build());
+                    .replyBroadcast(false));
             assertThat(postMessageResponse.getError(), is(nullValue()));
             assertThat(postMessageResponse.isOk(), is(true));
 
@@ -594,8 +585,7 @@ public class files_Test {
                     .channel(channel.getId())
                     .threadTs(postMessageResponse.getTs())
                     .text("[thread 1] This is a test message posted by unit tests for jslack library")
-                    .replyBroadcast(false)
-                    .build());
+                    .replyBroadcast(false));
             assertThat(postThread1Response.getError(), is(nullValue()));
             assertThat(postThread1Response.isOk(), is(true));
 
@@ -608,8 +598,7 @@ public class files_Test {
                         .filename("sample.txt")
                         .initialComment("initial comment")
                         .title("file title")
-                        .threadTs(postThread1Response.getTs())
-                        .build());
+                        .threadTs(postThread1Response.getTs()));
                 assertThat(response.getError(), is(nullValue()));
                 assertThat(response.isOk(), is(true));
                 fileObj = response.getFile();
@@ -618,8 +607,7 @@ public class files_Test {
             {
                 FilesInfoResponse response = slack.methods().filesInfo(r -> r
                         .token(token)
-                        .file(fileObj.getId())
-                        .build());
+                        .file(fileObj.getId()));
                 assertThat(response.getError(), is(nullValue()));
                 assertThat(response.isOk(), is(true));
             }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/groups_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/groups_Test.java
@@ -30,8 +30,7 @@ public class groups_Test {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
 
         String name = "secret-" + System.currentTimeMillis();
-        GroupsCreateResponse creationResponse = slack.methods().groupsCreate(
-                r -> r.token(token).name(name).build());
+        GroupsCreateResponse creationResponse = slack.methods().groupsCreate(r -> r.token(token).name(name));
         Group group = creationResponse.getGroup();
         {
             assertThat(creationResponse.getError(), is(nullValue()));
@@ -79,16 +78,14 @@ public class groups_Test {
             ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(r -> r
                     .token(token)
                     .text("How are you?")
-                    .channel(groupId)
-                    .build());
+                    .channel(groupId));
             assertThat(postResponse.getError(), is(nullValue()));
 
             ChatPostMessageResponse replyResponse = slack.methods().chatPostMessage(r -> r
                     .token(token)
                     .threadTs(postResponse.getTs())
                     .text("Great! How are you?")
-                    .channel(groupId)
-                    .build());
+                    .channel(groupId));
             assertThat(replyResponse.getError(), is(nullValue()));
 
             String ts = postResponse.getTs();
@@ -100,8 +97,7 @@ public class groups_Test {
             GroupsRepliesResponse repliesResponse = slack.methods().groupsReplies(r -> r
                     .token(token)
                     .channel(groupId)
-                    .threadTs(postResponse.getTs())
-                    .build());
+                    .threadTs(postResponse.getTs()));
             assertThat(repliesResponse.getError(), is(nullValue()));
             assertThat(repliesResponse.isOk(), is(true));
         }
@@ -127,7 +123,7 @@ public class groups_Test {
             assertThat(response.isOk(), is(true));
         }
         String userIdToInvite = null;
-        List<User> users = slack.methods().usersList(r -> r.token(token).limit(100).build()).getMembers();
+        List<User> users = slack.methods().usersList(r -> r.token(token).limit(100)).getMembers();
         for (User user : users) {
             boolean alreadyInTheGroup = false;
             for (String groupMember : group.getMembers()) {

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/im_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/im_Test.java
@@ -27,23 +27,20 @@ public class im_Test {
     public void operations() throws Exception {
         ImListResponse listResponse = slack.methods().imList(r -> r
                 .token(token)
-                .limit(2)
-                .build());
+                .limit(2));
         assertThat(listResponse.getError(), is(nullValue()));
         assertThat(listResponse.isOk(), is(true));
         assertThat(listResponse.getResponseMetadata(), is(notNullValue()));
 
         UsersListResponse usersListResponse = slack.methods().usersList(r -> r
                 .token(token)
-                .presence(true)
-                .build());
+                .presence(true));
         List<User> users = usersListResponse.getMembers();
         final String userId = users.get(0).getId();
 
         ImOpenResponse openResponse = slack.methods().imOpen(r -> r
                 .token(token)
-                .user(userId)
-                .build());
+                .user(userId));
         assertThat(openResponse.getError(), is(nullValue()));
         assertThat(openResponse.isOk(), is(true));
 
@@ -53,8 +50,7 @@ public class im_Test {
         {
             ImMarkResponse markResponse = slack.methods().imMark(r -> r
                     .token(token)
-                    .channel(channelId)
-                    .build());
+                    .channel(channelId));
             assertThat(markResponse.isOk(), is(false));
             assertThat(markResponse.getError(), is("invalid_timestamp"));
         }
@@ -62,7 +58,7 @@ public class im_Test {
         ChatPostMessageResponse firstMessageResponse = slack.methods().chatPostMessage(r -> r
                 .token(token)
                 .channel(channelId)
-                .text("Hi!").build());
+                .text("Hi!"));
         assertThat(firstMessageResponse.getError(), is(nullValue()));
         assertThat(firstMessageResponse.isOk(), is(true));
 
@@ -71,8 +67,7 @@ public class im_Test {
             ImMarkResponse markResponse = slack.methods().imMark(r -> r
                     .token(token)
                     .channel(channelId)
-                    .ts(firstMessageResponse.getTs())
-                    .build());
+                    .ts(firstMessageResponse.getTs()));
             assertThat(markResponse.getError(), is(nullValue()));
             assertThat(markResponse.isOk(), is(true));
         }
@@ -81,30 +76,27 @@ public class im_Test {
                 .token(token)
                 .channel(channelId)
                 .threadTs(firstMessageResponse.getTs())
-                .text("Hi!").build());
+                .text("Hi!"));
         assertThat(threadReplyResponse.getError(), is(nullValue()));
         assertThat(threadReplyResponse.isOk(), is(true));
 
         ImRepliesResponse repliesResponse = slack.methods().imReplies(r -> r
                 .token(token)
                 .channel(channelId)
-                .threadTs(threadReplyResponse.getMessage().getThreadTs())
-                .build());
+                .threadTs(threadReplyResponse.getMessage().getThreadTs()));
         assertThat(repliesResponse.getError(), is(nullValue()));
         assertThat(repliesResponse.isOk(), is(true));
 
         ImHistoryResponse historyResponse = slack.methods().imHistory(r -> r
                 .token(token)
                 .channel(channelId)
-                .count(10)
-                .build());
+                .count(10));
         assertThat(historyResponse.getError(), is(nullValue()));
         assertThat(historyResponse.isOk(), is(true));
 
         ImCloseResponse closeResponse = slack.methods().imClose(r -> r
                 .token(token)
-                .channel(channelId)
-                .build());
+                .channel(channelId));
         assertThat(closeResponse.getError(), is(nullValue()));
         assertThat(closeResponse.isOk(), is(true));
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/mpim_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/mpim_Test.java
@@ -26,10 +26,10 @@ public class mpim_Test {
 
     @Test
     public void operations() throws IOException, SlackApiException {
-        MpimListResponse listResponse = slack.methods().mpimList(r -> r.token(token).build());
+        MpimListResponse listResponse = slack.methods().mpimList(r -> r.token(token));
         assertThat(listResponse.isOk(), is(true));
 
-        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(token).presence(true).build());
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(token).presence(true));
         List<User> users = usersListResponse.getMembers();
         List<String> userIds = new ArrayList<>();
         for (User u : users) {
@@ -40,21 +40,21 @@ public class mpim_Test {
             }
         }
 
-        MpimOpenResponse openResponse = slack.methods().mpimOpen(r -> r.token(token).users(userIds).build());
+        MpimOpenResponse openResponse = slack.methods().mpimOpen(r -> r.token(token).users(userIds));
         assertThat(openResponse.getError(), is(nullValue()));
         assertThat(openResponse.isOk(), is(true));
 
         String channelId = openResponse.getGroup().getId();
 
-        MpimMarkResponse markResponse = slack.methods().mpimMark(r -> r.token(token).channel(channelId).build());
+        MpimMarkResponse markResponse = slack.methods().mpimMark(r -> r.token(token).channel(channelId));
         assertThat(markResponse.getError(), is(nullValue()));
         assertThat(markResponse.isOk(), is(true));
 
-        MpimHistoryResponse historyResponse = slack.methods().mpimHistory(r -> r.token(token).channel(channelId).count(10).build());
+        MpimHistoryResponse historyResponse = slack.methods().mpimHistory(r -> r.token(token).channel(channelId).count(10));
         assertThat(historyResponse.getError(), is(nullValue()));
         assertThat(historyResponse.isOk(), is(true));
 
-        MpimCloseResponse closeResponse = slack.methods().mpimClose(r -> r.token(token).channel(channelId).build());
+        MpimCloseResponse closeResponse = slack.methods().mpimClose(r -> r.token(token).channel(channelId));
         assertThat(closeResponse.getError(), is(nullValue()));
         assertThat(closeResponse.isOk(), is(true));
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/oauth_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/oauth_Test.java
@@ -26,8 +26,7 @@ public class oauth_Test {
                     .clientId("3485157640.XXXX")
                     .clientSecret("XXXXX")
                     .code("")
-                    .redirectUri("http://seratch.net/foo")
-                    .build());
+                    .redirectUri("http://seratch.net/foo"));
             assertThat(response.getError(), is("invalid_code"));
             assertThat(response.isOk(), is(false));
         }
@@ -41,8 +40,7 @@ public class oauth_Test {
                     .clientId("3485157640.XXXX")
                     .clientSecret("XXXXX")
                     .code("")
-                    .redirectUri("http://seratch.net/foo")
-                    .build());
+                    .redirectUri("http://seratch.net/foo"));
             assertThat(response.getError(), is("invalid_code"));
             assertThat(response.isOk(), is(false));
         }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/pins_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/pins_Test.java
@@ -30,7 +30,7 @@ public class pins_Test {
 
     @Test
     public void list() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token)).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -40,7 +40,7 @@ public class pins_Test {
         }
 
         PinsListResponse response = slack.methods().pinsList(
-                r -> r.token(token).channel(channels.get(0)).build());
+                r -> r.token(token).channel(channels.get(0)));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getItems(), is(notNullValue()));
@@ -48,7 +48,7 @@ public class pins_Test {
 
     @Test
     public void add() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token)).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -66,8 +66,7 @@ public class pins_Test {
                     .file(file)
                     .filename("sample.txt")
                     .initialComment("initial comment")
-                    .title("file title")
-                    .build());
+                    .title("file title"));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             fileObj = response.getFile();
@@ -77,8 +76,7 @@ public class pins_Test {
             PinsAddResponse response = slack.methods().pinsAdd(r -> r
                     .token(token)
                     .channel(channels.get(0))
-                    .file(fileObj.getId())
-                    .build());
+                    .file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -86,8 +84,7 @@ public class pins_Test {
             PinsRemoveResponse response = slack.methods().pinsRemove(r -> r
                     .token(token)
                     .channel(channels.get(0))
-                    .file(fileObj.getId())
-                    .build());
+                    .file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -98,8 +95,7 @@ public class pins_Test {
                 PinsAddResponse response = slack.methods().pinsAdd(r -> r
                         .token(token)
                         .channel(channels.get(0))
-                        .fileComment(fileObj.getInitialComment().getId())
-                        .build());
+                        .fileComment(fileObj.getInitialComment().getId()));
                 assertThat(response.getError(), is(nullValue()));
                 assertThat(response.isOk(), is(true));
             }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/reactions_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/reactions_Test.java
@@ -28,7 +28,7 @@ public class reactions_Test {
 
     @Test
     public void test() throws IOException, SlackApiException {
-        String channel = slack.methods().channelsList(r -> r.token(token).excludeArchived(true).build())
+        String channel = slack.methods().channelsList(r -> r.token(token).excludeArchived(true))
                 .getChannels().get(0).getId();
 
         ChatPostMessageResponse postMessage = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
@@ -44,16 +44,14 @@ public class reactions_Test {
                 .token(token)
                 .name("smile")
                 .channel(channel)
-                .timestamp(timestamp)
-                .build());
+                .timestamp(timestamp));
         assertThat(addResponse.getError(), is(nullValue()));
         assertThat(addResponse.isOk(), is(true));
 
         ReactionsGetResponse getResponse = slack.methods().reactionsGet(r -> r
                 .token(token)
                 .channel(channel)
-                .timestamp(timestamp)
-                .build());
+                .timestamp(timestamp));
         assertThat(getResponse.getError(), is(nullValue()));
         assertThat(getResponse.isOk(), is(true));
 
@@ -61,8 +59,7 @@ public class reactions_Test {
                 .token(token)
                 .name("smile")
                 .channel(channel)
-                .timestamp(timestamp)
-                .build());
+                .timestamp(timestamp));
         assertThat(removeResponse.getError(), is(nullValue()));
         assertThat(removeResponse.isOk(), is(true));
 
@@ -70,13 +67,12 @@ public class reactions_Test {
 
     @Test
     public void list() throws IOException, SlackApiException {
-        String user = slack.methods().usersList(r -> r.token(token).build())
+        String user = slack.methods().usersList(r -> r.token(token))
                 .getMembers().get(0).getId();
 
         ReactionsListResponse response = slack.methods().reactionsList(r -> r
                 .token(token)
-                .user(user)
-                .build());
+                .user(user));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getItems(), is(notNullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/reminders_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/reminders_Test.java
@@ -25,8 +25,7 @@ public class reminders_Test {
         RemindersAddResponse addResponse = slack.methods().remindersAdd(r -> r
                 .token(token)
                 .text("Don't forget it!")
-                .time("10")
-                .build());
+                .time("10"));
         assertThat(addResponse.getError(), is(nullValue()));
         assertThat(addResponse.isOk(), is(true));
 
@@ -34,22 +33,19 @@ public class reminders_Test {
 
         RemindersInfoResponse infoResponse = slack.methods().remindersInfo(r -> r
                 .token(token)
-                .reminder(reminderId)
-                .build());
+                .reminder(reminderId));
         assertThat(infoResponse.getError(), is(nullValue()));
         assertThat(infoResponse.isOk(), is(true));
 
         RemindersCompleteResponse completeResponse = slack.methods().remindersComplete(r -> r
                 .token(token)
-                .reminder(reminderId)
-                .build());
+                .reminder(reminderId));
         assertThat(completeResponse.getError(), is(nullValue()));
         assertThat(completeResponse.isOk(), is(true));
 
         RemindersDeleteResponse deleteResponse = slack.methods().remindersDelete(r -> r
                 .token(token)
-                .reminder(reminderId)
-                .build());
+                .reminder(reminderId));
         assertThat(deleteResponse.getError(), is(nullValue()));
         assertThat(deleteResponse.isOk(), is(true));
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/scim_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/scim_Test.java
@@ -25,8 +25,7 @@ public class scim_Test {
         try {
             UsersDeleteResponse response = slack.scim().delete(r -> r
                     .token(token)
-                    .id(userId)
-                    .build());
+                    .id(userId));
 
             // testing with an SCIM activated account
             assertThat(response.getError(), is(nullValue()));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/search_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/search_Test.java
@@ -26,7 +26,7 @@ public class search_Test {
 
     @Test
     public void all() throws IOException, SlackApiException {
-        SearchAllResponse response = slack.methods().searchAll(r -> r.token(token).query("test").build());
+        SearchAllResponse response = slack.methods().searchAll(r -> r.token(token).query("test"));
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -34,7 +34,7 @@ public class search_Test {
 
     @Test
     public void messages() throws IOException, SlackApiException {
-        SearchMessagesResponse response = slack.methods().searchMessages(r -> r.token(token).query("test").build());
+        SearchMessagesResponse response = slack.methods().searchMessages(r -> r.token(token).query("test"));
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -46,7 +46,7 @@ public class search_Test {
 
     @Test
     public void files() throws IOException, SlackApiException {
-        SearchFilesResponse response = slack.methods().searchFiles(r -> r.token(token).query("test").build());
+        SearchFilesResponse response = slack.methods().searchFiles(r -> r.token(token).query("test"));
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/stars_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/stars_Test.java
@@ -30,7 +30,7 @@ public class stars_Test {
 
     @Test
     public void list() throws IOException, SlackApiException {
-        StarsListResponse response = slack.methods().starsList(r -> r.token(token).build());
+        StarsListResponse response = slack.methods().starsList(r -> r.token(token));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getItems(), is(notNullValue()));
@@ -38,7 +38,7 @@ public class stars_Test {
 
     @Test
     public void add() throws IOException, SlackApiException {
-        List<Channel> channels = slack.methods().channelsList(r -> r.token(token).build()).getChannels();
+        List<Channel> channels = slack.methods().channelsList(r -> r.token(token)).getChannels();
         List<String> channelIds = new ArrayList<>();
         for (Channel c : channels) {
             if (c.getName().equals("random")) {
@@ -56,8 +56,7 @@ public class stars_Test {
                     .file(file)
                     .filename("sample.txt")
                     .initialComment("initial comment")
-                    .title("file title")
-                    .build());
+                    .title("file title"));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             fileObj = response.getFile();
@@ -67,8 +66,7 @@ public class stars_Test {
             StarsAddResponse response = slack.methods().starsAdd(r -> r
                     .token(token)
                     .channel(channelIds.get(0))
-                    .file(fileObj.getId())
-                    .build());
+                    .file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -76,8 +74,7 @@ public class stars_Test {
             StarsRemoveResponse response = slack.methods().starsRemove(r -> r
                     .token(token)
                     .channel(channelIds.get(0))
-                    .file(fileObj.getId())
-                    .build());
+                    .file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -88,8 +85,7 @@ public class stars_Test {
                 StarsAddResponse response = slack.methods().starsAdd(r -> r
                         .token(token)
                         .channel(channelIds.get(0))
-                        .fileComment(fileObj.getInitialComment().getId())
-                        .build());
+                        .fileComment(fileObj.getInitialComment().getId()));
                 assertThat(response.getError(), is(nullValue()));
                 assertThat(response.isOk(), is(true));
             }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/team_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/team_Test.java
@@ -26,9 +26,7 @@ public class team_Test {
 
     @Test
     public void teamAccessLogs() throws Exception {
-        TeamAccessLogsResponse response = slack.methods().teamAccessLogs(r -> r
-                .token(token)
-                .build());
+        TeamAccessLogsResponse response = slack.methods().teamAccessLogs(r -> r.token(token));
         if (response.isOk()) {
             // when you pay for this team
             assertThat(response.getError(), is(nullValue()));
@@ -42,7 +40,7 @@ public class team_Test {
 
     @Test
     public void teamBillableInfo() throws Exception {
-        List<User> users = slack.methods().usersList(r -> r.token(token).build()).getMembers();
+        List<User> users = slack.methods().usersList(r -> r.token(token)).getMembers();
         User user = null;
         for (User u : users) {
             if (!u.isBot() && !"USLACKBOT".equals(u.getId())) {
@@ -53,35 +51,31 @@ public class team_Test {
         String userId = user.getId();
         TeamBillableInfoResponse response = slack.methods().teamBillableInfo(r -> r
                 .token(token)
-                .user(userId)
-                .build());
+                .user(userId));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void teamInfo() throws Exception {
-        TeamInfoResponse response = slack.methods().teamInfo(r -> r
-                .token(token)
-                .build());
+        TeamInfoResponse response = slack.methods().teamInfo(r -> r.token(token));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void teamIntegrationLogs() throws Exception {
-        String user = slack.methods().usersList(r -> r.token(token).build()).getMembers().get(0).getId();
+        String user = slack.methods().usersList(r -> r.token(token)).getMembers().get(0).getId();
         TeamIntegrationLogsResponse response = slack.methods().teamIntegrationLogs(r -> r
                 .token(token)
-                .user(user)
-                .build());
+                .user(user));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void teamProfileGet() throws Exception {
-        TeamProfileGetResponse response = slack.methods().teamProfileGet(r -> r.token(token).build());
+        TeamProfileGetResponse response = slack.methods().teamProfileGet(r -> r.token(token));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/usergroups_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/usergroups_Test.java
@@ -34,8 +34,7 @@ public class usergroups_Test {
         String usergroupName = "usergroup-" + System.currentTimeMillis();
         UsergroupsCreateResponse response = slack.methods().usergroupsCreate(r -> r
                 .token(token)
-                .name(usergroupName)
-                .build());
+                .name(usergroupName));
         if (response.isOk()) {
             assertThat(response.getUsergroup(), is(notNullValue()));
             assertThat(response.getUsergroup().getName(), is(usergroupName));
@@ -51,14 +50,14 @@ public class usergroups_Test {
 
     @Test
     public void list() throws Exception {
-        UsergroupsListResponse response = slack.methods().usergroupsList(r -> r.token(token).build());
+        UsergroupsListResponse response = slack.methods().usergroupsList(r -> r.token(token));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void usergroups() throws Exception {
-        UsergroupsListResponse usergroups = slack.methods().usergroupsList(r -> r.token(token).build());
+        UsergroupsListResponse usergroups = slack.methods().usergroupsList(r -> r.token(token));
         if (usergroups.isOk() && usergroups.getUsergroups().size() > 0) {
             UsergroupUsersListResponse response = slack.methods().usergroupUsersList(
                     UsergroupUsersListRequest.builder()
@@ -72,37 +71,32 @@ public class usergroups_Test {
         UsergroupsCreateResponse creation = slack.methods().usergroupsCreate(r -> r
                 .token(token)
                 .name("usergroup-" + System.currentTimeMillis())
-                .description("Something wrong")
-                .build());
+                .description("Something wrong"));
         assertThat(creation.getError(), is(nullValue()));
         final Usergroup usergroup = creation.getUsergroup();
         {
             UsergroupsDisableResponse response = slack.methods().usergroupsDisable(r -> r
                     .token(token)
-                    .usergroup(usergroup.getId())
-                    .build());
+                    .usergroup(usergroup.getId()));
             assertThat(response.getError(), is(nullValue()));
         }
         {
             UsergroupsEnableResponse response = slack.methods().usergroupsEnable(r -> r
                     .token(token)
-                    .usergroup(usergroup.getId())
-                    .build());
+                    .usergroup(usergroup.getId()));
             assertThat(response.getError(), is(nullValue()));
         }
         {
             UsergroupsUpdateResponse response = slack.methods().usergroupsUpdate(r -> r
                     .token(token)
                     .usergroup(usergroup.getId())
-                    .description("updated")
-                    .build());
+                    .description("updated"));
             assertThat(response.getError(), is(nullValue()));
         }
         {
             UsersListResponse usersListResponse = slack.methods().usersList(r -> r
                     .token(token)
-                    .limit(3)
-                    .build());
+                    .limit(3));
             List<String> userIds = new ArrayList<>();
             for (User member : usersListResponse.getMembers()) {
                 userIds.add(member.getId());
@@ -110,8 +104,7 @@ public class usergroups_Test {
             UsergroupUsersUpdateResponse response = slack.methods().usergroupUsersUpdate(r -> r
                     .token(token)
                     .usergroup(usergroup.getId())
-                    .users(userIds)
-                    .build());
+                    .users(userIds));
             assertThat(response.getError(), is(nullValue()));
         }
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/users_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/users_Test.java
@@ -33,8 +33,7 @@ public class users_Test {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         UsersListResponse users = slack.methods().usersList(r -> r
                 .token(token)
-                .limit(100)
-                .build());
+                .limit(100));
         for (User member : users.getMembers()) {
             log.info("user id: {} , name: {}", member.getId(), member.getName());
         }
@@ -45,7 +44,7 @@ public class users_Test {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
 
         {
-            UsersSetPresenceResponse response = slack.methods().usersSetPresence(r -> r.token(token).presence("away").build());
+            UsersSetPresenceResponse response = slack.methods().usersSetPresence(r -> r.token(token).presence("away"));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -58,7 +57,7 @@ public class users_Test {
         }
 
         {
-            UsersIdentityResponse response = slack.methods().usersIdentity(r -> r.token(token).build());
+            UsersIdentityResponse response = slack.methods().usersIdentity(r -> r.token(token));
             // TODO: test preparation?
             // {"ok":false,"error":"missing_scope","needed":"identity.basic","provided":"identify,read,post,client,apps,admin"}
             assertThat(response.getError(), is("missing_scope"));
@@ -68,8 +67,7 @@ public class users_Test {
         UsersListResponse usersListResponse = slack.methods().usersList(r -> r
                 .token(token)
                 .limit(2)
-                .presence(true)
-                .build());
+                .presence(true));
         List<User> users = usersListResponse.getMembers();
         String userId = users.get(0).getId();
 
@@ -100,14 +98,14 @@ public class users_Test {
         }
 
         {
-            UsersInfoResponse response = slack.methods().usersInfo(r -> r.token(token).user(userId).build());
+            UsersInfoResponse response = slack.methods().usersInfo(r -> r.token(token).user(userId));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getUser(), is(notNullValue()));
         }
 
         {
-            UsersGetPresenceResponse response = slack.methods().usersGetPresence(r -> r.token(token).user(userId).build());
+            UsersGetPresenceResponse response = slack.methods().usersGetPresence(r -> r.token(token).user(userId));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getPresence(), is(notNullValue()));
@@ -116,13 +114,13 @@ public class users_Test {
         {
             UsersConversationsResponse response = slack.methods().usersConversations(r -> r
                     .token(token)
-                    .user(userId).build());
+                    .user(userId));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
-            UsersDeletePhotoResponse response = slack.methods().usersDeletePhoto(r -> r.token(token).build());
+            UsersDeletePhotoResponse response = slack.methods().usersDeletePhoto(r -> r.token(token));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -131,8 +129,7 @@ public class users_Test {
         {
             UsersSetPhotoResponse response = slack.methods().usersSetPhoto(r -> r
                     .token(token)
-                    .image(image)
-                    .build());
+                    .image(image));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -143,8 +140,7 @@ public class users_Test {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         UsersListResponse usersListResponse = slack.methods().usersList(r -> r
                 .token(token)
-                .presence(true)
-                .build());
+                .presence(true));
 
         List<User> users = usersListResponse.getMembers();
         User randomUserWhoHasEmail = null;

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/users_profile_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/users_profile_Test.java
@@ -27,7 +27,7 @@ public class users_profile_Test {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
 
         {
-            UsersProfileGetResponse response = slack.methods().usersProfileGet(r -> r.token(token).build());
+            UsersProfileGetResponse response = slack.methods().usersProfileGet(r -> r.token(token));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));
@@ -35,7 +35,7 @@ public class users_profile_Test {
 
         {
             UsersProfileSetResponse response = slack.methods().usersProfileSet(
-                    r -> r.token(token).name("skype").value("skype-" + System.currentTimeMillis()).build());
+                    r -> r.token(token).name("skype").value("skype-" + System.currentTimeMillis()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));
@@ -45,7 +45,7 @@ public class users_profile_Test {
             User.Profile profile = new User.Profile();
             profile.setSkype("skype-" + System.currentTimeMillis());
             UsersProfileSetResponse response = slack.methods().usersProfileSet(
-                    r -> r.token(token).profile(profile).build());
+                    r -> r.token(token).profile(profile));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));


### PR DESCRIPTION
When I introduced the new request builder APIs at https://github.com/seratch/jslack/pull/156, I intentionally kept having build() method call but now I have changed my mind that there is no benefit to have the method call from the view point of library users.

Although version 1.6.0 is very new (I shipped it today!), this is a breaking change towards the version. Sorry for that. I will release a new version including this change as version 1.7.0.