### PR TITLE
Incoming Webhook enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,38 @@ import com.github.seratch.jslack.api.webhook.*;
 String url = System.getenv("SLACK_WEBHOOK_URL");
 
 Payload payload = Payload.builder()
-  .channel("#random")
-  .username("jSlack Bot")
-  .iconEmoji(":smile_cat:")
   .text("Hello World!")
   .build();
 
 Slack slack = Slack.getInstance();
 WebhookResponse response = slack.send(url, payload);
 // response.code, response.message, response.body
+```
+
+Here is an example with [Block Kit](https://api.slack.com/block-kit).
+
+```java
+ButtonElement button = ButtonElement.builder()
+  .text(PlainTextObject.builder().emoji(true).text("Farmhouse").build())
+  .value("click_me_123")
+  .build();
+
+LayoutBlock block = ActionsBlock.builder().elements(Arrays.asList(button)).build();
+
+List<LayoutBlock> blocks = Arrays.asList(block);
+
+Payload payload = Payload.builder().blocks(blocks).build();
+
+Slack slack = Slack.getInstance();
+WebhookResponse response = slack.send(url, payload);
+// response.code, response.message, response.body
+```
+
+It's also possible to directly give a raw payload.
+
+```java
+String payload = "{\"text\": \"Hello there!\"}";
+WebhookResponse response = slack.send(url, payload);
 ```
 
 #### Real Time Messaging API

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Manually create a Slack user which has an email address for a unit test.
 
 ```bash
 export SLACK_WEBHOOK_TEST_URL=https://hooks.slack.com/services/Txxxx/yyy/zzz
+export SLACK_WEBHOOK_TEST_CHANNEL=C12345678 (or #random)
 ```
 
 ### Add youtube.com to App Unfurl Domains

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/Slack.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/Slack.java
@@ -83,6 +83,22 @@ public class Slack {
     }
 
     /**
+     * Send a raw JSON body to Incoming Webhook endpoint.
+     */
+    public WebhookResponse send(String url, String payload) throws IOException {
+        SlackHttpClient httpClient = getHttpClient();
+        Response httpResponse = httpClient.postJsonPostRequest(url, payload);
+        String body = httpResponse.body().string();
+        httpClient.runHttpResponseListeners(httpResponse, body);
+
+        return WebhookResponse.builder()
+                .code(httpResponse.code())
+                .message(httpResponse.message())
+                .body(body)
+                .build();
+    }
+
+    /**
      * Creates an RTM API client.
      *
      * @see "https://api.slack.com/docs/rate-limits#rtm"

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/common/http/SlackHttpClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/common/http/SlackHttpClient.java
@@ -62,8 +62,12 @@ public class SlackHttpClient {
     }
 
     private String toJsonString(Object obj) {
-        Gson gson = GsonFactory.createSnakeCase();
-        return gson.toJson(obj);
+        if (obj instanceof String) {
+            return (String) obj;
+        } else {
+            Gson gson = GsonFactory.createSnakeCase();
+            return gson.toJson(obj);
+        }
     }
 
 

--- a/jslack-api-client/src/test/java/config/Constants.java
+++ b/jslack-api-client/src/test/java/config/Constants.java
@@ -7,4 +7,6 @@ public class Constants {
     public static final String SLACK_TEST_OAUTH_ACCESS_TOKEN = "SLACK_TEST_OAUTH_ACCESS_TOKEN";
     public static final String SLACK_BOT_USER_TEST_OAUTH_ACCESS_TOKEN = "SLACK_BOT_USER_TEST_OAUTH_ACCESS_TOKEN";
     public static final String SLACK_TEST_SHARED_CHANNEL_ID = "SLACK_TEST_SHARED_CHANNEL_ID";
+    public static final String SLACK_WEBHOOK_TEST_URL = "SLACK_WEBHOOK_TEST_URL";
+    public static final String SLACK_WEBHOOK_TEST_CHANNEL = "SLACK_WEBHOOK_TEST_CHANNEL";
 }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
@@ -1,6 +1,7 @@
 package test_with_remote_apis;
 
 import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
 import com.github.seratch.jslack.api.model.Attachment;
 import com.github.seratch.jslack.api.model.Field;
 import com.github.seratch.jslack.api.model.block.ActionsBlock;
@@ -9,8 +10,10 @@ import com.github.seratch.jslack.api.model.block.composition.PlainTextObject;
 import com.github.seratch.jslack.api.model.block.element.ButtonElement;
 import com.github.seratch.jslack.api.webhook.Payload;
 import com.github.seratch.jslack.api.webhook.WebhookResponse;
+import config.Constants;
 import config.SlackTestConfig;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -18,21 +21,28 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 @Slf4j
 public class IncomingWebhooksTest {
 
+    // String url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX";
+    String url = System.getenv(Constants.SLACK_WEBHOOK_TEST_URL);
+    String channel = System.getenv(Constants.SLACK_WEBHOOK_TEST_CHANNEL);
+    String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+
     Slack slack = Slack.getInstance(SlackTestConfig.get());
 
-    @Test
-    public void incomingWebhook() throws IOException {
-        // String url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX";
-        String url = System.getenv("SLACK_WEBHOOK_TEST_URL");
+    @Before
+    public void setup() {
         if (url == null) {
             throw new IllegalStateException("Environment variable SLACK_WEBHOOK_TEST_URL must be defined");
         }
+    }
 
+    @Test
+    public void testWithSimplePayload() throws IOException {
         Payload payload = Payload.builder()
                 .channel("#random") // still work if the webhook in part of a custom integration
                 .iconEmoji(":smile_cat:") // still work if the webhook in part of a custom integration
@@ -83,13 +93,7 @@ public class IncomingWebhooksTest {
     }
 
     @Test
-    public void incomingWebhook_BlockKit() throws IOException {
-        // String url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX";
-        String url = System.getenv("SLACK_WEBHOOK_TEST_URL");
-        if (url == null) {
-            throw new IllegalStateException("Environment variable SLACK_WEBHOOK_TEST_URL must be defined");
-        }
-
+    public void testWithBlockKitPayload() throws IOException {
         Payload payload = Payload.builder()
                 .channel("#random") // still work if the webhook in part of a custom integration
                 .iconEmoji(":smile_cat:") // still work if the webhook in part of a custom integration
@@ -116,4 +120,140 @@ public class IncomingWebhooksTest {
         // assertThat(response.getMessage(), is("OK"));
     }
 
+    @Test
+    public void testWithRawBodyContainingAttachments() throws IOException {
+        String payload = "{\n" +
+                "    \"text\": \"Robert DeSoto added a new task\",\n" +
+                "    \"attachments\": [\n" +
+                "        {\n" +
+                "            \"fallback\": \"Plan a vacation\",\n" +
+                "            \"author_name\": \"Owner: rdesoto\",\n" +
+                "            \"title\": \"Plan a vacation\",\n" +
+                "            \"text\": \"I've been working too hard, it's time for a break.\",\n" +
+                "            \"actions\": [\n" +
+                "                {\n" +
+                "                    \"name\": \"action\",\n" +
+                "                    \"type\": \"button\",\n" +
+                "                    \"text\": \"Complete this task\",\n" +
+                "                    \"style\": \"\",\n" +
+                "                    \"value\": \"complete\"\n" +
+                "                },\n" +
+                "                {\n" +
+                "                    \"name\": \"tags_list\",\n" +
+                "                    \"type\": \"select\",\n" +
+                "                    \"text\": \"Add a tag...\",\n" +
+                "                    \"data_source\": \"static\",\n" +
+                "                    \"options\": [\n" +
+                "                        {\n" +
+                "                            \"text\": \"Launch Blocking\",\n" +
+                "                            \"value\": \"launch-blocking\"\n" +
+                "                        },\n" +
+                "                        {\n" +
+                "                            \"text\": \"Enhancement\",\n" +
+                "                            \"value\": \"enhancement\"\n" +
+                "                        },\n" +
+                "                        {\n" +
+                "                            \"text\": \"Bug\",\n" +
+                "                            \"value\": \"bug\"\n" +
+                "                        }\n" +
+                "                    ]\n" +
+                "                }\n" +
+                "            ]\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}";
+        WebhookResponse response = slack.send(url, payload);
+        log.info(response.toString());
+
+        assertThat(response.getBody(), is("ok"));
+        assertThat(response.getCode(), is(200));
+    }
+
+    @Test
+    public void testWithRawBodyContainingBlocks() throws IOException {
+        String payload = "{\n" +
+                "    \"blocks\": [\n" +
+                "        {\n" +
+                "            \"type\": \"section\",\n" +
+                "            \"text\": {\n" +
+                "                \"type\": \"mrkdwn\",\n" +
+                "                \"text\": \"You have a new request:\\n*<fakeLink.toEmployeeProfile.com|Fred Enriquez - New device request>*\"\n" +
+                "            }\n" +
+                "        },\n" +
+                "        {\n" +
+                "            \"type\": \"section\",\n" +
+                "            \"fields\": [\n" +
+                "                {\n" +
+                "                    \"type\": \"mrkdwn\",\n" +
+                "                    \"text\": \"*Type:*\\nComputer (laptop)\"\n" +
+                "                },\n" +
+                "                {\n" +
+                "                    \"type\": \"mrkdwn\",\n" +
+                "                    \"text\": \"*When:*\\nSubmitted Aut 10\"\n" +
+                "                },\n" +
+                "                {\n" +
+                "                    \"type\": \"mrkdwn\",\n" +
+                "                    \"text\": \"*Last Update:*\\nMar 10, 2015 (3 years, 5 months)\"\n" +
+                "                },\n" +
+                "                {\n" +
+                "                    \"type\": \"mrkdwn\",\n" +
+                "                    \"text\": \"*Reason:*\\nAll vowel keys aren't working.\"\n" +
+                "                },\n" +
+                "                {\n" +
+                "                    \"type\": \"mrkdwn\",\n" +
+                "                    \"text\": \"*Specs:*\\n\\\"Cheetah Pro 15\\\" - Fast, really fast\\\"\"\n" +
+                "                }\n" +
+                "            ]\n" +
+                "        },\n" +
+                "        {\n" +
+                "            \"type\": \"actions\",\n" +
+                "            \"elements\": [\n" +
+                "                {\n" +
+                "                    \"type\": \"button\",\n" +
+                "                    \"text\": {\n" +
+                "                        \"type\": \"plain_text\",\n" +
+                "                        \"emoji\": true,\n" +
+                "                        \"text\": \"Approve\"\n" +
+                "                    },\n" +
+                "                    \"style\": \"primary\",\n" +
+                "                    \"value\": \"click_me_123\"\n" +
+                "                },\n" +
+                "                {\n" +
+                "                    \"type\": \"button\",\n" +
+                "                    \"text\": {\n" +
+                "                        \"type\": \"plain_text\",\n" +
+                "                        \"emoji\": true,\n" +
+                "                        \"text\": \"Deny\"\n" +
+                "                    },\n" +
+                "                    \"style\": \"danger\",\n" +
+                "                    \"value\": \"click_me_123\"\n" +
+                "                }\n" +
+                "            ]\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}";
+        WebhookResponse response = slack.send(url, payload);
+        log.info(response.toString());
+
+        assertThat(response.getBody(), is("ok"));
+        assertThat(response.getCode(), is(200));
+    }
+
+
+    @Test
+    public void testWithThreads() throws Exception {
+        ChatPostMessageResponse chatPostMessageResponse = slack.methods().chatPostMessage(r ->
+                r.token(token).channel(channel).text("[thread] Hello"));
+        assertThat(chatPostMessageResponse.getError(), is(nullValue()));
+
+        Payload payload = Payload.builder()
+                .threadTs(chatPostMessageResponse.getMessage().getTs())
+                .text("Reply via Imcoming Webhook!").build();
+
+        WebhookResponse response = slack.send(url, payload);
+        log.info(response.toString());
+
+        assertThat(response.getBody(), is("ok"));
+        assertThat(response.getCode(), is(200));
+    }
 }

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/webhook/Payload.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/webhook/Payload.java
@@ -17,6 +17,12 @@ import java.util.List;
 public class Payload {
 
     /**
+     * You can add the thread_ts parameter to your POST request
+     * in order to make your message appear as a reply in a thread.
+     */
+    private String threadTs;
+
+    /**
      * The first step is to prepare this message as a key/value pair in JSON.
      * For a simple message, your JSON payload only needs to define a text property, containing the text that will be posted to the channel.
      */


### PR DESCRIPTION
This pull request adds missing thread_ts to Incoming Webhook. Also, I've added an overload method which accepts a string value.

* Add `thread_ts` to Incoming Wehook payload
* Add raw string payload to `Slack.send` method
