### PR TITLE
Add tests verifying channel creation with longer names (up to 80 chars)

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/conversations/ConversationsCreateResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/conversations/ConversationsCreateResponse.java
@@ -10,6 +10,14 @@ public class ConversationsCreateResponse implements SlackApiResponse {
     private boolean ok;
     private String warning;
     private String error;
+
+    // {
+    //   "ok": false,
+    //   "error": "invalid_name_maxlength",
+    //   "detail": "Value passed for `name` exceeded max length."
+    // }
+    private String detail;
+
     private String needed;
     private String provided;
 

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/conversations_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/conversations_Test.java
@@ -2,6 +2,7 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.methods.request.conversations.ConversationsCreateRequest;
 import com.github.seratch.jslack.api.methods.request.conversations.ConversationsListRequest;
 import com.github.seratch.jslack.api.methods.response.channels.ChannelsRepliesResponse;
 import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
@@ -420,6 +421,58 @@ public class conversations_Test {
         } finally {
             channelGenerator.archiveChannel(channel);
         }
+    }
+
+    @Test
+    public void longChannelName_public_ok() throws Exception {
+        TestChannelGenerator channelGenerator = new TestChannelGenerator(token);
+        String channelName = "test" + System.currentTimeMillis();
+        while (channelName.length() < 80) {
+            channelName += "_";
+        }
+        Conversation channel = channelGenerator.createNewPublicChannel(channelName);
+        channelGenerator.archiveChannel(channel);
+    }
+
+    @Test
+    public void longChannelName_private_ok() throws Exception {
+        TestChannelGenerator channelGenerator = new TestChannelGenerator(token);
+        String channelName = "secret-" + System.currentTimeMillis();
+        while (channelName.length() < 80) {
+            channelName += "_";
+        }
+        Conversation channel = channelGenerator.createNewPrivateChannel(channelName);
+        channelGenerator.archiveChannel(channel);
+    }
+
+    @Test
+    public void longChannelName_public_ng() throws Exception {
+        String channelName = "test-" + System.currentTimeMillis();
+        while (channelName.length() < 81) {
+            channelName += "_";
+        }
+        ConversationsCreateResponse createPublicResponse = slack.methods().conversationsCreate(
+                ConversationsCreateRequest.builder()
+                        .token(token)
+                        .name(channelName)
+                        .isPrivate(false)
+                        .build());
+        assertThat(createPublicResponse.getError(), is("invalid_name_maxlength"));
+    }
+
+    @Test
+    public void longChannelName_private_ng() throws Exception {
+        String channelName = "test-" + System.currentTimeMillis();
+        while (channelName.length() < 81) {
+            channelName += "_";
+        }
+        ConversationsCreateResponse createPublicResponse = slack.methods().conversationsCreate(
+                ConversationsCreateRequest.builder()
+                        .token(token)
+                        .name(channelName)
+                        .isPrivate(true)
+                        .build());
+        assertThat(createPublicResponse.getError(), is("invalid_name_maxlength"));
     }
 
 }

--- a/jslack-api-client/src/test/java/util/TestChannelGenerator.java
+++ b/jslack-api-client/src/test/java/util/TestChannelGenerator.java
@@ -24,16 +24,24 @@ public class TestChannelGenerator {
     }
 
     public Conversation createNewPublicChannel(String channelName) throws IOException, SlackApiException {
+        return createNewChannel(channelName, false);
+    }
+
+    public Conversation createNewPrivateChannel(String channelName) throws IOException, SlackApiException {
+        return createNewChannel(channelName, true);
+    }
+
+    public Conversation createNewChannel(String channelName, boolean isPrivate) throws IOException, SlackApiException {
         ConversationsCreateResponse createPublicResponse = slack.methods().conversationsCreate(
                 ConversationsCreateRequest.builder()
                         .token(token)
                         .name(channelName)
-                        .isPrivate(false)
+                        .isPrivate(isPrivate)
                         .build());
         assertThat(createPublicResponse.getError(), is(nullValue()));
         assertThat(createPublicResponse.isOk(), is(true));
         assertThat(createPublicResponse.getChannel(), is(notNullValue()));
-        assertThat(createPublicResponse.getChannel().isPrivate(), is(false));
+        assertThat(createPublicResponse.getChannel().isPrivate(), is(isPrivate));
 
         return createPublicResponse.getChannel();
 

--- a/json-logs/samples/api/conversations.create.json
+++ b/json-logs/samples/api/conversations.create.json
@@ -46,6 +46,7 @@
     "is_open": false
   },
   "error": "",
+  "detail": "",
   "needed": "",
   "provided": ""
 }

--- a/json-logs/samples/api/usergroups.users.list.json
+++ b/json-logs/samples/api/usergroups.users.list.json
@@ -1,7 +1,7 @@
 {
   "ok": false,
   "users": [
-    ""
+    "U00000000"
   ],
   "error": "",
   "needed": "",


### PR DESCRIPTION
https://api.slack.com/changelog#August_2019

>Channel names have grown up: instead of a maximum length of 21 characters, channel names may now feature a full 80 character label.

<img width="600" src="https://user-images.githubusercontent.com/19658/62584274-bdf22100-b8ee-11e9-9353-4bc5283f3484.png">
