### PR TITLE
Add historical data support and incoming webhooks in InstallationService #234

### DIFF
--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/aws.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/aws.kt
@@ -16,6 +16,14 @@ fun main() {
     val config = ResourceLoader.loadAppConfig()
     val mainApp = App(config)
 
+    // export AWS_REGION=us-east-1
+    // export AWS_ACCESS_KEY_ID=AAAA*************
+    // export AWS_SECRET_ACCESS_KEY=4o7***********************
+    val awsS3BucketName = "YOUR_OWN_BUCKET_NAME_HERE"
+    val installationService = AmazonS3InstallationService(awsS3BucketName)
+    installationService.setHistoricalDataEnabled(true)
+    mainApp.service(installationService)
+
     mainApp.command("/say-something") { req, ctx ->
         val p = req.payload
         val text = "<@${p.userId}> said ${p.text} at <#${p.channelId}|${p.channelName}>"
@@ -27,11 +35,8 @@ fun main() {
     val oauthConfig = ResourceLoader.loadAppConfig()
     val oauthApp = App(oauthConfig).asOAuthApp(true)
 
-    // export AWS_REGION=us-east-1
-    // export AWS_ACCESS_KEY_ID=AAAA*************
-    // export AWS_SECRET_ACCESS_KEY=4o7***********************
-    val awsS3BucketName = "YOUR_OWN_BUCKET_NAME_HERE"
-    oauthApp.service(AmazonS3InstallationService(awsS3BucketName))
+    oauthApp.service(installationService)
+    // for state parameter in OAuth flow
     oauthApp.service(AmazonS3OAuthStateService(awsS3BucketName))
 
     val server = SlackAppServer(mapOf(

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultSuccessHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultSuccessHandler.java
@@ -44,6 +44,12 @@ public class OAuthDefaultSuccessHandler implements OAuthSuccessHandler {
                 .scope(o.getScope())
                 .installedAt(System.currentTimeMillis());
 
+        if (o.getIncomingWebhook() != null) {
+            i = i.incomingWebhookChannelId(o.getIncomingWebhook().getChannelId())
+                    .incomingWebhookUrl(o.getIncomingWebhook().getUrl())
+                    .incomingWebhookConfigurationUrl(o.getIncomingWebhook().getConfigurationUrl());
+        }
+
         if (o.getBot() != null) {
             i = i.botUserId(o.getBot().getBotUserId());
             i = i.botAccessToken(o.getBot().getBotAccessToken());

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Bot.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Bot.java
@@ -22,4 +22,8 @@ public interface Bot {
 
     void setBotAccessToken(String botAccessToken);
 
+    Long getInstalledAt();
+
+    void setInstalledAt(Long installedAt);
+
 }

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Installer.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Installer.java
@@ -2,6 +2,10 @@ package com.github.seratch.jslack.lightning.model;
 
 public interface Installer {
 
+    // ---------------------------------
+    // Organization / Workspace
+    // ---------------------------------
+
     String getEnterpriseId();
 
     void setEnterpriseId(String enterpriseId);
@@ -10,6 +14,10 @@ public interface Installer {
 
     void setTeamId(String teamId);
 
+    // ---------------------------------
+    // Installer
+    // ---------------------------------
+
     String getInstallerUserId();
 
     void setInstallerUserId(String userId);
@@ -17,6 +25,10 @@ public interface Installer {
     String getInstallerUserAccessToken();
 
     void setInstallerUserAccessToken(String userAccessToken);
+
+    // ---------------------------------
+    // Bot
+    // ---------------------------------
 
     String getBotId();
 
@@ -31,5 +43,25 @@ public interface Installer {
     void setBotAccessToken(String botAccessToken);
 
     Bot toBot();
+
+    // ---------------------------------
+    // Incoming Webhooks
+    // ---------------------------------
+
+    String getIncomingWebhookUrl();
+
+    void setIncomingWebhookUrl(String incomingWebhookUrl);
+
+    String getIncomingWebhookChannelId();
+
+    void setIncomingWebhookChannelId(String incomingWebhookChannelId);
+
+    String getIncomingWebhookConfigurationUrl();
+
+    void setIncomingWebhookConfigurationUrl(String incomingWebhookConfigurationUrl);
+
+    Long getInstalledAt();
+
+    void setInstalledAt(Long installedAt);
 
 }

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultInstaller.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultInstaller.java
@@ -24,7 +24,12 @@ public class DefaultInstaller implements Installer {
 
     private String botId;
     private String botUserId;
+
     private String botAccessToken;
+
+    private String incomingWebhookUrl;
+    private String incomingWebhookChannelId;
+    private String incomingWebhookConfigurationUrl;
 
     private Long installedAt;
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/InstallationService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/InstallationService.java
@@ -5,6 +5,10 @@ import com.github.seratch.jslack.lightning.model.Installer;
 
 public interface InstallationService {
 
+    boolean isHistoricalDataEnabled();
+
+    void setHistoricalDataEnabled(boolean isHistoricalDataEnabled);
+
     void saveInstallerAndBot(Installer installer) throws Exception;
 
     void deleteBot(Bot bot) throws Exception;


### PR DESCRIPTION
This pull request fixes #234 by adding the following features:

* Add `incomingWebhookChannelId`, `incomingWebhookUrl`, `incomingWebhookConfigurationUrl` to `Installer` and extract them in the default implementation
* Add `historicalDataEnabled` flag to allow storing all the histories (the direct reason to add this here is to support multiple webhook urls per user, but this one is useful for other use cases)