### PR TITLE
Lightning OAuth support

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/oauth/OAuthAccessResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/oauth/OAuthAccessResponse.java
@@ -17,6 +17,7 @@ public class OAuthAccessResponse implements SlackApiResponse {
     private String tokenType;
     private String accessToken;
     private String scope;
+    private String enterpriseId;
     private String teamName;
     private String teamId;
     private String userId;

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/common/http/SlackHttpClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/common/http/SlackHttpClient.java
@@ -64,7 +64,11 @@ public class SlackHttpClient {
 
     public Response postFormWithBearerHeader(String url, String token, FormBody formBody) throws IOException {
         String bearerHeaderValue = "Bearer " + token;
-        Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).post(formBody).build();
+        return postFormWithAuthorizationHeader(url, bearerHeaderValue, formBody);
+    }
+
+    public Response postFormWithAuthorizationHeader(String url, String authorizationHeader, FormBody formBody) throws IOException {
+        Request request = new Request.Builder().url(url).header("Authorization", authorizationHeader).post(formBody).build();
         return okHttpClient.newCall(request).execute();
     }
 

--- a/jslack-lightning-jetty/src/main/java/com/github/seratch/jslack/lightning/jetty/SlackAppServer.java
+++ b/jslack-lightning-jetty/src/main/java/com/github/seratch/jslack/lightning/jetty/SlackAppServer.java
@@ -2,14 +2,20 @@ package com.github.seratch.jslack.lightning.jetty;
 
 import com.github.seratch.jslack.lightning.App;
 import com.github.seratch.jslack.lightning.servlet.SlackAppServlet;
+import com.github.seratch.jslack.lightning.servlet.SlackOAuthAppServlet;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
 public class SlackAppServer {
 
     private final Server server;
-    private final App app;
+    private final Map<String, App> pathToApp;
 
     public SlackAppServer(App app) {
         this(app, "/slack/events", 3000);
@@ -20,22 +26,77 @@ public class SlackAppServer {
     }
 
     public SlackAppServer(App app, String path, int port) {
-        this.app = app;
+        this(toApps(app, path), port);
+    }
+
+    public SlackAppServer(Map<String, App> pathToApp) {
+        this(pathToApp, 3000);
+    }
+
+    public SlackAppServer(Map<String, App> pathToApp, int port) {
+        this.pathToApp = pathToApp;
         server = new Server(port);
         ServletContextHandler handler = new ServletContextHandler();
-        ServletHolder holder = new ServletHolder(new SlackAppServlet(app));
-        handler.addServlet(holder, path);
+        Map<String, App> addedOnes = new HashMap<>();
+        for (Map.Entry<String, App> entry : this.pathToApp.entrySet()) {
+            String appPath = entry.getKey();
+            App theApp = entry.getValue();
+            theApp.config().setAppPath(appPath);
+            handler.addServlet(new ServletHolder(new SlackAppServlet(theApp)), appPath);
+
+            if (theApp.config().getOauthStartPath() != null) {
+                if (theApp.config().isDistributedApp()) {
+                    // start
+                    String oAuthStartPath = appPath + theApp.config().getOauthStartPath();
+                    App oAuthStartApp = theApp.toOAuthStartApp();
+                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(oAuthStartApp)), oAuthStartPath);
+                    addedOnes.put(oAuthStartPath, oAuthStartApp);
+                } else {
+                    log.error("The app is not ready for handling OAuth requests. Make sure if you set all the necessary values in AppConfig.");
+                }
+            }
+
+            if (theApp.config().getOauthCallbackPath() != null) {
+                if (theApp.config().isDistributedApp()) {
+                    // callback
+                    String oAuthCallbackPath = appPath + theApp.config().getOauthCallbackPath();
+                    App oAuthCallbackApp = theApp.toOAuthCallbackApp();
+                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(oAuthCallbackApp)), oAuthCallbackPath);
+                    addedOnes.put(oAuthCallbackPath, oAuthCallbackApp);
+                } else {
+                    log.error("The app is not ready for handling OAuth requests. Make sure if you set all the necessary values in AppConfig.");
+                }
+            }
+        }
+        pathToApp.putAll(addedOnes);
         server.setHandler(handler);
     }
 
     public void start() throws Exception {
-        app.start();
+        for (App app : pathToApp.values()) {
+            app.start();
+        }
         server.start();
+        log.info("⚡️ Your Lightning app is running!");
         server.join();
     }
 
     public void stop() throws Exception {
-        app.stop();
+        for (App app : pathToApp.values()) {
+            app.stop();
+        }
+        log.info("⚡️ Your Lightning app has stopped...");
         server.stop();
     }
+
+    // ----------------------------------------------------
+    // internal methods
+    // ----------------------------------------------------
+
+    private static Map<String, App> toApps(App app, String path) {
+        Map<String, App> apps = new HashMap<>();
+        apps.put(path, app);
+        return apps;
+    }
+
 }

--- a/jslack-lightning-kotlin-examples/pom.xml
+++ b/jslack-lightning-kotlin-examples/pom.xml
@@ -46,6 +46,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.11.648</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
@@ -68,12 +74,16 @@
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <goals> <goal>compile</goal> </goals>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
                     </execution>
 
                     <execution>
                         <id>test-compile</id>
-                        <goals> <goal>test-compile</goal> </goals>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/app.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/app.kt
@@ -1,0 +1,34 @@
+package examples.oauth_flow
+
+import com.github.seratch.jslack.lightning.App
+import com.github.seratch.jslack.lightning.jetty.SlackAppServer
+import org.slf4j.LoggerFactory
+import util.ResourceLoader
+
+fun main() {
+
+    val logger = LoggerFactory.getLogger("main")
+
+    // export SLACK_BOT_TOKEN=xoxb-***
+    // export SLACK_SIGNING_SECRET=123abc***
+    val config = ResourceLoader.loadAppConfig()
+    config.isAlwaysRequestUserTokenNeeded = true
+    val mainApp = App(config)
+
+    mainApp.command("/say-something") { req, ctx ->
+        val p = req.payload
+        val text = "<@${p.userId}> said ${p.text} at <#${p.channelId}|${p.channelName}>"
+        val res = ctx.respond { it.text(text).responseType("in_channel") }
+        logger.info("respond result - {}", res)
+        ctx.ack()
+    }
+
+    val oauthConfig = ResourceLoader.loadAppConfig()
+    val oauthApp = App(oauthConfig).asOAuthApp(true)
+
+    val server = SlackAppServer(mapOf(
+            "/slack/events" to mainApp,
+            "/slack/oauth" to oauthApp
+    ))
+    server.start()
+}

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/aws.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/aws.kt
@@ -1,0 +1,42 @@
+package examples.oauth_flow
+
+import com.github.seratch.jslack.lightning.App
+import com.github.seratch.jslack.lightning.jetty.SlackAppServer
+import com.github.seratch.jslack.lightning.service.builtin.AmazonS3InstallationService
+import com.github.seratch.jslack.lightning.service.builtin.AmazonS3OAuthStateService
+import org.slf4j.LoggerFactory
+import util.ResourceLoader
+
+fun main() {
+
+    val logger = LoggerFactory.getLogger("main")
+
+    // export SLACK_BOT_TOKEN=xoxb-***
+    // export SLACK_SIGNING_SECRET=123abc***
+    val config = ResourceLoader.loadAppConfig()
+    val mainApp = App(config)
+
+    mainApp.command("/say-something") { req, ctx ->
+        val p = req.payload
+        val text = "<@${p.userId}> said ${p.text} at <#${p.channelId}|${p.channelName}>"
+        val res = ctx.respond { it.text(text).responseType("in_channel") }
+        logger.info("respond result - {}", res)
+        ctx.ack()
+    }
+
+    val oauthConfig = ResourceLoader.loadAppConfig()
+    val oauthApp = App(oauthConfig).asOAuthApp(true)
+
+    // export AWS_REGION=us-east-1
+    // export AWS_ACCESS_KEY_ID=AAAA*************
+    // export AWS_SECRET_ACCESS_KEY=4o7***********************
+    val awsS3BucketName = "YOUR_OWN_BUCKET_NAME_HERE"
+    oauthApp.service(AmazonS3InstallationService(awsS3BucketName))
+    oauthApp.service(AmazonS3OAuthStateService(awsS3BucketName))
+
+    val server = SlackAppServer(mapOf(
+            "/slack/events" to mainApp,
+            "/slack/oauth" to oauthApp
+    ))
+    server.start()
+}

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/util/ResourceLoader.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/util/ResourceLoader.kt
@@ -24,6 +24,16 @@ class ResourceLoader {
                         val j = Gson().fromJson(json, JsonElement::class.java).asJsonObject
                         config.signingSecret = j.get("signingSecret").asString
                         config.singleTeamBotToken = j.get("singleTeamBotToken").asString
+                        config.clientId = j.get("clientId").asString
+                        config.clientSecret = j.get("clientSecret").asString
+                        config.redirectUri = j.get("redirectUri").asString
+                        config.scope = j.get("scope").asString
+                        config.oauthStartPath = j.get("oauthStartPath").asString
+                        config.oauthCallbackPath = j.get("oauthCallbackPath").asString
+                        config.oauthCompletionUrl = j.get("oauthCompletionUrl").asString
+                        config.oauthCancellationUrl = j.get("oauthCancellationUrl").asString
+                        config.isOAuthStartEnabled = config.oauthStartPath != null
+                        config.isOAuthCallbackEnabled = config.oauthCallbackPath != null
                     }
                 }
             } catch (e: IOException) {

--- a/jslack-lightning/pom.xml
+++ b/jslack-lightning/pom.xml
@@ -37,6 +37,12 @@
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.11.648</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/AppConfig.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/AppConfig.java
@@ -6,8 +6,10 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Optional;
+
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class AppConfig {
@@ -18,6 +20,14 @@ public class AppConfig {
 
         public static final String SLACK_BOT_TOKEN = "SLACK_BOT_TOKEN";
         public static final String SLACK_SIGNING_SECRET = "SLACK_SIGNING_SECRET";
+        public static final String SLACK_APP_CLIENT_ID = "SLACK_APP_CLIENT_ID";
+        public static final String SLACK_APP_CLIENT_SECRET = "SLACK_APP_CLIENT_SECRET";
+        public static final String SLACK_APP_REDIRECT_URI = "SLACK_APP_REDIRECT_URI";
+        public static final String SLACK_APP_SCOPE = "SLACK_APP_SCOPE";
+        public static final String SLACK_APP_OAUTH_START_PATH = "SLACK_APP_OAUTH_START_PATH";
+        public static final String SLACK_APP_OAUTH_CALLBACK_PATH = "SLACK_APP_OAUTH_CALLBACK_PATH";
+        public static final String SLACK_APP_OAUTH_CANCELLATION_URL = "SLACK_APP_OAUTH_CANCELLATION_URL";
+        public static final String SLACK_APP_OAUTH_COMPLETION_URL = "SLACK_APP_OAUTH_COMPLETION_URL";
     }
 
     @Builder.Default
@@ -26,4 +36,63 @@ public class AppConfig {
     private String singleTeamBotToken = System.getenv(EnvVariableName.SLACK_BOT_TOKEN);
     @Builder.Default
     private String signingSecret = System.getenv(EnvVariableName.SLACK_SIGNING_SECRET);
+
+    // https://api.slack.com/docs/oauth
+
+    public boolean isDistributedApp() {
+        return clientId != null && clientSecret != null;
+    }
+
+    private boolean oAuthStartEnabled = false;
+    private boolean oAuthCallbackEnabled = false;
+
+    public void setOauthStartPath(String oauthStartPath) {
+        this.oauthStartPath = oauthStartPath;
+        this.oAuthStartEnabled = oauthStartPath != null;
+    }
+
+    public void setOauthCallbackPath(String oauthCallbackPath) {
+        this.oauthCallbackPath = oauthCallbackPath;
+        this.oAuthCallbackEnabled = oauthCallbackPath != null;
+    }
+
+    @Builder.Default
+    private String clientId = System.getenv(EnvVariableName.SLACK_APP_CLIENT_ID);
+    @Builder.Default
+    private String clientSecret = System.getenv(EnvVariableName.SLACK_APP_CLIENT_SECRET);
+    @Builder.Default
+    private String redirectUri = System.getenv(EnvVariableName.SLACK_APP_REDIRECT_URI);
+    @Builder.Default
+    private String scope = System.getenv(EnvVariableName.SLACK_APP_SCOPE);
+
+    public String getOauthInstallationUrl(String state) {
+        if (clientId == null || scope == null || state == null) {
+            return null;
+        } else {
+            return "https://slack.com/oauth/authorize?client_id=" + clientId + "&scope=" + scope + "&state=" + state;
+        }
+    }
+
+    private String appPath;
+
+    public String getOauthStartRequestURI() {
+        return appPath + oauthStartPath;
+    }
+
+    public String getOauthCallbackRequestURI() {
+        return appPath + oauthCallbackPath;
+    }
+
+    @Builder.Default
+    private String oauthStartPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_START_PATH)).orElse("start");
+    @Builder.Default
+    private String oauthCallbackPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_CALLBACK_PATH)).orElse("callback");
+
+    @Builder.Default
+    private String oauthCancellationUrl = System.getenv(EnvVariableName.SLACK_APP_OAUTH_CANCELLATION_URL);
+    @Builder.Default
+    private String oauthCompletionUrl = System.getenv(EnvVariableName.SLACK_APP_OAUTH_COMPLETION_URL);
+
+    private boolean alwaysRequestUserTokenNeeded;
+
 }

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/context/Context.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/context/Context.java
@@ -24,7 +24,10 @@ public abstract class Context {
 
     protected String botToken;
     protected String botId; // set by MultiTeamsAuthorization
-    protected String botUserId; // set by MultiTeamsAuthorization
+    protected String botUserId;
+
+    protected String requestUserId;
+    protected String requestUserToken;
 
     protected final Map<String, String> additionalValues = new HashMap<>();
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/context/builtin/OAuthCallbackContext.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/context/builtin/OAuthCallbackContext.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.lightning.context.builtin;
+
+import com.github.seratch.jslack.lightning.context.Context;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
+public class OAuthCallbackContext extends Context {
+
+    private String oauthCompletionUrl;
+    private String oauthCancellationUrl;
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthAccessErrorHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthAccessErrorHandler.java
@@ -1,0 +1,12 @@
+package com.github.seratch.jslack.lightning.handler;
+
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+
+@FunctionalInterface
+public interface OAuthAccessErrorHandler {
+
+    Response handle(OAuthCallbackRequest req, OAuthAccessResponse apiResponse);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthErrorHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthErrorHandler.java
@@ -1,0 +1,11 @@
+package com.github.seratch.jslack.lightning.handler;
+
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+
+@FunctionalInterface
+public interface OAuthErrorHandler {
+
+    Response handle(OAuthCallbackRequest req);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthExceptionHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthExceptionHandler.java
@@ -1,0 +1,11 @@
+package com.github.seratch.jslack.lightning.handler;
+
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+
+@FunctionalInterface
+public interface OAuthExceptionHandler {
+
+    Response handle(OAuthCallbackRequest req, Exception e);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthStateErrorHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthStateErrorHandler.java
@@ -1,0 +1,11 @@
+package com.github.seratch.jslack.lightning.handler;
+
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+
+@FunctionalInterface
+public interface OAuthStateErrorHandler {
+
+    Response handle(OAuthCallbackRequest req);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthSuccessHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthSuccessHandler.java
@@ -1,0 +1,12 @@
+package com.github.seratch.jslack.lightning.handler;
+
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+
+@FunctionalInterface
+public interface OAuthSuccessHandler {
+
+    Response handle(OAuthCallbackRequest req, OAuthAccessResponse oauthAccess);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultAccessErrorHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultAccessErrorHandler.java
@@ -1,0 +1,23 @@
+package com.github.seratch.jslack.lightning.handler.builtin;
+
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
+import com.github.seratch.jslack.lightning.handler.OAuthAccessErrorHandler;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class OAuthDefaultAccessErrorHandler implements OAuthAccessErrorHandler {
+
+    @Override
+    public Response handle(OAuthCallbackRequest req, OAuthAccessResponse apiResponse) {
+        log.error("Failed to run an oauth.access API call: {} - {}", apiResponse.getError(), apiResponse);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Location", req.getContext().getOauthCancellationUrl());
+        return Response.builder().statusCode(302).headers(headers).build();
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultErrorHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultErrorHandler.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.lightning.handler.builtin;
+
+import com.github.seratch.jslack.lightning.handler.OAuthErrorHandler;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class OAuthDefaultErrorHandler implements OAuthErrorHandler {
+
+    @Override
+    public Response handle(OAuthCallbackRequest req) {
+        log.error("Received error code in OAuth callback: {}", req.getPayload());
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Location", req.getContext().getOauthCancellationUrl());
+        return Response.builder().statusCode(302).headers(headers).build();
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultExceptionHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.lightning.handler.builtin;
+
+import com.github.seratch.jslack.lightning.handler.OAuthExceptionHandler;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class OAuthDefaultExceptionHandler implements OAuthExceptionHandler {
+
+    @Override
+    public Response handle(OAuthCallbackRequest req, Exception e) {
+        log.error("Failed to run an OAuth callback operation - {}", e.getMessage(), e);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Location", req.getContext().getOauthCancellationUrl());
+        return Response.builder().statusCode(302).headers(headers).build();
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultStateErrorHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultStateErrorHandler.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.lightning.handler.builtin;
+
+import com.github.seratch.jslack.lightning.handler.OAuthStateErrorHandler;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class OAuthDefaultStateErrorHandler implements OAuthStateErrorHandler {
+
+    @Override
+    public Response handle(OAuthCallbackRequest req) {
+        log.warn("Invalid state parameter detected - TODO");
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Location", req.getContext().getOauthCancellationUrl());
+        return Response.builder().statusCode(302).headers(headers).build();
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultSuccessHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultSuccessHandler.java
@@ -1,0 +1,74 @@
+package com.github.seratch.jslack.lightning.handler.builtin;
+
+import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
+import com.github.seratch.jslack.api.methods.response.users.UsersInfoResponse;
+import com.github.seratch.jslack.lightning.context.builtin.OAuthCallbackContext;
+import com.github.seratch.jslack.lightning.handler.OAuthSuccessHandler;
+import com.github.seratch.jslack.lightning.model.Installer;
+import com.github.seratch.jslack.lightning.model.builtin.DefaultInstaller;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+import com.github.seratch.jslack.lightning.service.InstallationService;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class OAuthDefaultSuccessHandler implements OAuthSuccessHandler {
+
+    private InstallationService installationService;
+
+    public OAuthDefaultSuccessHandler(InstallationService installationService) {
+        this.installationService = installationService;
+    }
+
+    @Override
+    public Response handle(OAuthCallbackRequest req, OAuthAccessResponse o) {
+        OAuthCallbackContext context = req.getContext();
+        context.setEnterpriseId(o.getEnterpriseId());
+        context.setTeamId(o.getTeamId());
+        context.setBotUserId(o.getBot().getBotUserId());
+        context.setBotToken(o.getBot().getBotAccessToken());
+        context.setRequestUserId(o.getUserId());
+        context.setRequestUserToken(o.getAccessToken());
+
+        DefaultInstaller.DefaultInstallerBuilder i = DefaultInstaller.builder()
+                .enterpriseId(o.getEnterpriseId())
+                .teamId(o.getTeamId())
+                .teamName(o.getTeamName())
+                .installerUserId(o.getUserId())
+                .installerUserAccessToken(o.getAccessToken())
+                .scope(o.getScope())
+                .installedAt(System.currentTimeMillis());
+
+        if (o.getBot() != null) {
+            i = i.botUserId(o.getBot().getBotUserId());
+            i = i.botAccessToken(o.getBot().getBotAccessToken());
+            try {
+                UsersInfoResponse user = context.client().usersInfo(r -> r.user(o.getBot().getBotUserId()));
+                if (user.isOk()) {
+                    i = i.botId(user.getUser().getProfile().getBotId());
+                } else {
+                    log.warn("Failed to call users.info to fetch botId for the user: {} - {}", o.getBot().getBotUserId(), user.getError());
+                }
+            } catch (SlackApiException | IOException e) {
+                log.warn("Failed to call users.info to fetch botId for the user: {}", o.getBot().getBotUserId(), e);
+            }
+        }
+        Installer installer = i.build();
+
+        Map<String, String> headers = new HashMap<>();
+        try {
+            installationService.saveInstallerAndBot(installer);
+            headers.put("Location", context.getOauthCompletionUrl());
+        } catch (Exception e) {
+            log.warn("Failed to store the installation - {}", e.getMessage(), e);
+            headers.put("Location", context.getOauthCancellationUrl());
+        }
+        return Response.builder().statusCode(302).headers(headers).build();
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/MiddlewareOps.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/MiddlewareOps.java
@@ -1,0 +1,11 @@
+package com.github.seratch.jslack.lightning.middleware;
+
+import com.github.seratch.jslack.lightning.request.RequestType;
+
+public class MiddlewareOps {
+    private MiddlewareOps() {}
+
+    public static boolean isOAuthRequest(RequestType requestType) {
+        return requestType == RequestType.OAuthStart || requestType == RequestType.OAuthCallback;
+    }
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/IgnoringSelfEvents.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/IgnoringSelfEvents.java
@@ -91,7 +91,9 @@ public class IgnoringSelfEvents implements Middleware {
             BotsInfoResponse botInfo = client.botsInfo(r -> r.bot(botId));
             if (botInfo.isOk()) {
                 botUserId = botInfo.getBot().getUserId();
-                botIdToBotUserId.put(botId, botUserId);
+                if (botUserId != null) {
+                    botIdToBotUserId.put(botId, botUserId);
+                }
                 return botUserId;
             } else {
                 return null;

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/LegacyRequestVerification.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/LegacyRequestVerification.java
@@ -15,6 +15,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import lombok.extern.slf4j.Slf4j;
 
+import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isOAuthRequest;
+
 @Deprecated
 @Slf4j
 public class LegacyRequestVerification implements Middleware {
@@ -33,7 +35,10 @@ public class LegacyRequestVerification implements Middleware {
 
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
-        String actualToken = null;
+        if (isOAuthRequest(req.getRequestType())) {
+            return chain.next(req);
+        }
+        String actualToken;
         String body = req.getRequestBodyAsString();
         String json = jsonPayloadExtractor.extractIfExists(body);
         if (json != null) {

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/MultiTeamsAuthorization.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/MultiTeamsAuthorization.java
@@ -2,62 +2,123 @@ package com.github.seratch.jslack.lightning.middleware.builtin;
 
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.response.auth.AuthTestResponse;
+import com.github.seratch.jslack.lightning.AppConfig;
 import com.github.seratch.jslack.lightning.context.Context;
 import com.github.seratch.jslack.lightning.middleware.Middleware;
 import com.github.seratch.jslack.lightning.middleware.MiddlewareChain;
+import com.github.seratch.jslack.lightning.model.Bot;
+import com.github.seratch.jslack.lightning.model.Installer;
 import com.github.seratch.jslack.lightning.request.Request;
 import com.github.seratch.jslack.lightning.response.Response;
-import lombok.Builder;
-import lombok.Data;
+import com.github.seratch.jslack.lightning.service.InstallationService;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
-@Slf4j
-public abstract class MultiTeamsAuthorization implements Middleware {
+import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isOAuthRequest;
 
-    public MultiTeamsAuthorization() {
+@Slf4j
+public class MultiTeamsAuthorization implements Middleware {
+
+    private final InstallationService installationService;
+
+    private boolean alwaysRequestUserTokenNeeded;
+
+    public boolean isAlwaysRequestUserTokenNeeded() {
+        return alwaysRequestUserTokenNeeded;
+    }
+
+    public void setAlwaysRequestUserTokenNeeded(boolean alwaysRequestUserTokenNeeded) {
+        this.alwaysRequestUserTokenNeeded = alwaysRequestUserTokenNeeded;
+    }
+
+    public MultiTeamsAuthorization(AppConfig config, InstallationService installationService) {
+        setAlwaysRequestUserTokenNeeded(config.isAlwaysRequestUserTokenNeeded());
+        this.installationService = installationService;
     }
 
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
+        if (isOAuthRequest(req.getRequestType())) {
+            return chain.next(req);
+        }
         Context context = req.getContext();
-        AppInstallation appInstallation = findInstalledTeam(context.getEnterpriseId(), context.getTeamId());
+
+        String botToken = null;
+        String userToken = null;
+
+        Bot bot = installationService.findBot(context.getEnterpriseId(), context.getTeamId());
+        Installer installer = null;
+        if (bot != null) {
+            botToken = bot.getBotAccessToken();
+        }
+
+        if ((isAlwaysRequestUserTokenNeeded() || bot == null) && context.getRequestUserId() != null) {
+            // no bot for this app - try to fetch installer's access token instead
+            installer = installationService.findInstaller(
+                    context.getEnterpriseId(),
+                    context.getTeamId(),
+                    context.getRequestUserId()
+            );
+            if (installer != null) {
+                userToken = installer.getInstallerUserAccessToken();
+            }
+        }
+
+        if (botToken == null && userToken == null) {
+            return buildError(401, null, null, null);
+        }
+
         try {
-            AuthTestResponse authResult = context.client().authTest(r -> r.token(appInstallation.getBotToken()));
-            if (authResult.isOk()) {
+            String token = botToken != null ? botToken : userToken;
+            AuthTestResponse authTestResponse = context.client().authTest(r -> r.token(token));
+            if (authTestResponse.isOk()) {
+                context.setBotToken(botToken);
+                context.setRequestUserToken(userToken);
+                context.setTeamId(authTestResponse.getTeamId());
+                context.setEnterpriseId(authTestResponse.getEnterpriseId());
+                if (bot != null) {
+                    context.setBotId(bot.getBotId());
+                    context.setBotUserId(authTestResponse.getUserId());
+                }
                 return chain.next(req);
             } else {
-                return buildError(401, authResult, null, null);
+                return handleAuthTestError(authTestResponse.getError(), bot, installer, authTestResponse);
             }
         } catch (IOException e) {
             return buildError(503, null, e, null);
         } catch (SlackApiException e) {
-            return buildError(401, null, null, e);
+            return buildError(503, null, null, e);
         }
     }
 
-    @Data
-    @Builder
-    public static class AppInstallation {
-        private String botToken;
-        private String botId; // oauth.access
-        private String botUserId; // oauth.access
+    protected Response handleAuthTestError(
+            String errorCode,
+            Bot foundBot,
+            Installer foundInstaller,
+            AuthTestResponse authTestResponse) throws Exception {
+        if (errorCode.equals("account_inactive")) {
+            // this is not recoverable - going to remove the data not to repeat the same error
+            if (foundBot != null) {
+                installationService.deleteBot(foundBot);
+            } else if (foundInstaller != null) {
+                installationService.deleteInstaller(foundInstaller);
+            }
+        }
+        return buildError(401, authTestResponse, null, null);
     }
-
-    abstract AppInstallation findInstalledTeam(String enterpriseId, String teamId);
 
     protected Response buildError(
             int statusCode,
             AuthTestResponse authTestResponse,
             IOException ioException,
             SlackApiException slackException) {
-        if (log.isDebugEnabled()) {
-            log.debug("auth.test result: {}, io error: {}, api error: {}",
-                    authTestResponse, ioException, slackException);
-        }
+
+        log.info("auth.test result: {}, io error: {}, api error: {}", authTestResponse, ioException, slackException);
+
         return Response.builder()
                 .statusCode(statusCode)
+                .contentType(Response.CONTENT_TYPE_APPLICATION_JSON)
                 .body("{\"error\":\"a request for an unknown workspace detected\"}")
                 .build();
     }

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/RequestVerification.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/RequestVerification.java
@@ -4,8 +4,11 @@ import com.github.seratch.jslack.app_backend.SlackSignature;
 import com.github.seratch.jslack.lightning.middleware.Middleware;
 import com.github.seratch.jslack.lightning.middleware.MiddlewareChain;
 import com.github.seratch.jslack.lightning.request.Request;
+import com.github.seratch.jslack.lightning.request.RequestType;
 import com.github.seratch.jslack.lightning.response.Response;
 import lombok.extern.slf4j.Slf4j;
+
+import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isOAuthRequest;
 
 @Slf4j
 public class RequestVerification implements Middleware {
@@ -18,6 +21,9 @@ public class RequestVerification implements Middleware {
 
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
+        if (isOAuthRequest(req.getRequestType())) {
+            return chain.next(req);
+        }
         if (req.isValid(verifier)) {
             return chain.next(req);
         } else {

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/SingleTeamAuthorization.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/SingleTeamAuthorization.java
@@ -5,19 +5,32 @@ import com.github.seratch.jslack.lightning.AppConfig;
 import com.github.seratch.jslack.lightning.context.Context;
 import com.github.seratch.jslack.lightning.middleware.Middleware;
 import com.github.seratch.jslack.lightning.middleware.MiddlewareChain;
+import com.github.seratch.jslack.lightning.model.Installer;
 import com.github.seratch.jslack.lightning.request.Request;
+import com.github.seratch.jslack.lightning.request.RequestType;
 import com.github.seratch.jslack.lightning.response.Response;
+import com.github.seratch.jslack.lightning.service.InstallationService;
+import lombok.extern.slf4j.Slf4j;
 
+import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isOAuthRequest;
+
+@Slf4j
 public class SingleTeamAuthorization implements Middleware {
 
     private final AppConfig appConfig;
+    private final InstallationService installationService;
 
-    public SingleTeamAuthorization(AppConfig appConfig) {
+    public SingleTeamAuthorization(AppConfig appConfig, InstallationService installationService) {
         this.appConfig = appConfig;
+        this.installationService = installationService;
     }
 
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
+        if (isOAuthRequest(req.getRequestType())) {
+            return chain.next(req);
+        }
+
         Context context = req.getContext();
         AuthTestResponse authResult = context.client().authTest(r -> r.token(appConfig.getSingleTeamBotToken()));
         if (authResult.isOk()) {
@@ -27,6 +40,24 @@ public class SingleTeamAuthorization implements Middleware {
             context.setBotUserId(authResult.getUserId());
             context.setTeamId(authResult.getTeamId());
             context.setEnterpriseId(authResult.getEnterpriseId());
+
+            if (appConfig.isAlwaysRequestUserTokenNeeded()) {
+                if (installationService == null) {
+                    log.warn("Skipped to fetch requestUserToken as InstallationService is not available for SingleTeamAuthorization - " +
+                                    "enterprise_id: {}, team_id: {}, user_id: {}",
+                            context.getEnterpriseId(), context.getTeamId(), context.getRequestUserId()
+                    );
+                }
+                Installer installer = installationService.findInstaller(
+                        context.getEnterpriseId(),
+                        context.getTeamId(),
+                        context.getRequestUserId()
+                );
+                if (installer != null) {
+                    context.setRequestUserToken(installer.getInstallerUserAccessToken());
+                }
+            }
+
             return chain.next(req);
         } else {
             resp.setStatusCode(500);

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Bot.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Bot.java
@@ -1,0 +1,25 @@
+package com.github.seratch.jslack.lightning.model;
+
+public interface Bot {
+
+    String getEnterpriseId();
+
+    void setEnterpriseId(String enterpriseId);
+
+    String getTeamId();
+
+    void setTeamId(String teamId);
+
+    String getBotId();
+
+    void setBotId(String botId);
+
+    String getBotUserId();
+
+    void setBotUserId(String botUserId);
+
+    String getBotAccessToken();
+
+    void setBotAccessToken(String botAccessToken);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Installer.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Installer.java
@@ -1,0 +1,35 @@
+package com.github.seratch.jslack.lightning.model;
+
+public interface Installer {
+
+    String getEnterpriseId();
+
+    void setEnterpriseId(String enterpriseId);
+
+    String getTeamId();
+
+    void setTeamId(String teamId);
+
+    String getInstallerUserId();
+
+    void setInstallerUserId(String userId);
+
+    String getInstallerUserAccessToken();
+
+    void setInstallerUserAccessToken(String userAccessToken);
+
+    String getBotId();
+
+    void setBotId(String botId);
+
+    String getBotUserId();
+
+    void setBotUserId(String botUserId);
+
+    String getBotAccessToken();
+
+    void setBotAccessToken(String botAccessToken);
+
+    Bot toBot();
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultBot.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultBot.java
@@ -1,0 +1,20 @@
+package com.github.seratch.jslack.lightning.model.builtin;
+
+import com.github.seratch.jslack.lightning.model.Bot;
+import lombok.Data;
+
+@Data
+public class DefaultBot implements Bot {
+
+    private String enterpriseId;
+    private String teamId;
+    private String teamName;
+
+    private String scope;
+
+    private String botId;
+    private String botUserId;
+    private String botAccessToken;
+
+    private Long installedAt;
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultInstaller.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultInstaller.java
@@ -1,0 +1,44 @@
+package com.github.seratch.jslack.lightning.model.builtin;
+
+import com.github.seratch.jslack.lightning.model.Bot;
+import com.github.seratch.jslack.lightning.model.Installer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DefaultInstaller implements Installer {
+
+    private String enterpriseId;
+    private String teamId;
+    private String teamName;
+
+    private String installerUserId;
+    private String installerUserAccessToken;
+
+    private String scope;
+
+    private String botId;
+    private String botUserId;
+    private String botAccessToken;
+
+    private Long installedAt;
+
+    @Override
+    public Bot toBot() {
+        DefaultBot bot = new DefaultBot();
+        bot.setEnterpriseId(enterpriseId);
+        bot.setTeamId(teamId);
+        bot.setTeamName(teamName);
+        bot.setScope(scope);
+        bot.setBotId(botId);
+        bot.setBotUserId(botUserId);
+        bot.setBotAccessToken(botAccessToken);
+        bot.setInstalledAt(installedAt);
+        return bot;
+    }
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/Request.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/Request.java
@@ -3,6 +3,7 @@ package com.github.seratch.jslack.lightning.request;
 import com.github.seratch.jslack.app_backend.SlackSignature;
 import com.github.seratch.jslack.lightning.AppConfig;
 import com.github.seratch.jslack.lightning.context.Context;
+import com.github.seratch.jslack.lightning.context.builtin.OAuthCallbackContext;
 import lombok.ToString;
 
 @ToString
@@ -21,9 +22,20 @@ public abstract class Request<CTX extends Context> {
     public abstract CTX getContext();
 
     public void updateContext(AppConfig config) {
+        // To use the properly configured Web API client
         getContext().setSlack(config.getSlack());
-        if (getContext().getBotToken() == null && config.getSingleTeamBotToken() != null) {
+
+        // When the app is a distributed app, Lightning enables MultiTeamsAuthorization
+        if (config.isDistributedApp() == false
+                && getContext().getBotToken() == null
+                && config.getSingleTeamBotToken() != null) {
             getContext().setBotToken(config.getSingleTeamBotToken());
+        }
+
+        if (config.isOAuthCallbackEnabled() && getContext() instanceof OAuthCallbackContext) {
+            OAuthCallbackContext ctx = (OAuthCallbackContext) getContext();
+            ctx.setOauthCompletionUrl(config.getOauthCompletionUrl());
+            ctx.setOauthCancellationUrl(config.getOauthCancellationUrl());
         }
     }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/RequestType.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/RequestType.java
@@ -1,6 +1,8 @@
 package com.github.seratch.jslack.lightning.request;
 
 public enum RequestType {
+    OAuthStart,
+    OAuthCallback,
     Command,
     OutgoingWebhooks,
     Event,

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/AttachmentActionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/AttachmentActionRequest.java
@@ -23,6 +23,7 @@ public class AttachmentActionRequest extends Request<ActionContext> {
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, AttachmentActionPayload.class);
         getContext().setResponseUrl(payload.getResponseUrl());
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private ActionContext context = new ActionContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/BlockActionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/BlockActionRequest.java
@@ -24,6 +24,7 @@ public class BlockActionRequest extends Request<ActionContext> {
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, BlockActionPayload.class);
         getContext().setResponseUrl(payload.getResponseUrl());
         getContext().setTriggerId(payload.getTriggerId());
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private ActionContext context = new ActionContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/BlockSuggestionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/BlockSuggestionRequest.java
@@ -22,6 +22,7 @@ public class BlockSuggestionRequest extends Request<BlockSuggestionContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, BlockSuggestionPayload.class);
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private BlockSuggestionContext context = new BlockSuggestionContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogCancellationRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogCancellationRequest.java
@@ -23,6 +23,7 @@ public class DialogCancellationRequest extends Request<DialogCancellationContext
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, DialogCancellationPayload.class);
         getContext().setResponseUrl(payload.getResponseUrl());
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private DialogCancellationContext context = new DialogCancellationContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogSubmissionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogSubmissionRequest.java
@@ -23,6 +23,7 @@ public class DialogSubmissionRequest extends Request<DialogSubmissionContext> {
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, DialogSubmissionPayload.class);
         getContext().setResponseUrl(payload.getResponseUrl());
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private DialogSubmissionContext context = new DialogSubmissionContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogSuggestionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogSuggestionRequest.java
@@ -22,6 +22,7 @@ public class DialogSuggestionRequest extends Request<DialogSuggestionContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, DialogSuggestionPayload.class);
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private DialogSuggestionContext context = new DialogSuggestionContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/MessageActionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/MessageActionRequest.java
@@ -24,6 +24,7 @@ public class MessageActionRequest extends Request<ActionContext> {
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, MessageActionPayload.class);
         getContext().setResponseUrl(payload.getResponseUrl());
         getContext().setTriggerId(payload.getTriggerId());
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private ActionContext context = new ActionContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/OAuthCallbackRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/OAuthCallbackRequest.java
@@ -1,0 +1,52 @@
+package com.github.seratch.jslack.lightning.request.builtin;
+
+import com.github.seratch.jslack.app_backend.oauth.payload.VerificationCodePayload;
+import com.github.seratch.jslack.lightning.context.builtin.OAuthCallbackContext;
+import com.github.seratch.jslack.lightning.request.Request;
+import com.github.seratch.jslack.lightning.request.RequestHeaders;
+import com.github.seratch.jslack.lightning.request.RequestType;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+public class OAuthCallbackRequest extends Request<OAuthCallbackContext> {
+
+    private final String requestBody;
+    private final RequestHeaders headers;
+    private final VerificationCodePayload payload;
+
+    public OAuthCallbackRequest(
+            String requestBody,
+            VerificationCodePayload payload,
+            RequestHeaders headers) {
+        this.requestBody = requestBody;
+        this.headers = headers;
+        this.payload = payload;
+    }
+
+    private OAuthCallbackContext context = new OAuthCallbackContext();
+
+    @Override
+    public OAuthCallbackContext getContext() {
+        return context;
+    }
+
+    @Override
+    public RequestType getRequestType() {
+        return RequestType.OAuthCallback;
+    }
+
+    @Override
+    public String getRequestBodyAsString() {
+        return requestBody;
+    }
+
+    @Override
+    public RequestHeaders getHeaders() {
+        return this.headers;
+    }
+
+    public VerificationCodePayload getPayload() {
+        return payload;
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/OAuthStartRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/OAuthStartRequest.java
@@ -1,0 +1,44 @@
+package com.github.seratch.jslack.lightning.request.builtin;
+
+import com.github.seratch.jslack.lightning.context.builtin.OAuthCallbackContext;
+import com.github.seratch.jslack.lightning.request.Request;
+import com.github.seratch.jslack.lightning.request.RequestHeaders;
+import com.github.seratch.jslack.lightning.request.RequestType;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+public class OAuthStartRequest extends Request<OAuthCallbackContext> {
+
+    private final String requestBody;
+    private final RequestHeaders headers;
+
+    public OAuthStartRequest(
+            String requestBody,
+            RequestHeaders headers) {
+        this.requestBody = requestBody;
+        this.headers = headers;
+    }
+
+    private OAuthCallbackContext context = new OAuthCallbackContext();
+
+    @Override
+    public OAuthCallbackContext getContext() {
+        return context;
+    }
+
+    @Override
+    public RequestType getRequestType() {
+        return RequestType.OAuthStart;
+    }
+
+    @Override
+    public String getRequestBodyAsString() {
+        return requestBody;
+    }
+
+    @Override
+    public RequestHeaders getHeaders() {
+        return this.headers;
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/OutgoingWebhooksRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/OutgoingWebhooksRequest.java
@@ -23,6 +23,7 @@ public class OutgoingWebhooksRequest extends Request<OutgoingWebhooksContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = PAYLOAD_PARSER.parse(requestBody);
+        getContext().setRequestUserId(payload.getUserId());
     }
 
     private OutgoingWebhooksContext context = new OutgoingWebhooksContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/SlashCommandRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/SlashCommandRequest.java
@@ -27,6 +27,9 @@ public class SlashCommandRequest extends Request<SlashCommandContext> {
         this.payload = PAYLOAD_PARSER.parse(requestBody);
         getContext().setResponseUrl(payload.getResponseUrl());
         getContext().setTriggerId(payload.getTriggerId());
+        getContext().setEnterpriseId(payload.getEnterpriseId());
+        getContext().setTeamId(payload.getTeamId());
+        getContext().setRequestUserId(payload.getUserId());
     }
 
     @Override

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/ViewClosedRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/ViewClosedRequest.java
@@ -22,6 +22,7 @@ public class ViewClosedRequest extends Request<DefaultContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, ViewClosedPayload.class);
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private DefaultContext context = new DefaultContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/ViewSubmissionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/ViewSubmissionRequest.java
@@ -22,6 +22,7 @@ public class ViewSubmissionRequest extends Request<ViewSubmissionContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, ViewSubmissionPayload.class);
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private ViewSubmissionContext context = new ViewSubmissionContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/InstallationService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/InstallationService.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.lightning.service;
+
+import com.github.seratch.jslack.lightning.model.Bot;
+import com.github.seratch.jslack.lightning.model.Installer;
+
+public interface InstallationService {
+
+    void saveInstallerAndBot(Installer installer) throws Exception;
+
+    void deleteBot(Bot bot) throws Exception;
+
+    void deleteInstaller(Installer installer) throws Exception;
+
+    Bot findBot(String enterpriseId, String teamId);
+
+    Installer findInstaller(String enterpriseId, String teamId, String userId);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/OAuthCallbackService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/OAuthCallbackService.java
@@ -1,0 +1,10 @@
+package com.github.seratch.jslack.lightning.service;
+
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+
+public interface OAuthCallbackService {
+
+    Response handle(OAuthCallbackRequest request);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/OAuthStateService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/OAuthStateService.java
@@ -1,0 +1,11 @@
+package com.github.seratch.jslack.lightning.service;
+
+public interface OAuthStateService {
+
+    String issueNewState() throws Exception;
+
+    boolean isValid(String state);
+
+    void consume(String state) throws Exception;
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/AmazonS3InstallationService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/AmazonS3InstallationService.java
@@ -1,0 +1,144 @@
+package com.github.seratch.jslack.lightning.service.builtin;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.util.IOUtils;
+import com.github.seratch.jslack.lightning.model.Bot;
+import com.github.seratch.jslack.lightning.model.Installer;
+import com.github.seratch.jslack.lightning.model.builtin.DefaultBot;
+import com.github.seratch.jslack.lightning.model.builtin.DefaultInstaller;
+import com.github.seratch.jslack.lightning.service.InstallationService;
+import com.github.seratch.jslack.lightning.util.JsonOps;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+public class AmazonS3InstallationService implements InstallationService {
+
+    private final String bucketName;
+
+    public AmazonS3InstallationService(String bucketName) {
+        this.bucketName = bucketName;
+    }
+
+    @Override
+    public void saveInstallerAndBot(Installer i) throws Exception {
+        AmazonS3 s3 = this.createS3Client();
+        save(s3, getInstallerKey(i), JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}");
+        save(s3, getBotKey(i), JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}");
+    }
+
+    private void save(AmazonS3 s3, String s3Key, String json, String logMessage) {
+        PutObjectResult botPutResult = s3.putObject(bucketName, s3Key, json);
+        if (log.isDebugEnabled()) {
+            log.debug(logMessage, JsonOps.toJsonString(botPutResult));
+        }
+    }
+
+    @Override
+    public void deleteBot(Bot bot) throws Exception {
+        AmazonS3 s3 = this.createS3Client();
+        s3.deleteObject(bucketName, getBotKey(bot.getEnterpriseId(), bot.getTeamId()));
+    }
+
+    @Override
+    public void deleteInstaller(Installer installer) throws Exception {
+        AmazonS3 s3 = this.createS3Client();
+        s3.deleteObject(bucketName, getInstallerKey(installer));
+    }
+
+    @Override
+    public Bot findBot(String enterpriseId, String teamId) {
+        AmazonS3 s3 = this.createS3Client();
+        String fullKey = getBotKey(enterpriseId, teamId);
+        if (s3.getObjectMetadata(bucketName, fullKey) == null && enterpriseId != null) {
+            String nonGridKey = getBotKey(null, teamId);
+            S3Object nonGridObject = s3.getObject(bucketName, nonGridKey);
+            if (nonGridObject != null) {
+                try {
+                    Bot bot = toBot(nonGridObject);
+                    bot.setEnterpriseId(enterpriseId); // the workspace seems to be in a Grid org now
+                    save(s3, fullKey, JsonOps.toJsonString(bot), "AWS S3 putObject result of Bot data - {}");
+                    return bot;
+                } catch (Exception e) {
+                    log.error("Failed to save a new Bot data for enterprise_id: {}, team_id: {}", enterpriseId, teamId);
+                }
+            }
+        }
+        S3Object s3Object = s3.getObject(bucketName, fullKey);
+        try {
+            return toBot(s3Object);
+        } catch (IOException e) {
+            log.error("Failed to load Bot data for enterprise_id: {}, team_id: {}", enterpriseId, teamId);
+            return null;
+        }
+    }
+
+    @Override
+    public Installer findInstaller(String enterpriseId, String teamId, String userId) {
+        AmazonS3 s3 = this.createS3Client();
+        String fullKey = getInstallerKey(enterpriseId, teamId, userId);
+        if (s3.getObjectMetadata(bucketName, fullKey) == null && enterpriseId != null) {
+            String nonGridKey = getInstallerKey(null, teamId, userId);
+            S3Object nonGridObject = s3.getObject(bucketName, nonGridKey);
+            if (nonGridObject != null) {
+                try {
+                    Installer installer = toInstaller(nonGridObject);
+                    installer.setEnterpriseId(enterpriseId); // the workspace seems to be in a Grid org now
+                    saveInstallerAndBot(installer);
+                    return installer;
+                } catch (Exception e) {
+                    log.error("Failed to save a new Installer data for enterprise_id: {}, team_id: {}, user_id: {}",
+                            enterpriseId, teamId, userId);
+                }
+            }
+        }
+        S3Object s3Object = s3.getObject(bucketName, fullKey);
+        try {
+            return toInstaller(s3Object);
+        } catch (Exception e) {
+            log.error("Failed to save a new Installer data for enterprise_id: {}, team_id: {}, user_id: {}",
+                    enterpriseId, teamId, userId);
+            return null;
+        }
+    }
+
+    private Bot toBot(S3Object s3Object) throws IOException {
+        String json = IOUtils.toString(s3Object.getObjectContent());
+        return JsonOps.fromJson(json, DefaultBot.class);
+    }
+
+    private Installer toInstaller(S3Object s3Object) throws IOException {
+        String json = IOUtils.toString(s3Object.getObjectContent());
+        return JsonOps.fromJson(json, DefaultInstaller.class);
+    }
+
+    private AmazonS3 createS3Client() {
+        return AmazonS3ClientBuilder.defaultClient();
+    }
+
+    private String getInstallerKey(Installer i) {
+        return getInstallerKey(i.getEnterpriseId(), i.getTeamId(), i.getInstallerUserId());
+    }
+
+    private String getInstallerKey(String enterpriseId, String teamId, String userId) {
+        return "installer/"
+                + Optional.ofNullable(enterpriseId).orElse("none") + "-"
+                + teamId + "-"
+                + userId;
+    }
+
+    private String getBotKey(Installer i) {
+        return getBotKey(i.getEnterpriseId(), i.getTeamId());
+    }
+
+    private String getBotKey(String enterpriseId, String teamId) {
+        return "bot/"
+                + Optional.ofNullable(enterpriseId).orElse("none") + "-"
+                + teamId;
+    }
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/AmazonS3OAuthStateService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/AmazonS3OAuthStateService.java
@@ -1,0 +1,75 @@
+package com.github.seratch.jslack.lightning.service.builtin;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.util.IOUtils;
+import com.github.seratch.jslack.lightning.service.OAuthStateService;
+import com.github.seratch.jslack.lightning.util.JsonOps;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+public class AmazonS3OAuthStateService implements OAuthStateService {
+
+    public static final long DEFAULT_EXPIRATION_IN_MILLIS = 10 * 60 * 1000; // default 10 min
+
+    private final String bucketName;
+    private final long millisToExpire;
+
+    public AmazonS3OAuthStateService(String bucketName) {
+        this(bucketName, DEFAULT_EXPIRATION_IN_MILLIS);
+    }
+
+    public AmazonS3OAuthStateService(String bucketName, long millisToExpire) {
+        this.bucketName = bucketName;
+        this.millisToExpire = millisToExpire;
+    }
+
+    @Override
+    public String issueNewState() {
+        String state = UUID.randomUUID().toString();
+        AmazonS3 s3 = this.createS3Client();
+        String value = "" + (System.currentTimeMillis() + millisToExpire);
+        PutObjectResult putObjectResult = s3.putObject(bucketName, getKey(state), value);
+        if (log.isDebugEnabled()) {
+            log.debug("AWS S3 putObject result of state data - {}", JsonOps.toJsonString(putObjectResult));
+        }
+        return state;
+    }
+
+    @Override
+    public boolean isValid(String state) {
+        AmazonS3 s3 = this.createS3Client();
+        S3Object s3Object = s3.getObject(bucketName, getKey(state));
+        String millisToExpire = null;
+        try {
+            millisToExpire = IOUtils.toString(s3Object.getObjectContent());
+            return Long.valueOf(millisToExpire) > System.currentTimeMillis();
+        } catch (IOException e) {
+            log.error("Failed to load a state data for state: {}", state, e);
+            return false;
+        } catch (NumberFormatException ne) {
+            log.error("Invalid state value detected - state: {}, millisToExpire: {}", state, millisToExpire);
+            return false;
+        }
+    }
+
+    @Override
+    public void consume(String state) {
+        AmazonS3 s3 = this.createS3Client();
+        s3.deleteObject(bucketName, getKey(state));
+    }
+
+    private AmazonS3 createS3Client() {
+        return AmazonS3ClientBuilder.defaultClient();
+    }
+
+    private String getKey(String state) {
+        return "state/" + state;
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/DefaultOAuthCallbackService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/DefaultOAuthCallbackService.java
@@ -1,0 +1,74 @@
+package com.github.seratch.jslack.lightning.service.builtin;
+
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
+import com.github.seratch.jslack.app_backend.config.SlackAppConfig;
+import com.github.seratch.jslack.app_backend.oauth.OAuthFlowOperator;
+import com.github.seratch.jslack.app_backend.oauth.payload.VerificationCodePayload;
+import com.github.seratch.jslack.lightning.AppConfig;
+import com.github.seratch.jslack.lightning.handler.*;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+import com.github.seratch.jslack.lightning.service.OAuthCallbackService;
+import com.github.seratch.jslack.lightning.service.OAuthStateService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DefaultOAuthCallbackService implements OAuthCallbackService {
+
+    private final AppConfig config;
+    private final OAuthFlowOperator operator;
+    private final OAuthStateService stateService;
+    private final OAuthSuccessHandler successHandler;
+    private final OAuthErrorHandler errorHandler;
+    private final OAuthStateErrorHandler stateErrorHandler;
+    private final OAuthAccessErrorHandler accessErrorHandler;
+    private final OAuthExceptionHandler exceptionHandler;
+
+    public DefaultOAuthCallbackService(
+            AppConfig config,
+            OAuthStateService stateService,
+            OAuthSuccessHandler successHandler,
+            OAuthErrorHandler errorHandler,
+            OAuthStateErrorHandler stateErrorHandler,
+            OAuthAccessErrorHandler accessErrorHandler,
+            OAuthExceptionHandler exceptionHandler) {
+        this.config = config;
+        this.stateService = stateService;
+        this.successHandler = successHandler;
+        this.errorHandler = errorHandler;
+        this.stateErrorHandler = stateErrorHandler;
+        this.accessErrorHandler = accessErrorHandler;
+        this.exceptionHandler = exceptionHandler;
+
+        SlackAppConfig slackAppConfig = SlackAppConfig.builder()
+                .clientId(config.getClientId())
+                .clientSecret(config.getClientSecret())
+                .redirectUri(config.getRedirectUri())
+                .build();
+        this.operator = new OAuthFlowOperator(config.getSlack(), slackAppConfig);
+    }
+
+    public Response handle(OAuthCallbackRequest request) {
+        VerificationCodePayload payload = request.getPayload();
+        try {
+            if (payload.getError() != null) {
+                return errorHandler.handle(request);
+            }
+            if (stateService.isValid(payload.getState())) {
+                OAuthAccessResponse oauthAccess = operator.callOAuthAccessMethod(payload);
+                if (oauthAccess.isOk()) {
+                    stateService.consume(payload.getState());
+                    return successHandler.handle(request, oauthAccess);
+                } else {
+                    return accessErrorHandler.handle(request, oauthAccess);
+                }
+            } else {
+                return stateErrorHandler.handle(request);
+            }
+        } catch (Exception e) {
+            log.error("Failed to handle an OAuth request - {}", e.getMessage(), e);
+            return exceptionHandler.handle(request, e);
+        }
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/FileInstallationService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/FileInstallationService.java
@@ -1,0 +1,137 @@
+package com.github.seratch.jslack.lightning.service.builtin;
+
+import com.github.seratch.jslack.lightning.model.Bot;
+import com.github.seratch.jslack.lightning.model.Installer;
+import com.github.seratch.jslack.lightning.model.builtin.DefaultBot;
+import com.github.seratch.jslack.lightning.model.builtin.DefaultInstaller;
+import com.github.seratch.jslack.lightning.service.InstallationService;
+import com.github.seratch.jslack.lightning.util.JsonOps;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static java.util.stream.Collectors.joining;
+
+@Slf4j
+public class FileInstallationService implements InstallationService {
+
+    public static final String DEFAULT_BASE_DIR = System.getProperty("user.home") + File.separator + ".jslack-lightning";
+
+    private final String baseDir;
+
+    public FileInstallationService() {
+        this(DEFAULT_BASE_DIR);
+    }
+
+    public FileInstallationService(String baseDir) {
+        this.baseDir = baseDir;
+    }
+
+    @Override
+    public void saveInstallerAndBot(Installer installer) throws Exception {
+        write(getInstallerPath(installer), JsonOps.toJsonString(installer));
+        write(getBotPath(installer.getEnterpriseId(), installer.getTeamId()), JsonOps.toJsonString(installer.toBot()));
+    }
+
+    @Override
+    public void deleteBot(Bot bot) throws Exception {
+        Files.deleteIfExists(Paths.get(getBotPath(bot.getEnterpriseId(), bot.getTeamId())));
+    }
+
+    @Override
+    public void deleteInstaller(Installer installer) throws Exception {
+        Files.deleteIfExists(Paths.get(getInstallerPath(installer)));
+        Files.deleteIfExists(Paths.get(getBotPath(installer.getEnterpriseId(), installer.getTeamId())));
+    }
+
+    @Override
+    public Bot findBot(String enterpriseId, String teamId) {
+        try {
+            String json = loadFileContent(getBotPath(enterpriseId, teamId));
+            if (json == null && enterpriseId != null) {
+                json = loadFileContent(getBotPath(null, teamId));
+                if (json != null) {
+                    Bot bot = JsonOps.fromJson(json, DefaultBot.class);
+                    bot.setEnterpriseId(enterpriseId);
+                    write(getBotPath(enterpriseId, teamId), JsonOps.toJsonString(bot));
+                    return bot;
+                }
+            }
+            if (json != null) {
+                return JsonOps.fromJson(json, DefaultBot.class);
+            } else {
+                return null;
+            }
+        } catch (IOException e) {
+            log.warn("Failed to load a bot user (enterprise_id: {}, team_id: {})", enterpriseId, teamId);
+            return null;
+        }
+    }
+
+    @Override
+    public Installer findInstaller(String enterpriseId, String teamId, String userId) {
+        try {
+            String json = loadFileContent(getInstallerPath(enterpriseId, teamId, userId));
+            if (json == null && enterpriseId != null) {
+                json = loadFileContent(getInstallerPath(null, teamId, userId));
+                if (json != null) {
+                    Installer i = JsonOps.fromJson(json, DefaultInstaller.class);
+                    i.setEnterpriseId(enterpriseId);
+                    write(getInstallerPath(enterpriseId, teamId, userId), JsonOps.toJsonString(i));
+                    return i;
+                }
+            }
+            if (json != null) {
+                return JsonOps.fromJson(json, DefaultInstaller.class);
+            } else {
+                return null;
+            }
+        } catch (IOException e) {
+            log.warn("Failed to load an installer user (enterprise_id: {}, team_id: {})", enterpriseId, teamId);
+            return null;
+        }
+    }
+
+    private String getInstallerPath(Installer i) throws IOException {
+        return getInstallerPath(i.getEnterpriseId(), i.getTeamId(), i.getInstallerUserId());
+    }
+
+    private String getInstallerPath(String enterpriseId, String teamId, String userId) throws IOException {
+        String dir = getBaseDir() + File.separator + "installer";
+        Path dirPath = Paths.get(dir);
+        if (!Files.exists(dirPath)) {
+            Files.createDirectories(dirPath);
+        }
+        String key = ((enterpriseId == null) ? "none" : enterpriseId) + "-" + teamId + "-" + userId;
+        return dir + File.separator + key;
+    }
+
+    private String getBotPath(String enterpriseId, String teamId) throws IOException {
+        String dir = getBaseDir() + File.separator + "bot";
+        Path dirPath = Paths.get(dir);
+        if (!Files.exists(dirPath)) {
+            Files.createDirectories(dirPath);
+        }
+        String key = ((enterpriseId == null) ? "none" : enterpriseId) + "-" + teamId;
+        return dir + File.separator + key;
+    }
+
+    private String getBaseDir() {
+        return baseDir + File.separator + "installation";
+    }
+
+    private void write(String path, String json) throws IOException {
+        Files.write(Paths.get(path), json.getBytes());
+    }
+
+    private String loadFileContent(String filepath) throws IOException {
+        return Files.readAllLines(Paths.get(filepath))
+                .stream()
+                .collect(joining());
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/FileOAuthStateService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/FileOAuthStateService.java
@@ -1,0 +1,82 @@
+package com.github.seratch.jslack.lightning.service.builtin;
+
+import com.github.seratch.jslack.lightning.service.OAuthStateService;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.joining;
+
+public class FileOAuthStateService implements OAuthStateService {
+
+    public static final String DEFAULT_BASE_DIR = System.getProperty("user.home") + File.separator + ".jslack-lightning";
+    public static final long DEFAULT_EXPIRATION_IN_MILLIS = 10 * 60 * 1000; // default 10 min
+
+    private final String baseDir;
+    private final long millisToExpire;
+
+    public FileOAuthStateService() throws RuntimeException {
+        this(DEFAULT_BASE_DIR, DEFAULT_EXPIRATION_IN_MILLIS);
+    }
+
+    public FileOAuthStateService(String baseDir, long millisToExpire) throws RuntimeException {
+        this.baseDir = baseDir;
+        this.millisToExpire = millisToExpire;
+        initDirectoryIfAbsent();
+    }
+
+    @Override
+    public String issueNewState() throws Exception {
+        initDirectoryIfAbsent();
+        String newState = UUID.randomUUID().toString();
+        Path filepath = Paths.get(getPath(newState));
+        String value = "" + (System.currentTimeMillis() + millisToExpire);
+        Files.write(filepath, value.getBytes());
+        return newState;
+    }
+
+    @Override
+    public boolean isValid(String state) {
+        Long millisToExpire = getMillisToExpire(state);
+        return millisToExpire != null && millisToExpire > System.currentTimeMillis();
+    }
+
+    @Override
+    public void consume(String state) throws Exception {
+        initDirectoryIfAbsent();
+        Path filepath = Paths.get(getPath(state));
+        Files.delete(filepath);
+    }
+
+    private String getPath(String state) {
+        return baseDir + File.separator + "state" + File.separator + state;
+    }
+
+    private Long getMillisToExpire(String state) {
+        initDirectoryIfAbsent();
+        try {
+            String value = Files.readAllLines(Paths.get(getPath(state))).stream().collect(joining());
+            return Long.valueOf(value);
+        } catch (IOException e) {
+            return null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void initDirectoryIfAbsent() {
+        String dir = baseDir + File.separator + "state";
+        Path dirPath = Paths.get(dir);
+        if (!Files.exists(dirPath)) {
+            try {
+                Files.createDirectories(dirPath);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/ServletAdapter.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/ServletAdapter.java
@@ -8,6 +8,7 @@ import com.github.seratch.jslack.app_backend.interactive_messages.payload.Attach
 import com.github.seratch.jslack.app_backend.interactive_messages.payload.BlockActionPayload;
 import com.github.seratch.jslack.app_backend.interactive_messages.payload.BlockSuggestionPayload;
 import com.github.seratch.jslack.app_backend.message_actions.payload.MessageActionPayload;
+import com.github.seratch.jslack.app_backend.oauth.payload.VerificationCodePayload;
 import com.github.seratch.jslack.app_backend.util.JsonPayloadExtractor;
 import com.github.seratch.jslack.app_backend.util.OutgoingWebhooksRequestDetector;
 import com.github.seratch.jslack.app_backend.util.SlashCommandRequestDetector;
@@ -19,6 +20,7 @@ import com.github.seratch.jslack.lightning.request.Request;
 import com.github.seratch.jslack.lightning.request.RequestHeaders;
 import com.github.seratch.jslack.lightning.request.builtin.*;
 import com.github.seratch.jslack.lightning.response.Response;
+import com.github.seratch.jslack.lightning.util.QueryStringParser;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -101,6 +103,11 @@ public class ServletAdapter {
                     slackRequest = new SlashCommandRequest(requestBody, headers);
                 } else if (webhookRequestDetector.isWebhook(requestBody)) {
                     slackRequest = new OutgoingWebhooksRequest(requestBody, headers);
+                } else if (appConfig.isOAuthStartEnabled() && appConfig.getOauthStartRequestURI().equals(req.getRequestURI())) {
+                    slackRequest = new OAuthStartRequest(requestBody, headers);
+                } else if (appConfig.isOAuthCallbackEnabled() && appConfig.getOauthCallbackRequestURI().equals(req.getRequestURI())) {
+                    VerificationCodePayload payload = VerificationCodePayload.from(QueryStringParser.toMap(req.getQueryString()));
+                    slackRequest = new OAuthCallbackRequest(requestBody, payload, headers);
                 } else {
                     log.warn("No request pattern detected for {}", requestBody);
                 }

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/SlackAppServlet.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/SlackAppServlet.java
@@ -25,6 +25,7 @@ public class SlackAppServlet extends HttpServlet {
         this.adapter = new ServletAdapter(app.config());
     }
 
+    @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         Request slackReq = adapter.buildSlackRequest(req);
         if (slackReq != null) {

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/SlackOAuthAppServlet.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/SlackOAuthAppServlet.java
@@ -1,0 +1,43 @@
+package com.github.seratch.jslack.lightning.servlet;
+
+import com.github.seratch.jslack.lightning.App;
+import com.github.seratch.jslack.lightning.request.Request;
+import com.github.seratch.jslack.lightning.response.Response;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+public class SlackOAuthAppServlet extends HttpServlet {
+
+    private final App app;
+    private final ServletAdapter adapter;
+
+    public App getApp() {
+        return this.app;
+    }
+
+    public SlackOAuthAppServlet(App app) {
+        this.app = app;
+        this.adapter = new ServletAdapter(app.config());
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        Request slackReq = adapter.buildSlackRequest(req);
+        if (slackReq != null) {
+            try {
+                Response slackResp = app.run(slackReq);
+                adapter.writeResponse(resp, slackResp);
+            } catch (Exception e) {
+                log.error("Failed to handle a request - {}", e.getMessage(), e);
+                resp.setStatus(500);
+                resp.setContentType("application/json");
+                resp.getWriter().write("{\"error\":\"Something is wrong\"}");
+            }
+        }
+    }
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/util/QueryStringParser.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/util/QueryStringParser.java
@@ -1,0 +1,28 @@
+package com.github.seratch.jslack.lightning.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class QueryStringParser {
+    private QueryStringParser() {
+    }
+
+    public static Map<String, String> toMap(String query) {
+        Map<String, String> query_pairs = new LinkedHashMap<>();
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+            int idx = pair.indexOf("=");
+            try {
+                String key = URLDecoder.decode(pair.substring(0, idx), "UTF-8");
+                String value = URLDecoder.decode(pair.substring(idx + 1), "UTF-8");
+                query_pairs.put(key, value);
+            } catch (UnsupportedEncodingException e) {
+                query_pairs.put(pair.substring(0, idx), pair.substring(idx + 1));
+            }
+        }
+        return query_pairs;
+    }
+
+}

--- a/jslack-lightning/src/test/java/samples/OutgoingWebhooksSample.java
+++ b/jslack-lightning/src/test/java/samples/OutgoingWebhooksSample.java
@@ -20,7 +20,7 @@ public class OutgoingWebhooksSample {
         App app = new App(config, Arrays.asList(
                 // x-slack-signature unsupported
                 new LegacyRequestVerification(verificationToken),
-                new SingleTeamAuthorization(config)
+                new SingleTeamAuthorization(config, null)
         ));
 
         app.webhook("something", (req, ctx) -> {

--- a/json-logs/samples/api/oauth.access.json
+++ b/json-logs/samples/api/oauth.access.json
@@ -7,6 +7,7 @@
   "token_type": "",
   "access_token": "",
   "scope": "",
+  "enterprise_id": "",
   "team_name": "",
   "team_id": "",
   "user_id": "",

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -273,7 +273,8 @@
       },
       "msg_input_sticky_composer": false,
       "seen_workflow_builder_deluxe_toast": false,
-      "workflow_builder_intro_modal_clicked_through": false
+      "workflow_builder_intro_modal_clicked_through": false,
+      "has_received_threaded_message": false
     },
     "created": 12345,
     "manual_presence": ""
@@ -436,7 +437,12 @@
           ""
         ]
       },
-      "invite_requests_admin_apis": false
+      "invite_requests_admin_apis": false,
+      "who_can_create_ext_shared_channel_invites": {
+        "type": [
+          ""
+        ]
+      }
     },
     "icon": {
       "image_34": "https://www.example.com/",


### PR DESCRIPTION
This pull request adds OAuth support for Lightning apps. The initial implementation supports file system and Amazon S3. Technically, it's also possible to support other datastores like RDB, any key-value stores.

Also, the first commit improves the implementation of `oauth.access` API client. https://api.slack.com/methods/oauth.access