### PR TITLE
 Change the types of user.enterprise_user.is_admin, is_owner (string -> boolean)

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/pins/PinsAddResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/pins/PinsAddResponse.java
@@ -1,7 +1,10 @@
 package com.github.seratch.jslack.api.methods.response.pins;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.methods.response.chat.ChatPostMessageResponse;
 import lombok.Data;
+
+import java.util.List;
 
 @Data
 public class PinsAddResponse implements SlackApiResponse {
@@ -11,4 +14,12 @@ public class PinsAddResponse implements SlackApiResponse {
     private String error;
     private String needed;
     private String provided;
+
+    private ResponseMetadata responseMetadata;
+
+    @Data
+    public static class ResponseMetadata {
+        private List<String> messages;
+    }
+
 }

--- a/jslack-api-client/src/test/java/test_locally/api/model/UserTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/model/UserTest.java
@@ -1,0 +1,19 @@
+package test_locally.api.model;
+
+import com.github.seratch.jslack.api.methods.response.users.UsersInfoResponse;
+import com.github.seratch.jslack.api.methods.response.users.UsersListResponse;
+import org.junit.Test;
+
+public class UserTest implements Verifier {
+
+    @Test
+    public void parseUsersListResponse() throws Exception {
+        verifyParsing("users.list", UsersListResponse.class);
+    }
+
+    @Test
+    public void parseUsersInfoResponse() throws Exception {
+        verifyParsing("users.info", UsersInfoResponse.class);
+    }
+
+}

--- a/jslack-api-client/src/test/java/test_locally/api/model/Verifier.java
+++ b/jslack-api-client/src/test/java/test_locally/api/model/Verifier.java
@@ -2,6 +2,9 @@ package test_locally.api.model;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
 import com.github.seratch.jslack.common.json.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,13 +17,19 @@ import static org.junit.Assert.assertThat;
 
 public interface Verifier {
 
-    default void verifyParsing(String api, Class<? extends SlackApiResponse> clazz) throws IOException {
+    default Logger logger() {
+        return LoggerFactory.getLogger(this.getClass());
+    }
+
+    default <T extends SlackApiResponse> T verifyParsing(String api, Class<T> clazz) throws IOException {
         String json = Files.readAllLines(
                 new File("../json-logs/samples/api/" + api + ".json").toPath())
                 .stream()
                 .collect(joining());
-        Object resp = GsonFactory.createSnakeCase().fromJson(json, clazz);
+        T resp = GsonFactory.createSnakeCase().fromJson(json, clazz);
+        logger().info("parsed object: {}", resp);
         assertThat(resp, is(notNullValue()));
+        return resp;
     }
 
 }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/pins_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/pins_Test.java
@@ -71,20 +71,24 @@ public class pins_Test {
         }
 
         {
+            // https://api.slack.com/methods/pins.add
+            // We are phasing out support for pinning files and file comments only.
+            // This method will no longer accept the file and file_comment parameters beginning August 22, 2019.
             PinsAddResponse response = slack.methods().pinsAdd(r -> r
                     .token(token)
                     .channel(channels.get(0))
                     .file(fileObj.getId()));
-            assertThat(response.getError(), is(nullValue()));
-            assertThat(response.isOk(), is(true));
+            assertThat(response.getError(), is("not_pinnable"));
         }
         {
+            // https://api.slack.com/methods/pins.add
+            // We are phasing out support for pinning files and file comments only.
+            // This method will no longer accept the file and file_comment parameters beginning August 22, 2019.
             PinsRemoveResponse response = slack.methods().pinsRemove(r -> r
                     .token(token)
                     .channel(channels.get(0))
                     .file(fileObj.getId()));
-            assertThat(response.getError(), is(nullValue()));
-            assertThat(response.isOk(), is(true));
+            assertThat(response.getError(), is("no_pin"));
         }
 
         {

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/User.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/User.java
@@ -123,8 +123,10 @@ public class User {
         private String id;
         private String enterpriseId;
         private String enterpriseName;
-        private String isAdmin;
-        private String isOwner;
+        @SerializedName("is_admin")
+        private boolean isAdmin;
+        @SerializedName("is_owner")
+        private boolean isOwner;
         private List<String> teams;
     }
 

--- a/json-logs/samples/rtm/TeamJoinEvent.json
+++ b/json-logs/samples/rtm/TeamJoinEvent.json
@@ -53,6 +53,13 @@
     "updated": 123,
     "has_2fa": false,
     "presence": "",
+    "enterprise_user": {
+      "id": "",
+      "enterprise_id": "",
+      "enterprise_name": "",
+      "is_admin": false,
+      "is_owner": false
+    },
     "two_factor_type": "",
     "has_files": false,
     "locale": ""

--- a/json-logs/samples/rtm/UserChangeEvent.json
+++ b/json-logs/samples/rtm/UserChangeEvent.json
@@ -53,6 +53,13 @@
     "updated": 123,
     "has_2fa": false,
     "presence": "",
+    "enterprise_user": {
+      "id": "",
+      "enterprise_id": "",
+      "enterprise_name": "",
+      "is_admin": false,
+      "is_owner": false
+    },
     "two_factor_type": "",
     "has_files": false,
     "locale": ""


### PR DESCRIPTION
This pull request corrects the types of `user.enterprise_user.is_admin` and `user.enterprise_user.is_owener` from string to boolean. The attribute has been just added in version 2.1.0 so that I believe this change won't affect any existing users.

Also, while running tests, I noticed tests for `pins.add` need updates. Another commit is for it.