### PR TITLE
Add Granular Bot Permissions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ json-logs/raw
 .DS_Store
 
 appConfig.json
+appConfig_GBP.json
 verificationToken.txt
 
 *.hprof

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/Methods.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/Methods.java
@@ -249,6 +249,7 @@ public class Methods {
     // ------------------------------
 
     public static final String OAUTH_ACCESS = "oauth.access";
+    public static final String OAUTH_V2_ACCESS = "oauth.v2.access";
     public static final String OAUTH_TOKEN = "oauth.token";
 
     // ------------------------------

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
@@ -34,6 +34,7 @@ import com.github.seratch.jslack.api.methods.request.migration.MigrationExchange
 import com.github.seratch.jslack.api.methods.request.mpim.*;
 import com.github.seratch.jslack.api.methods.request.oauth.OAuthAccessRequest;
 import com.github.seratch.jslack.api.methods.request.oauth.OAuthTokenRequest;
+import com.github.seratch.jslack.api.methods.request.oauth.OAuthV2AccessRequest;
 import com.github.seratch.jslack.api.methods.request.pins.PinsAddRequest;
 import com.github.seratch.jslack.api.methods.request.pins.PinsListRequest;
 import com.github.seratch.jslack.api.methods.request.pins.PinsRemoveRequest;
@@ -97,6 +98,7 @@ import com.github.seratch.jslack.api.methods.response.migration.MigrationExchang
 import com.github.seratch.jslack.api.methods.response.mpim.*;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthTokenResponse;
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthV2AccessResponse;
 import com.github.seratch.jslack.api.methods.response.pins.PinsAddResponse;
 import com.github.seratch.jslack.api.methods.response.pins.PinsListResponse;
 import com.github.seratch.jslack.api.methods.response.pins.PinsRemoveResponse;
@@ -711,6 +713,10 @@ public interface MethodsClient {
     OAuthAccessResponse oauthAccess(OAuthAccessRequest req) throws IOException, SlackApiException;
 
     OAuthAccessResponse oauthAccess(RequestConfigurator<OAuthAccessRequest.OAuthAccessRequestBuilder> req) throws IOException, SlackApiException;
+
+    OAuthV2AccessResponse oauthV2Access(OAuthV2AccessRequest req) throws IOException, SlackApiException;
+
+    OAuthV2AccessResponse oauthV2Access(RequestConfigurator<OAuthV2AccessRequest.OAuthV2AccessRequestBuilder> req) throws IOException, SlackApiException;
 
     OAuthTokenResponse oauthToken(OAuthTokenRequest req) throws IOException, SlackApiException;
 

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
@@ -35,6 +35,7 @@ import com.github.seratch.jslack.api.methods.request.migration.MigrationExchange
 import com.github.seratch.jslack.api.methods.request.mpim.*;
 import com.github.seratch.jslack.api.methods.request.oauth.OAuthAccessRequest;
 import com.github.seratch.jslack.api.methods.request.oauth.OAuthTokenRequest;
+import com.github.seratch.jslack.api.methods.request.oauth.OAuthV2AccessRequest;
 import com.github.seratch.jslack.api.methods.request.pins.PinsAddRequest;
 import com.github.seratch.jslack.api.methods.request.pins.PinsListRequest;
 import com.github.seratch.jslack.api.methods.request.pins.PinsRemoveRequest;
@@ -98,6 +99,7 @@ import com.github.seratch.jslack.api.methods.response.migration.MigrationExchang
 import com.github.seratch.jslack.api.methods.response.mpim.*;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthTokenResponse;
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthV2AccessResponse;
 import com.github.seratch.jslack.api.methods.response.pins.PinsAddResponse;
 import com.github.seratch.jslack.api.methods.response.pins.PinsListResponse;
 import com.github.seratch.jslack.api.methods.response.pins.PinsRemoveResponse;
@@ -1253,6 +1255,20 @@ public class MethodsClientImpl implements MethodsClient {
     @Override
     public OAuthAccessResponse oauthAccess(RequestConfigurator<OAuthAccessRequest.OAuthAccessRequestBuilder> req) throws IOException, SlackApiException {
         return oauthAccess(req.configure(OAuthAccessRequest.builder()).build());
+    }
+
+    @Override
+    public OAuthV2AccessResponse oauthV2Access(OAuthV2AccessRequest req) throws IOException, SlackApiException {
+        FormBody.Builder form = new FormBody.Builder();
+        form.add("code", req.getCode());
+        form.add("redirect_uri", req.getRedirectUri());
+        String authorizationHeader = Credentials.basic(req.getClientId(), req.getClientSecret());
+        return doPostFormWithAuthorizationHeader(form, endpointUrlPrefix + Methods.OAUTH_V2_ACCESS, authorizationHeader, OAuthV2AccessResponse.class);
+    }
+
+    @Override
+    public OAuthV2AccessResponse oauthV2Access(RequestConfigurator<OAuthV2AccessRequest.OAuthV2AccessRequestBuilder> req) throws IOException, SlackApiException {
+        return oauthV2Access(req.configure(OAuthV2AccessRequest.builder()).build());
     }
 
     @Override

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/oauth/OAuthV2AccessRequest.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/oauth/OAuthV2AccessRequest.java
@@ -1,0 +1,39 @@
+package com.github.seratch.jslack.api.methods.request.oauth;
+
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/authentication/basics
+ * https://api.slack.com/methods/oauth.v2.access
+ */
+@Data
+@Builder
+public class OAuthV2AccessRequest implements SlackApiRequest {
+
+    /**
+     * Issued when you created your application.
+     */
+    private String clientId;
+
+    /**
+     * Issued when you created your application.
+     */
+    private String clientSecret;
+
+    /**
+     * The `code` param returned via the OAuth callback.
+     */
+    private String code;
+
+    /**
+     * This must match the originally submitted URI (if one was sent).
+     */
+    private String redirectUri;
+
+    @Override
+    public String getToken() {
+        return null;
+    }
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/oauth/OAuthV2AccessResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/oauth/OAuthV2AccessResponse.java
@@ -1,0 +1,55 @@
+package com.github.seratch.jslack.api.methods.response.oauth;
+
+import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/oauth.v2.access
+ */
+@Data
+public class OAuthV2AccessResponse implements SlackApiResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private String appId;
+    private AuthedUser authedUser;
+    private String scope;
+    private String tokenType; // "bot"
+    private String accessToken; // xoxb-xxx-yyy
+    private String botUserId;
+    private Team team;
+    private Enterprise enterprise;
+    private IncomingWebhook incomingWebhook;
+
+    @Data
+    public static class AuthedUser {
+        private String id;
+        private String scope;
+        private String tokenType; // "user"
+        private String accessToken; // xoxp-xxx-yyy
+    }
+
+    @Data
+    public static class Team {
+        private String id;
+        private String name;
+    }
+
+    @Data
+    public static class Enterprise {
+        private String id;
+        private String name;
+    }
+
+    @Data
+    public static class IncomingWebhook {
+        private String url;
+        private String channel;
+        private String channelId;
+        private String configurationUrl;
+    }
+}

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/oauth_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/oauth_Test.java
@@ -4,6 +4,7 @@ import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthTokenResponse;
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthV2AccessResponse;
 import config.SlackTestConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
@@ -26,6 +27,19 @@ public class oauth_Test {
     public void access() throws IOException, SlackApiException {
         {
             OAuthAccessResponse response = slack.methods().oauthAccess(r -> r
+                    .clientId("3485157640.XXXX")
+                    .clientSecret("XXXXX")
+                    .code("")
+                    .redirectUri("http://seratch.net/foo"));
+            assertThat(response.getError(), is("invalid_code"));
+            assertThat(response.isOk(), is(false));
+        }
+    }
+
+    @Test
+    public void accessV2() throws IOException, SlackApiException {
+        {
+            OAuthV2AccessResponse response = slack.methods().oauthV2Access(r -> r
                     .clientId("3485157640.XXXX")
                     .clientSecret("XXXXX")
                     .code("")
@@ -68,6 +82,18 @@ public class oauth_Test {
         response.setInstallerUser(new OAuthAccessResponse.InstallerUser());
         ObjectInitializer.initProperties(response);
         dumper.dump("oauth.access", response);
+    }
+
+    @Test
+    public void dumpFullJsonV2() throws IOException {
+        ObjectToJsonDumper dumper = new ObjectToJsonDumper("../json-logs/samples/api");
+        OAuthV2AccessResponse response = new OAuthV2AccessResponse();
+        response.setAuthedUser(new OAuthV2AccessResponse.AuthedUser());
+        response.setIncomingWebhook(new OAuthV2AccessResponse.IncomingWebhook());
+        response.setEnterprise(new OAuthV2AccessResponse.Enterprise());
+        response.setTeam(new OAuthV2AccessResponse.Team());
+        ObjectInitializer.initProperties(response);
+        dumper.dump("oauth.v2.access", response);
     }
 
 }

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/admin/AppRequest.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/admin/AppRequest.java
@@ -30,6 +30,7 @@ public class AppRequest {
         @SerializedName("is_internal")
         private boolean isInternal;
         private String additionalInfo;
+        private Icons icons;
     }
 
     @Data
@@ -59,6 +60,30 @@ public class AppRequest {
     public static class PreviousResolution {
         private String status;
         private List<Scope> scopes;
+    }
+
+    @Data
+    public static class Icons {
+        @SerializedName("image_32")
+        private String image32;
+        @SerializedName("image_36")
+        private String image36;
+        @SerializedName("image_48")
+        private String image48;
+        @SerializedName("image_64")
+        private String image64;
+        @SerializedName("image_72")
+        private String image72;
+        @SerializedName("image_96")
+        private String image96;
+        @SerializedName("image_128")
+        private String image128;
+        @SerializedName("image_192")
+        private String image192;
+        @SerializedName("image_512")
+        private String image512;
+        @SerializedName("image_1024")
+        private String image1024;
     }
 
 }

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/oauth/OAuthFlowOperator.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/oauth/OAuthFlowOperator.java
@@ -3,7 +3,9 @@ package com.github.seratch.jslack.app_backend.oauth;
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
 import com.github.seratch.jslack.api.methods.request.oauth.OAuthAccessRequest;
+import com.github.seratch.jslack.api.methods.request.oauth.OAuthV2AccessRequest;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthV2AccessResponse;
 import com.github.seratch.jslack.app_backend.config.SlackAppConfig;
 import com.github.seratch.jslack.app_backend.oauth.payload.VerificationCodePayload;
 
@@ -21,6 +23,15 @@ public class OAuthFlowOperator {
 
     public OAuthAccessResponse callOAuthAccessMethod(VerificationCodePayload payload) throws IOException, SlackApiException {
         return slack.methods().oauthAccess(OAuthAccessRequest.builder()
+                .clientId(config.getClientId())
+                .clientSecret(config.getClientSecret())
+                .code(payload.getCode())
+                .redirectUri(config.getRedirectUri())
+                .build());
+    }
+
+    public OAuthV2AccessResponse callOAuthV2AccessMethod(VerificationCodePayload payload) throws IOException, SlackApiException {
+        return slack.methods().oauthV2Access(OAuthV2AccessRequest.builder()
                 .clientId(config.getClientId())
                 .clientSecret(config.getClientSecret())
                 .code(payload.getCode())

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/v2_app.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/v2_app.kt
@@ -1,0 +1,35 @@
+package examples.oauth_flow
+
+import com.github.seratch.jslack.lightning.App
+import com.github.seratch.jslack.lightning.jetty.SlackAppServer
+import org.slf4j.LoggerFactory
+import util.ResourceLoader
+
+fun main() {
+
+    val logger = LoggerFactory.getLogger("main")
+
+    // export SLACK_BOT_TOKEN=xoxb-***
+    // export SLACK_SIGNING_SECRET=123abc***
+    val config = ResourceLoader.loadAppConfig("appConfig_GBP.json")
+    config.isAlwaysRequestUserTokenNeeded = true
+    val mainApp = App(config)
+
+    mainApp.command("/say-something-gbp") { req, ctx ->
+        val p = req.payload
+        val text = "<@${p.userId}> said ${p.text} at <#${p.channelId}|${p.channelName}>"
+        val res = ctx.respond { it.text(text).responseType("in_channel") }
+        logger.info("respond result - {}", res)
+        ctx.ack()
+    }
+
+    val oauthConfig = ResourceLoader.loadAppConfig("appConfig_GBP.json")
+    oauthConfig.isGranularBotPermissionsEnabled = true
+    val oauthApp = App(oauthConfig).asOAuthApp(true)
+
+    val server = SlackAppServer(mapOf(
+            "/slack/events" to mainApp,
+            "/slack/oauth" to oauthApp
+    ))
+    server.start()
+}

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/v2_aws.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/v2_aws.kt
@@ -13,18 +13,18 @@ fun main() {
 
     // export SLACK_BOT_TOKEN=xoxb-***
     // export SLACK_SIGNING_SECRET=123abc***
-    val config = ResourceLoader.loadAppConfig()
+    val config = ResourceLoader.loadAppConfig("appConfig_GBP.json")
     val mainApp = App(config)
 
     // export AWS_REGION=us-east-1
     // export AWS_ACCESS_KEY_ID=AAAA*************
     // export AWS_SECRET_ACCESS_KEY=4o7***********************
-    val awsS3BucketName = "YOUR_OWN_BUCKET_NAME_HERE"
+    val awsS3BucketName = "jslack-lightning-test-123"
     val installationService = AmazonS3InstallationService(awsS3BucketName)
     installationService.isHistoricalDataEnabled = true
     mainApp.service(installationService)
 
-    mainApp.command("/say-something") { req, ctx ->
+    mainApp.command("/say-something-gbp") { req, ctx ->
         val p = req.payload
         val text = "<@${p.userId}> said ${p.text} at <#${p.channelId}|${p.channelName}>"
         val res = ctx.respond { it.text(text).responseType("in_channel") }
@@ -32,7 +32,8 @@ fun main() {
         ctx.ack()
     }
 
-    val oauthConfig = ResourceLoader.loadAppConfig()
+    val oauthConfig = ResourceLoader.loadAppConfig("appConfig_GBP.json")
+    oauthConfig.isGranularBotPermissionsEnabled = true
     val oauthApp = App(oauthConfig).asOAuthApp(true)
 
     oauthApp.service(installationService)

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/util/ResourceLoader.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/util/ResourceLoader.kt
@@ -14,11 +14,11 @@ class ResourceLoader {
     companion object {
         private val logger = LoggerFactory.getLogger("resource-loader")
 
-        fun loadAppConfig(): AppConfig {
+        fun loadAppConfig(name: String = "appConfig.json"): AppConfig {
             val config = AppConfig()
             val classLoader = ResourceLoader::class.java.classLoader
             try {
-                classLoader.getResourceAsStream("appConfig.json").use { resource ->
+                classLoader.getResourceAsStream(name).use { resource ->
                     InputStreamReader(resource).use { isr ->
                         val json = BufferedReader(isr).lines().collect(joining())
                         val j = Gson().fromJson(json, JsonElement::class.java).asJsonObject
@@ -28,6 +28,7 @@ class ResourceLoader {
                         config.clientSecret = j.get("clientSecret").asString
                         config.redirectUri = j.get("redirectUri").asString
                         config.scope = j.get("scope").asString
+                        config.userScope = j.get("userScope")?.asString
                         config.oauthStartPath = j.get("oauthStartPath").asString
                         config.oauthCallbackPath = j.get("oauthCallbackPath").asString
                         config.oauthCompletionUrl = j.get("oauthCompletionUrl").asString

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/App.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/App.java
@@ -66,6 +66,7 @@ public class App {
     private OAuthCallbackService oAuthCallbackService = null;
 
     private OAuthSuccessHandler oAuthSuccessHandler = new OAuthDefaultSuccessHandler(installationService);
+    private OAuthV2SuccessHandler oAuthV2SuccessHandler = new OAuthV2DefaultSuccessHandler(installationService);
     private OAuthErrorHandler oAuthErrorHandler = new OAuthDefaultErrorHandler();
     private OAuthAccessErrorHandler oAuthAccessErrorHandler = new OAuthDefaultAccessErrorHandler();
     private OAuthStateErrorHandler oAuthStateErrorHandler = new OAuthDefaultStateErrorHandler();
@@ -278,11 +279,20 @@ public class App {
 
     public App service(InstallationService installationService) {
         this.installationService = installationService;
-        return oauthCallback(new OAuthDefaultSuccessHandler(installationService));
+        if (config().isGranularBotPermissionsEnabled()) {
+            return oauthCallback(new OAuthV2DefaultSuccessHandler(installationService));
+        } else {
+            return oauthCallback(new OAuthDefaultSuccessHandler(installationService));
+        }
     }
 
     public App oauthCallback(OAuthSuccessHandler handler) {
         oAuthSuccessHandler = handler;
+        return this;
+    }
+
+    public App oauthCallback(OAuthV2SuccessHandler handler) {
+        oAuthV2SuccessHandler = handler;
         return this;
     }
 
@@ -614,6 +624,7 @@ public class App {
                         config(),
                         oAuthStateService,
                         oAuthSuccessHandler,
+                        oAuthV2SuccessHandler,
                         oAuthErrorHandler,
                         oAuthStateErrorHandler,
                         oAuthAccessErrorHandler,

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/AppConfig.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/AppConfig.java
@@ -24,6 +24,7 @@ public class AppConfig {
         public static final String SLACK_APP_CLIENT_SECRET = "SLACK_APP_CLIENT_SECRET";
         public static final String SLACK_APP_REDIRECT_URI = "SLACK_APP_REDIRECT_URI";
         public static final String SLACK_APP_SCOPE = "SLACK_APP_SCOPE";
+        public static final String SLACK_APP_USER_SCOPE = "SLACK_APP_USER_SCOPE";
         public static final String SLACK_APP_OAUTH_START_PATH = "SLACK_APP_OAUTH_START_PATH";
         public static final String SLACK_APP_OAUTH_CALLBACK_PATH = "SLACK_APP_OAUTH_CALLBACK_PATH";
         public static final String SLACK_APP_OAUTH_CANCELLATION_URL = "SLACK_APP_OAUTH_CANCELLATION_URL";
@@ -45,6 +46,7 @@ public class AppConfig {
 
     private boolean oAuthStartEnabled = false;
     private boolean oAuthCallbackEnabled = false;
+    private boolean granularBotPermissionsEnabled = false;
 
     public void setOauthStartPath(String oauthStartPath) {
         this.oauthStartPath = oauthStartPath;
@@ -64,12 +66,25 @@ public class AppConfig {
     private String redirectUri = System.getenv(EnvVariableName.SLACK_APP_REDIRECT_URI);
     @Builder.Default
     private String scope = System.getenv(EnvVariableName.SLACK_APP_SCOPE);
+    @Builder.Default
+    private String userScope = System.getenv(EnvVariableName.SLACK_APP_USER_SCOPE);
 
     public String getOauthInstallationUrl(String state) {
         if (clientId == null || scope == null || state == null) {
             return null;
         } else {
-            return "https://slack.com/oauth/authorize?client_id=" + clientId + "&scope=" + scope + "&state=" + state;
+            if (isGranularBotPermissionsEnabled()) {
+                return "https://slack.com/oauth/v2/authorize" +
+                        "?client_id=" + clientId +
+                        "&scope=" + scope +
+                        "&user_scope=" + userScope +
+                        "&state=" + state;
+            } else {
+                return "https://slack.com/oauth/authorize" +
+                        "?client_id=" + clientId +
+                        "&scope=" + scope +
+                        "&state=" + state;
+            }
         }
     }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthV2SuccessHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthV2SuccessHandler.java
@@ -1,0 +1,12 @@
+package com.github.seratch.jslack.lightning.handler;
+
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+
+@FunctionalInterface
+public interface OAuthV2SuccessHandler {
+
+    Response handle(OAuthCallbackRequest req, OAuthV2AccessResponse oauthAccess);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthV2DefaultSuccessHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthV2DefaultSuccessHandler.java
@@ -1,0 +1,88 @@
+package com.github.seratch.jslack.lightning.handler.builtin;
+
+import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.github.seratch.jslack.api.methods.response.users.UsersInfoResponse;
+import com.github.seratch.jslack.lightning.context.builtin.OAuthCallbackContext;
+import com.github.seratch.jslack.lightning.handler.OAuthV2SuccessHandler;
+import com.github.seratch.jslack.lightning.model.Installer;
+import com.github.seratch.jslack.lightning.model.builtin.DefaultInstaller;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+import com.github.seratch.jslack.lightning.service.InstallationService;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
+
+    private InstallationService installationService;
+
+    public OAuthV2DefaultSuccessHandler(InstallationService installationService) {
+        this.installationService = installationService;
+    }
+
+    @Override
+    public Response handle(OAuthCallbackRequest req, OAuthV2AccessResponse o) {
+        OAuthCallbackContext context = req.getContext();
+        if (o.getEnterprise() != null) {
+            context.setEnterpriseId(o.getEnterprise().getId());
+        }
+        context.setTeamId(o.getTeam().getId());
+        context.setBotUserId(o.getBotUserId());
+        context.setBotToken(o.getAccessToken());
+        context.setRequestUserId(o.getAuthedUser().getId());
+        context.setRequestUserToken(o.getAccessToken());
+
+        DefaultInstaller.DefaultInstallerBuilder i = DefaultInstaller.builder()
+                .botUserId(o.getBotUserId())
+                .botAccessToken(o.getAccessToken())
+                .enterpriseId(o.getEnterprise() != null ? o.getEnterprise().getId() : null)
+                .teamId(o.getTeam().getId())
+                .teamName(o.getTeam().getName())
+                .scope(o.getScope())
+                .botScope(o.getScope())
+                .installedAt(System.currentTimeMillis());
+
+        if (o.getAuthedUser() != null) {
+            // we can assume authed_user should exist but just in case
+            i = i.installerUserId(o.getAuthedUser().getId())
+                    .installerUserAccessToken(o.getAuthedUser().getAccessToken())
+                    .installerUserScope(o.getAuthedUser().getScope());
+        }
+
+        if (o.getBotUserId() != null) {
+            try {
+                UsersInfoResponse user = context.client().usersInfo(r -> r.user(o.getBotUserId()));
+                if (user.isOk()) {
+                    i = i.botId(user.getUser().getProfile().getBotId());
+                } else {
+                    log.warn("Failed to call users.info to fetch botId for the user: {} - {}", o.getBotUserId(), user.getError());
+                }
+            } catch (SlackApiException | IOException e) {
+                log.warn("Failed to call users.info to fetch botId for the user: {}", o.getBotUserId(), e);
+            }
+        }
+
+        if (o.getIncomingWebhook() != null) {
+            i = i.incomingWebhookChannelId(o.getIncomingWebhook().getChannelId())
+                    .incomingWebhookUrl(o.getIncomingWebhook().getUrl())
+                    .incomingWebhookConfigurationUrl(o.getIncomingWebhook().getConfigurationUrl());
+        }
+
+        Installer installer = i.build();
+
+        Map<String, String> headers = new HashMap<>();
+        try {
+            installationService.saveInstallerAndBot(installer);
+            headers.put("Location", context.getOauthCompletionUrl());
+        } catch (Exception e) {
+            log.warn("Failed to store the installation - {}", e.getMessage(), e);
+            headers.put("Location", context.getOauthCancellationUrl());
+        }
+        return Response.builder().statusCode(302).headers(headers).build();
+    }
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Bot.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Bot.java
@@ -18,6 +18,10 @@ public interface Bot {
 
     void setBotUserId(String botUserId);
 
+    String getBotScope();
+
+    void setBotScope(String scope);
+
     String getBotAccessToken();
 
     void setBotAccessToken(String botAccessToken);

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Installer.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/Installer.java
@@ -22,6 +22,10 @@ public interface Installer {
 
     void setInstallerUserId(String userId);
 
+    String getInstallerUserScope();
+
+    void setInstallerUserScope(String scope);
+
     String getInstallerUserAccessToken();
 
     void setInstallerUserAccessToken(String userAccessToken);
@@ -37,6 +41,10 @@ public interface Installer {
     String getBotUserId();
 
     void setBotUserId(String botUserId);
+
+    String getBotScope();
+
+    void setBotScope(String scope);
 
     String getBotAccessToken();
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultBot.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultBot.java
@@ -14,6 +14,7 @@ public class DefaultBot implements Bot {
 
     private String botId;
     private String botUserId;
+    private String botScope;
     private String botAccessToken;
 
     private Long installedAt;

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultInstaller.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/model/builtin/DefaultInstaller.java
@@ -18,9 +18,12 @@ public class DefaultInstaller implements Installer {
     private String teamName;
 
     private String installerUserId;
+    private String installerUserScope;
     private String installerUserAccessToken;
 
+    @Deprecated
     private String scope;
+    private String botScope;
 
     private String botId;
     private String botUserId;
@@ -39,7 +42,7 @@ public class DefaultInstaller implements Installer {
         bot.setEnterpriseId(enterpriseId);
         bot.setTeamId(teamId);
         bot.setTeamName(teamName);
-        bot.setScope(scope);
+        bot.setScope(botScope);
         bot.setBotId(botId);
         bot.setBotUserId(botUserId);
         bot.setBotAccessToken(botAccessToken);

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/AmazonS3InstallationService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/AmazonS3InstallationService.java
@@ -40,20 +40,20 @@ public class AmazonS3InstallationService implements InstallationService {
     public void saveInstallerAndBot(Installer i) throws Exception {
         AmazonS3 s3 = this.createS3Client();
         if (isHistoricalDataEnabled()) {
-            save(s3, getInstallerKey(i) + "-latest", JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}");
-            save(s3, getBotKey(i)  + "-latest", JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}");
-            save(s3, getInstallerKey(i) + "-" + i.getInstalledAt(), JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}");
-            save(s3, getBotKey(i)  + "-" + i.getInstalledAt(), JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}");
+            save(s3, getInstallerKey(i) + "-latest", JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}, {}");
+            save(s3, getBotKey(i)  + "-latest", JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}, {}");
+            save(s3, getInstallerKey(i) + "-" + i.getInstalledAt(), JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}, {}");
+            save(s3, getBotKey(i)  + "-" + i.getInstalledAt(), JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}, {}");
         } else {
-            save(s3, getInstallerKey(i), JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}");
-            save(s3, getBotKey(i), JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}");
+            save(s3, getInstallerKey(i), JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}, {}");
+            save(s3, getBotKey(i), JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}, {}");
         }
     }
 
     private void save(AmazonS3 s3, String s3Key, String json, String logMessage) {
         PutObjectResult botPutResult = s3.putObject(bucketName, s3Key, json);
         if (log.isDebugEnabled()) {
-            log.debug(logMessage, JsonOps.toJsonString(botPutResult));
+            log.debug(logMessage, s3Key, JsonOps.toJsonString(botPutResult));
         }
     }
 

--- a/json-logs/samples/api/admin.apps.requests.list.json
+++ b/json-logs/samples/api/admin.apps.requests.list.json
@@ -16,7 +16,19 @@
         "app_directory_url": "https://www.example.com/",
         "is_app_directory_approved": false,
         "is_internal": false,
-        "additional_info": ""
+        "additional_info": "",
+        "icons": {
+          "image_32": "https://www.example.com/",
+          "image_36": "https://www.example.com/",
+          "image_48": "https://www.example.com/",
+          "image_64": "https://www.example.com/",
+          "image_72": "https://www.example.com/",
+          "image_96": "https://www.example.com/",
+          "image_128": "https://www.example.com/",
+          "image_192": "https://www.example.com/",
+          "image_512": "https://www.example.com/",
+          "image_1024": "https://www.example.com/"
+        }
       },
       "user": {
         "id": "W00000000",
@@ -37,7 +49,18 @@
         }
       ],
       "message": "",
-      "date_created": 12345
+      "date_created": 12345,
+      "previous_resolution": {
+        "status": "",
+        "scopes": [
+          {
+            "name": "",
+            "description": "",
+            "is_sensitive": false,
+            "token_type": ""
+          }
+        ]
+      }
     }
   ],
   "response_metadata": {

--- a/json-logs/samples/api/oauth.v2.access.json
+++ b/json-logs/samples/api/oauth.v2.access.json
@@ -1,0 +1,32 @@
+{
+  "ok": false,
+  "warning": "",
+  "error": "",
+  "needed": "",
+  "provided": "",
+  "app_id": "",
+  "authed_user": {
+    "id": "",
+    "scope": "",
+    "token_type": "",
+    "access_token": ""
+  },
+  "scope": "",
+  "token_type": "",
+  "access_token": "",
+  "bot_user_id": "",
+  "team": {
+    "id": "",
+    "name": ""
+  },
+  "enterprise": {
+    "id": "",
+    "name": ""
+  },
+  "incoming_webhook": {
+    "url": "",
+    "channel": "",
+    "channel_id": "",
+    "configuration_url": ""
+  }
+}

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -278,7 +278,10 @@
       "iap1_lab": 12345,
       "seen_people_search_count": 12345,
       "dismissed_app_launcher_welcome": false,
-      "dismissed_app_launcher_limit": false
+      "dismissed_app_launcher_limit": false,
+      "dismissed_scroll_search_tooltip_count": 12345,
+      "seen_contextual_message_shortcuts_modal": false,
+      "seen_message_navigation_educational_toast": false
     },
     "created": 12345,
     "manual_presence": ""
@@ -446,7 +449,8 @@
         "type": [
           ""
         ]
-      }
+      },
+      "gg_enabled": false
     },
     "icon": {
       "image_34": "https://www.example.com/",


### PR DESCRIPTION
This pull request adds Granular Bot Permissions support. Read https://api.slack.com/authentication/basics for details.