### PR TITLE
Add missing types of rich sections

### DIFF
--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/element/RichTextSectionElement.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/element/RichTextSectionElement.java
@@ -38,6 +38,78 @@ public class RichTextSectionElement extends BlockElement {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class Link implements Element {
+        public static final String TYPE = "link";
+        private final String type = TYPE;
+        private String url;
+        private String text;
+        private String style;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Channel implements Element {
+        public static final String TYPE = "channel";
+        private final String type = TYPE;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class User implements Element {
+        public static final String TYPE = "user";
+        private final String type = TYPE;
+        private String user_id;
+        private String style;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Team implements Element {
+        public static final String TYPE = "team";
+        private final String type = TYPE;
+        private String team_id;
+        private String style;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserGroup implements Element {
+        public static final String TYPE = "usergroup";
+        private final String type = TYPE;
+        private String usergroup_id;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Date implements Element {
+        public static final String TYPE = "date";
+        private final String type = TYPE;
+        private String timestamp;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Broadcast implements Element {
+        public static final String TYPE = "broadcast";
+        private final String type = TYPE;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class TextStyle {
         private boolean bold;
         private boolean italic;

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/element/RichTextSectionElement.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/element/RichTextSectionElement.java
@@ -43,16 +43,7 @@ public class RichTextSectionElement extends BlockElement {
         private final String type = TYPE;
         private String url;
         private String text;
-        private String style;
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Channel implements Element {
-        public static final String TYPE = "channel";
-        private final String type = TYPE;
+        private TextStyle style;
     }
 
     @Data
@@ -63,7 +54,7 @@ public class RichTextSectionElement extends BlockElement {
         public static final String TYPE = "user";
         private final String type = TYPE;
         private String user_id;
-        private String style;
+        private TextStyle style;
     }
 
     @Data
@@ -74,7 +65,7 @@ public class RichTextSectionElement extends BlockElement {
         public static final String TYPE = "team";
         private final String type = TYPE;
         private String team_id;
-        private String style;
+        private TextStyle style;
     }
 
     @Data
@@ -95,15 +86,6 @@ public class RichTextSectionElement extends BlockElement {
         public static final String TYPE = "date";
         private final String type = TYPE;
         private String timestamp;
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Broadcast implements Element {
-        public static final String TYPE = "broadcast";
-        private final String type = TYPE;
     }
 
     @Data

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/common/json/GsonRichTextSectionElementFactory.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/common/json/GsonRichTextSectionElementFactory.java
@@ -28,8 +28,22 @@ public class GsonRichTextSectionElementFactory implements JsonDeserializer<RichT
         switch (className) {
             case RichTextSectionElement.Text.TYPE:
                 return RichTextSectionElement.Text.class;
+            case RichTextSectionElement.Channel.TYPE:
+                return RichTextSectionElement.Channel.class;
+            case RichTextSectionElement.User.TYPE:
+                return RichTextSectionElement.User.class;
             case RichTextSectionElement.Emoji.TYPE:
                 return RichTextSectionElement.Emoji.class;
+            case RichTextSectionElement.Link.TYPE:
+                return RichTextSectionElement.Link.class;
+            case RichTextSectionElement.Team.TYPE:
+                return RichTextSectionElement.Team.class;
+            case RichTextSectionElement.UserGroup.TYPE:
+                return RichTextSectionElement.UserGroup.class;
+            case RichTextSectionElement.Date.TYPE:
+                return RichTextSectionElement.Date.class;
+            case RichTextSectionElement.Broadcast.TYPE:
+                return RichTextSectionElement.Broadcast.class;
             default:
                 throw new JsonParseException("Unknown RichTextSectionElement type: " + className);
         }

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/common/json/GsonRichTextSectionElementFactory.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/common/json/GsonRichTextSectionElementFactory.java
@@ -28,8 +28,6 @@ public class GsonRichTextSectionElementFactory implements JsonDeserializer<RichT
         switch (className) {
             case RichTextSectionElement.Text.TYPE:
                 return RichTextSectionElement.Text.class;
-            case RichTextSectionElement.Channel.TYPE:
-                return RichTextSectionElement.Channel.class;
             case RichTextSectionElement.User.TYPE:
                 return RichTextSectionElement.User.class;
             case RichTextSectionElement.Emoji.TYPE:
@@ -42,8 +40,6 @@ public class GsonRichTextSectionElementFactory implements JsonDeserializer<RichT
                 return RichTextSectionElement.UserGroup.class;
             case RichTextSectionElement.Date.TYPE:
                 return RichTextSectionElement.Date.class;
-            case RichTextSectionElement.Broadcast.TYPE:
-                return RichTextSectionElement.Broadcast.class;
             default:
                 throw new JsonParseException("Unknown RichTextSectionElement type: " + className);
         }


### PR DESCRIPTION
See https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
Only `text` and `emoji` are supported atm, added the rest of types.