### PR TITLE
Add new attributes for shared channels in Conversation

### DIFF
--- a/jslack-api-client/src/test/java/config/Constants.java
+++ b/jslack-api-client/src/test/java/config/Constants.java
@@ -6,4 +6,5 @@ public class Constants {
 
     public static final String SLACK_TEST_OAUTH_ACCESS_TOKEN = "SLACK_TEST_OAUTH_ACCESS_TOKEN";
     public static final String SLACK_BOT_USER_TEST_OAUTH_ACCESS_TOKEN = "SLACK_BOT_USER_TEST_OAUTH_ACCESS_TOKEN";
+    public static final String SLACK_TEST_SHARED_CHANNEL_ID = "SLACK_TEST_SHARED_CHANNEL_ID";
 }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/shared_channels_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/shared_channels_Test.java
@@ -1,0 +1,35 @@
+package test_with_remote_apis.web_api;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.api.methods.response.conversations.ConversationsInfoResponse;
+import config.Constants;
+import config.SlackTestConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+@Slf4j
+public class shared_channels_Test {
+
+    Slack slack = Slack.getInstance(SlackTestConfig.get());
+    String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+
+    @Test
+    public void fetchSharedChannel() throws Exception {
+        Optional<String> sharedChannelId = Optional.ofNullable(System.getenv(Constants.SLACK_TEST_SHARED_CHANNEL_ID));
+        if (sharedChannelId.isPresent()) {
+            String channel = sharedChannelId.get();
+            ConversationsInfoResponse response = slack.methods().conversationsInfo(r ->
+                    r.token(token).channel(channel));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.getChannel().isShared(), is(true));
+            assertThat(response.getChannel().isExtShared(), is(true));
+            assertThat(response.getChannel().getConversationHostId(), is(notNullValue()));
+        }
+    }
+
+}

--- a/jslack-api-client/src/test/java/util/ObjectInitializer.java
+++ b/jslack-api-client/src/test/java/util/ObjectInitializer.java
@@ -58,7 +58,7 @@ public class ObjectInitializer {
                             continue;
                         }
                     }
-                    log.info("Skipped a field which doesn't have non arg constructor");
+                    log.info("Skipped a field which doesn't have non arg constructor: {} in {}", field.getName(), obj.getClass().getSimpleName());
                 }
             }
             return obj;

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Conversation.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Conversation.java
@@ -48,6 +48,9 @@ public class Conversation {
     private String parentConversation;
     private List<String> pendingConnectedTeamIds;
 
+    // shared channels
+    private String conversationHostId;
+
     @SerializedName("is_channel")
     private boolean isChannel;
     @SerializedName("is_group")
@@ -68,6 +71,8 @@ public class Conversation {
     private boolean isOrgShared;
     @SerializedName("is_pending_ext_shared")
     private boolean isPendingExtShared;
+    @SerializedName("is_moved")
+    private boolean isMoved;
     @SerializedName("is_member")
     private boolean isMember;
     @SerializedName("is_open")

--- a/json-logs/samples/api/conversations.info.json
+++ b/json-logs/samples/api/conversations.info.json
@@ -19,7 +19,7 @@
       "T00000000"
     ],
     "pending_shared": [
-      ""
+      "T00000000"
     ],
     "is_pending_ext_shared": false,
     "is_member": false,
@@ -41,7 +41,101 @@
     ],
     "locale": "",
     "pending_connected_team_ids": [
-      ""
+      "E00000000"
+    ],
+    "is_read_only": false,
+    "conversation_host_id": "T00000000",
+    "is_moved": 12345,
+    "is_global_shared": false,
+    "is_org_default": false,
+    "is_org_mandatory": false,
+    "is_open": false,
+    "user": "U00000000",
+    "latest": {
+      "type": "",
+      "subtype": "",
+      "text": "",
+      "ts": "0000000000.000000",
+      "user": "U00000000",
+      "username": "",
+      "bot_id": "",
+      "attachments": [
+        {
+          "msg_subtype": "",
+          "fallback": "",
+          "callback_id": "",
+          "color": "",
+          "pretext": "",
+          "service_url": "",
+          "service_name": "",
+          "service_icon": "",
+          "author_name": "",
+          "author_link": "",
+          "author_icon": "",
+          "from_url": "",
+          "original_url": "",
+          "author_subname": "",
+          "channel_id": "",
+          "channel_name": "",
+          "id": 12345,
+          "bot_id": "",
+          "is_msg_unfurl": false,
+          "is_reply_unfurl": false,
+          "is_thread_root_unfurl": false,
+          "app_unfurl_url": "",
+          "is_app_unfurl": false,
+          "title": "",
+          "title_link": "",
+          "text": "",
+          "fields": [
+            {
+              "title": "",
+              "value": "",
+              "short": false
+            }
+          ],
+          "image_url": "",
+          "image_width": 12345,
+          "image_height": 12345,
+          "image_bytes": 12345,
+          "thumb_url": "",
+          "thumb_width": 12345,
+          "thumb_height": 12345,
+          "video_html": "",
+          "video_html_width": 12345,
+          "video_html_height": 12345,
+          "footer": "",
+          "footer_icon": "",
+          "ts": "",
+          "mrkdwn_in": [
+            ""
+          ],
+          "actions": [
+            {
+              "id": "",
+              "name": "",
+              "text": "",
+              "style": "",
+              "type": "",
+              "value": "",
+              "data_source": "",
+              "min_query_length": 12345,
+              "url": ""
+            }
+          ],
+          "filename": "",
+          "size": 12345,
+          "mimetype": "",
+          "url": "",
+          "metadata": ""
+        }
+      ]
+    },
+    "unread_count": 12345,
+    "unread_count_display": 12345,
+    "priority": 12345,
+    "connected_team_ids": [
+      "T00000000"
     ]
   },
   "error": "",

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -466,7 +466,30 @@
       "previous_names": [
         ""
       ],
-      "priority": 12345
+      "priority": 12345,
+      "is_group": false,
+      "is_im": false,
+      "is_ext_shared": false,
+      "shared_team_ids": [
+        "T00000000"
+      ],
+      "internal_team_ids": [
+        ""
+      ],
+      "connected_team_ids": [
+        "E00000000"
+      ],
+      "previously_connected_team_ids": [
+        ""
+      ],
+      "pending_shared": [
+        ""
+      ],
+      "pending_connected_team_ids": [
+        ""
+      ],
+      "is_pending_ext_shared": false,
+      "conversation_host_id": "T00000000"
     }
   ],
   "groups": [


### PR DESCRIPTION
This pull request adds `conversation_host_id` and `is_moved` to `Conversation`