### PR TITLE
Lightning: Add ssl_check request handler

### DIFF
--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/ssl_check/payload/SSLCheckPayload.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/ssl_check/payload/SSLCheckPayload.java
@@ -1,0 +1,9 @@
+package com.github.seratch.jslack.app_backend.ssl_check.payload;
+
+import lombok.Data;
+
+@Data
+public class SSLCheckPayload {
+    private String sslCheck;
+    private String token;
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/ssl_check/payload/SSLCheckPayloadParser.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/ssl_check/payload/SSLCheckPayloadParser.java
@@ -1,0 +1,39 @@
+package com.github.seratch.jslack.app_backend.ssl_check.payload;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+@Slf4j
+public class SSLCheckPayloadParser {
+
+    public SSLCheckPayload parse(String requestBody) {
+        if (requestBody == null) {
+            return null;
+        }
+        SSLCheckPayload payload = new SSLCheckPayload();
+        String[] pairs = requestBody.split("\\&");
+        for (String pair : pairs) {
+            String[] fields = pair.split("=");
+            if (fields.length == 2) {
+                try {
+                    String name = URLDecoder.decode(fields[0].trim().replaceAll("\\n+", ""), "UTF-8");
+                    String value = URLDecoder.decode(fields[1], "UTF-8");
+                    switch (name) {
+                        case "token":
+                            payload.setToken(value);
+                            break;
+                        case "ssl_check":
+                            payload.setSslCheck(value);
+                            break;
+                        default:
+                    }
+                } catch (UnsupportedEncodingException e) {
+                    log.error("Failed to decode URL-encoded string values - {}", e.getMessage(), e);
+                }
+            }
+        }
+        return payload;
+    }
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/util/SSLCheckRequestDetector.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/util/SSLCheckRequestDetector.java
@@ -1,0 +1,30 @@
+package com.github.seratch.jslack.app_backend.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+@Slf4j
+public class SSLCheckRequestDetector {
+
+    public boolean isSSLCheckRequest(String requestBody) {
+        String[] pairs = requestBody.split("\\&");
+        for (String pair : pairs) {
+            String[] fields = pair.split("=");
+            if (fields.length == 2) {
+                try {
+                    String name = URLDecoder.decode(fields[0].trim().replaceAll("\\n+", ""), "UTF-8");
+                    String value = URLDecoder.decode(fields[1], "UTF-8");
+                    if (name.equals("ssl_check") && value.equals("1")) {
+                        return true;
+                    }
+                } catch (UnsupportedEncodingException e) {
+                    log.error("Failed to decode URL-encoded string values - {}", e.getMessage(), e);
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/middleware/app.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/middleware/app.kt
@@ -1,0 +1,24 @@
+package examples.middleware
+
+import com.github.seratch.jslack.lightning.App
+import com.github.seratch.jslack.lightning.jetty.SlackAppServer
+import org.slf4j.LoggerFactory
+
+fun main() {
+
+    val logger = LoggerFactory.getLogger("main")
+
+    // export SLACK_BOT_TOKEN=xoxb-***
+    // export SLACK_SIGNING_SECRET=123abc***
+     val app = App()
+
+    app.use { req, _, chain ->
+        logger.info("Request - $req")
+        val resp = chain.next(req)
+        logger.info("Response - $resp")
+        resp
+    }
+
+    val server = SlackAppServer(app)
+    server.start()
+}

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/util/ResourceLoader.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/util/ResourceLoader.kt
@@ -23,6 +23,7 @@ class ResourceLoader {
                         val json = BufferedReader(isr).lines().collect(joining())
                         val j = Gson().fromJson(json, JsonElement::class.java).asJsonObject
                         config.signingSecret = j.get("signingSecret").asString
+                        config.verificationToken = j.get("verificationToken")?.asString
                         config.singleTeamBotToken = j.get("singleTeamBotToken")?.asString
                         config.clientId = j.get("clientId")?.asString
                         config.clientSecret = j.get("clientSecret")?.asString

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/App.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/App.java
@@ -13,10 +13,7 @@ import com.github.seratch.jslack.common.json.GsonFactory;
 import com.github.seratch.jslack.lightning.handler.*;
 import com.github.seratch.jslack.lightning.handler.builtin.*;
 import com.github.seratch.jslack.lightning.middleware.Middleware;
-import com.github.seratch.jslack.lightning.middleware.builtin.IgnoringSelfEvents;
-import com.github.seratch.jslack.lightning.middleware.builtin.MultiTeamsAuthorization;
-import com.github.seratch.jslack.lightning.middleware.builtin.RequestVerification;
-import com.github.seratch.jslack.lightning.middleware.builtin.SingleTeamAuthorization;
+import com.github.seratch.jslack.lightning.middleware.builtin.*;
 import com.github.seratch.jslack.lightning.request.Request;
 import com.github.seratch.jslack.lightning.request.builtin.*;
 import com.github.seratch.jslack.lightning.response.Response;
@@ -356,6 +353,9 @@ public class App {
 
     protected List<Middleware> buildDefaultMiddlewareList(AppConfig appConfig) {
         List<Middleware> middlewareList = new ArrayList<>();
+
+        // ssl_check (slash command)
+        middlewareList.add(new SSLCheck(config().getVerificationToken()));
 
         // request verification
         // https://api.slack.com/docs/verifying-requests-from-slack

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/AppConfig.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/AppConfig.java
@@ -20,6 +20,7 @@ public class AppConfig {
 
         public static final String SLACK_BOT_TOKEN = "SLACK_BOT_TOKEN";
         public static final String SLACK_SIGNING_SECRET = "SLACK_SIGNING_SECRET";
+        public static final String SLACK_VERIFICATION_TOKEN = "SLACK_VERIFICATION_TOKEN";
         public static final String SLACK_APP_CLIENT_ID = "SLACK_APP_CLIENT_ID";
         public static final String SLACK_APP_CLIENT_SECRET = "SLACK_APP_CLIENT_SECRET";
         public static final String SLACK_APP_REDIRECT_URI = "SLACK_APP_REDIRECT_URI";
@@ -37,6 +38,9 @@ public class AppConfig {
     private String singleTeamBotToken = System.getenv(EnvVariableName.SLACK_BOT_TOKEN);
     @Builder.Default
     private String signingSecret = System.getenv(EnvVariableName.SLACK_SIGNING_SECRET);
+    @Builder.Default
+    @Deprecated
+    private String verificationToken = System.getenv(EnvVariableName.SLACK_VERIFICATION_TOKEN);
 
     // https://api.slack.com/docs/oauth
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/MiddlewareOps.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/MiddlewareOps.java
@@ -5,7 +5,9 @@ import com.github.seratch.jslack.lightning.request.RequestType;
 public class MiddlewareOps {
     private MiddlewareOps() {}
 
-    public static boolean isOAuthRequest(RequestType requestType) {
-        return requestType == RequestType.OAuthStart || requestType == RequestType.OAuthCallback;
+    public static boolean isNoSlackSignatureRequest(RequestType requestType) {
+        return requestType == RequestType.OAuthStart
+                || requestType == RequestType.OAuthCallback
+                || requestType == RequestType.SSLCheck;
     }
 }

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/LegacyRequestVerification.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/LegacyRequestVerification.java
@@ -15,7 +15,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import lombok.extern.slf4j.Slf4j;
 
-import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isOAuthRequest;
+import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isNoSlackSignatureRequest;
 
 @Deprecated
 @Slf4j
@@ -35,7 +35,7 @@ public class LegacyRequestVerification implements Middleware {
 
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
-        if (isOAuthRequest(req.getRequestType())) {
+        if (isNoSlackSignatureRequest(req.getRequestType())) {
             return chain.next(req);
         }
         String actualToken;

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/MultiTeamsAuthorization.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/MultiTeamsAuthorization.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
-import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isOAuthRequest;
+import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isNoSlackSignatureRequest;
 
 @Slf4j
 public class MultiTeamsAuthorization implements Middleware {
@@ -39,7 +39,7 @@ public class MultiTeamsAuthorization implements Middleware {
 
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
-        if (isOAuthRequest(req.getRequestType())) {
+        if (isNoSlackSignatureRequest(req.getRequestType())) {
             return chain.next(req);
         }
         Context context = req.getContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/RequestVerification.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/RequestVerification.java
@@ -7,7 +7,7 @@ import com.github.seratch.jslack.lightning.request.Request;
 import com.github.seratch.jslack.lightning.response.Response;
 import lombok.extern.slf4j.Slf4j;
 
-import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isOAuthRequest;
+import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isNoSlackSignatureRequest;
 
 @Slf4j
 public class RequestVerification implements Middleware {
@@ -20,7 +20,7 @@ public class RequestVerification implements Middleware {
 
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
-        if (isOAuthRequest(req.getRequestType())) {
+        if (isNoSlackSignatureRequest(req.getRequestType())) {
             return chain.next(req);
         }
         if (req.isValid(verifier)) {

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/SSLCheck.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/SSLCheck.java
@@ -1,0 +1,52 @@
+package com.github.seratch.jslack.lightning.middleware.builtin;
+
+import com.github.seratch.jslack.lightning.middleware.Middleware;
+import com.github.seratch.jslack.lightning.middleware.MiddlewareChain;
+import com.github.seratch.jslack.lightning.request.Request;
+import com.github.seratch.jslack.lightning.request.RequestType;
+import com.github.seratch.jslack.lightning.request.builtin.SSLCheckRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SSLCheck implements Middleware {
+
+    private final String expectedVerificationToken;
+
+    public SSLCheck(String verificationToken) {
+        this.expectedVerificationToken = verificationToken;
+    }
+
+    @Override
+    public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
+        if (req.getRequestType() == RequestType.SSLCheck) {
+            // https://api.slack.com/interactivity/slash-commands
+            // If public distribution is active for your app,
+            // Slack will occasionally send your command's request URL a simple POST request
+            // to verify the server's SSL certificate.
+            if (expectedVerificationToken != null) {
+                // These requests will include a parameter ssl_check set to 1 and a token parameter.
+                // The token value corresponds to the verification token registered with your app's slash command.
+                // See the token field above for more information on validating verification tokens.
+                // Mostly, you may ignore these requests, but please do confirm receipt as below.
+                SSLCheckRequest request = (SSLCheckRequest) req;
+
+                String sslCheck = request.getPayload().getSslCheck();
+                String actualVerificationToken = request.getPayload().getToken();
+                if (!sslCheck.equals("1")
+                        || actualVerificationToken == null
+                        || !actualVerificationToken.equals(expectedVerificationToken)) {
+                    log.info("Detected an invalid ssl_check request - payload: {}, headers: {}", request.getPayload(), request.getHeaders());
+                    return Response.error(401);
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Received a valid ssl_check request - payload: {}, headers: {}", request.getPayload(), request.getHeaders());
+                }
+            }
+            return Response.ok();
+        } else {
+            return chain.next(req);
+        }
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/SingleTeamAuthorization.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/SingleTeamAuthorization.java
@@ -7,12 +7,11 @@ import com.github.seratch.jslack.lightning.middleware.Middleware;
 import com.github.seratch.jslack.lightning.middleware.MiddlewareChain;
 import com.github.seratch.jslack.lightning.model.Installer;
 import com.github.seratch.jslack.lightning.request.Request;
-import com.github.seratch.jslack.lightning.request.RequestType;
 import com.github.seratch.jslack.lightning.response.Response;
 import com.github.seratch.jslack.lightning.service.InstallationService;
 import lombok.extern.slf4j.Slf4j;
 
-import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isOAuthRequest;
+import static com.github.seratch.jslack.lightning.middleware.MiddlewareOps.isNoSlackSignatureRequest;
 
 @Slf4j
 public class SingleTeamAuthorization implements Middleware {
@@ -27,7 +26,7 @@ public class SingleTeamAuthorization implements Middleware {
 
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
-        if (isOAuthRequest(req.getRequestType())) {
+        if (isNoSlackSignatureRequest(req.getRequestType())) {
             return chain.next(req);
         }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/RequestType.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/RequestType.java
@@ -4,6 +4,7 @@ public enum RequestType {
     OAuthStart,
     OAuthCallback,
     Command,
+    SSLCheck,
     OutgoingWebhooks,
     Event,
     UrlVerification,

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/SSLCheckRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/SSLCheckRequest.java
@@ -1,0 +1,53 @@
+package com.github.seratch.jslack.lightning.request.builtin;
+
+import com.github.seratch.jslack.app_backend.ssl_check.payload.SSLCheckPayload;
+import com.github.seratch.jslack.app_backend.ssl_check.payload.SSLCheckPayloadParser;
+import com.github.seratch.jslack.lightning.context.builtin.DefaultContext;
+import com.github.seratch.jslack.lightning.request.Request;
+import com.github.seratch.jslack.lightning.request.RequestHeaders;
+import com.github.seratch.jslack.lightning.request.RequestType;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+public class SSLCheckRequest extends Request<DefaultContext> {
+
+    private static final SSLCheckPayloadParser PAYLOAD_PARSER = new SSLCheckPayloadParser();
+
+    private final DefaultContext context = new DefaultContext();
+
+    private final String requestBody;
+    private final RequestHeaders headers;
+    private final SSLCheckPayload payload;
+
+    public SSLCheckRequest(
+            String requestBody,
+            RequestHeaders headers) {
+        this.requestBody = requestBody;
+        this.headers = headers;
+        this.payload = PAYLOAD_PARSER.parse(requestBody);
+    }
+
+    @Override
+    public DefaultContext getContext() {
+        return context;
+    }
+
+    @Override
+    public RequestType getRequestType() {
+        return RequestType.SSLCheck;
+    }
+
+    @Override
+    public String getRequestBodyAsString() {
+        return requestBody;
+    }
+
+    @Override
+    public RequestHeaders getHeaders() {
+        return this.headers;
+    }
+
+    public SSLCheckPayload getPayload() {
+        return payload;
+    }
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/SlackAppServletAdapter.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/SlackAppServletAdapter.java
@@ -11,6 +11,7 @@ import com.github.seratch.jslack.app_backend.message_actions.payload.MessageActi
 import com.github.seratch.jslack.app_backend.oauth.payload.VerificationCodePayload;
 import com.github.seratch.jslack.app_backend.util.JsonPayloadExtractor;
 import com.github.seratch.jslack.app_backend.util.OutgoingWebhooksRequestDetector;
+import com.github.seratch.jslack.app_backend.util.SSLCheckRequestDetector;
 import com.github.seratch.jslack.app_backend.util.SlashCommandRequestDetector;
 import com.github.seratch.jslack.app_backend.views.payload.ViewClosedPayload;
 import com.github.seratch.jslack.app_backend.views.payload.ViewSubmissionPayload;
@@ -37,6 +38,7 @@ public class SlackAppServletAdapter {
     private AppConfig appConfig;
     private JsonPayloadExtractor jsonPayloadExtractor = new JsonPayloadExtractor();
     private SlashCommandRequestDetector commandRequestDetector = new SlashCommandRequestDetector();
+    private SSLCheckRequestDetector sslCheckRequestDetector = new SSLCheckRequestDetector();
     private OutgoingWebhooksRequestDetector webhookRequestDetector = new OutgoingWebhooksRequestDetector();
     private Gson gson = GsonFactory.createSnakeCase();
 
@@ -94,6 +96,8 @@ public class SlackAppServletAdapter {
             } else {
                 if (commandRequestDetector.isCommand(requestBody)) {
                     slackRequest = new SlashCommandRequest(requestBody, headers);
+                } else if (sslCheckRequestDetector.isSSLCheckRequest(requestBody)) {
+                    slackRequest = new SSLCheckRequest(requestBody, headers);
                 } else if (webhookRequestDetector.isWebhook(requestBody)) {
                     slackRequest = new OutgoingWebhooksRequest(requestBody, headers);
                 } else if (appConfig.isOAuthStartEnabled() && appConfig.getOauthStartRequestURI().equals(req.getRequestURI())) {


### PR DESCRIPTION
I forgot to implement `ssl_check` request handler in Lightning framework 😱This pull request fixes the missing piece. https://api.slack.com/interactivity/slash-commands