### PR TITLE
Mark some attributes in Incoming Webhook payloads as deprecated

### DIFF
--- a/jslack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
@@ -34,10 +34,10 @@ public class IncomingWebhooksTest {
         }
 
         Payload payload = Payload.builder()
-                .channel("#random")
+                .channel("#random") // still work if the webhook in part of a custom integration
+                .iconEmoji(":smile_cat:") // still work if the webhook in part of a custom integration
+                .username("jSlack") // still work if the webhook in part of a custom integration
                 .text("Hello World!")
-                .iconEmoji(":smile_cat:")
-                .username("jSlack")
                 .attachments(new ArrayList<>())
                 .build();
 
@@ -91,10 +91,10 @@ public class IncomingWebhooksTest {
         }
 
         Payload payload = Payload.builder()
-                .channel("#random")
+                .channel("#random") // still work if the webhook in part of a custom integration
+                .iconEmoji(":smile_cat:") // still work if the webhook in part of a custom integration
+                .username("jSlack") // still work if the webhook in part of a custom integration
                 .text("Hello World!")
-                .iconEmoji(":smile_cat:")
-                .username("jSlack")
                 .blocks(new ArrayList<>())
                 .build();
 

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/webhook/Payload.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/webhook/Payload.java
@@ -23,26 +23,38 @@ public class Payload {
     private String text;
 
     /**
+     * NOTE: No longer works if your webhook is managed in a Slack app
+     * <p>
      * Incoming webhooks output to a default channel and can only send messages to a single channel at a time.
      * You can override a custom integration's configured channel by specifying the channel field in your JSON payload.
      * <p>
      * Specify a Slack channel by name with "channel": "#other-channel", or send a Slackbot message to a specific user with "channel": "@username".
      */
+    @Deprecated
     private String channel;
 
     /**
+     * NOTE: No longer works if your webhook is managed in a Slack app
+     * <p>
      * Incoming webhooks originate from a default identity you configured when originally creating your webhook.
      * You can override a custom integration's configured name with the username field in your JSON payload.
      */
+    @Deprecated
     private String username;
 
     /**
+     * NOTE: No longer works if your webhook is managed in a Slack app
+     * <p>
      * You can also override the bot icon either with icon_url or icon_emoji.
      */
+    @Deprecated
     private String iconUrl;
     /**
+     * NOTE: No longer works if your webhook is managed in a Slack app
+     * <p>
      * You can also override the bot icon either with icon_url or icon_emoji.
      */
+    @Deprecated
     private String iconEmoji;
 
     /**


### PR DESCRIPTION
Refer to the comments in the code for details.