### PR TITLE
Lightning - skip starting EventDispatcher when it is empty

### DIFF
--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventsDispatcher.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventsDispatcher.java
@@ -7,6 +7,10 @@ import com.github.seratch.jslack.app_backend.events.payload.EventsApiPayload;
  */
 public interface EventsDispatcher {
 
+    boolean isRunning();
+
+    boolean isEmpty();
+
     /**
      * Registers a new EventHandler.
      */

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventsDispatcherImpl.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventsDispatcherImpl.java
@@ -57,6 +57,16 @@ public class EventsDispatcherImpl implements EventsDispatcher {
     }
 
     @Override
+    public boolean isRunning() {
+        return !closed.get();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return eventTypeAndHandlers.isEmpty();
+    }
+
+    @Override
     public void register(EventHandler<? extends EventsApiPayload<?>> handler) {
         String eventType = handler.getEventType();
         List<EventHandler<?>> handlers = eventTypeAndHandlers.getOrDefault(eventType, new ArrayList<>());

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/App.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/App.java
@@ -117,12 +117,16 @@ public class App {
         }
         initOAuthServicesIfNecessary();
 
-        this.eventsDispatcher.start();
+        if (!this.eventsDispatcher.isEmpty()) {
+            this.eventsDispatcher.start();
+        }
         return this;
     }
 
     public App stop() {
-        this.eventsDispatcher.stop();
+        if (this.eventsDispatcher.isRunning()) {
+            this.eventsDispatcher.stop();
+        }
         return this;
     }
 
@@ -440,7 +444,9 @@ public class App {
                 break;
             }
             case Event: {
-                eventsDispatcher.enqueue(req.getRequestBodyAsString());
+                if (eventsDispatcher.isRunning()) {
+                    eventsDispatcher.enqueue(req.getRequestBodyAsString());
+                }
                 EventRequest request = (EventRequest) req;
                 LightningEventHandler<Event> handler = eventHandlers.get(request.getEventType());
                 if (handler != null) {


### PR DESCRIPTION
To avoid unnecessary overhead and annoying debug logs, this pull request adds the followings:

* Add `isEmpty` and `isRunning` to `EventDispatcher`
* Check those in `App#start()` and `App#stop()`