### PR TITLE
Ensure team and enterprise ids are set on requests

### DIFF
--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/AttachmentActionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/AttachmentActionRequest.java
@@ -23,9 +23,9 @@ public class AttachmentActionRequest extends Request<ActionContext> {
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, AttachmentActionPayload.class);
         getContext().setResponseUrl(payload.getResponseUrl());
-        getContext().setRequestUserId(payload.getUser().getId());
         getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         getContext().setTeamId(payload.getTeam().getId());
+        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private ActionContext context = new ActionContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/BlockActionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/BlockActionRequest.java
@@ -24,6 +24,8 @@ public class BlockActionRequest extends Request<ActionContext> {
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, BlockActionPayload.class);
         getContext().setResponseUrl(payload.getResponseUrl());
         getContext().setTriggerId(payload.getTriggerId());
+        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+        getContext().setTeamId(payload.getTeam().getId());
         getContext().setRequestUserId(payload.getUser().getId());
     }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/BlockSuggestionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/BlockSuggestionRequest.java
@@ -22,6 +22,8 @@ public class BlockSuggestionRequest extends Request<BlockSuggestionContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, BlockSuggestionPayload.class);
+        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+        getContext().setTeamId(payload.getTeam().getId());
         getContext().setRequestUserId(payload.getUser().getId());
     }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogCancellationRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogCancellationRequest.java
@@ -23,6 +23,8 @@ public class DialogCancellationRequest extends Request<DialogCancellationContext
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, DialogCancellationPayload.class);
         getContext().setResponseUrl(payload.getResponseUrl());
+        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+        getContext().setTeamId(payload.getTeam().getId());
         getContext().setRequestUserId(payload.getUser().getId());
     }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogSubmissionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogSubmissionRequest.java
@@ -23,6 +23,8 @@ public class DialogSubmissionRequest extends Request<DialogSubmissionContext> {
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, DialogSubmissionPayload.class);
         getContext().setResponseUrl(payload.getResponseUrl());
+        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+        getContext().setTeamId(payload.getTeam().getId());
         getContext().setRequestUserId(payload.getUser().getId());
     }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogSuggestionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/DialogSuggestionRequest.java
@@ -22,6 +22,8 @@ public class DialogSuggestionRequest extends Request<DialogSuggestionContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, DialogSuggestionPayload.class);
+        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+        getContext().setTeamId(payload.getTeam().getId());
         getContext().setRequestUserId(payload.getUser().getId());
     }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/EventRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/EventRequest.java
@@ -23,6 +23,7 @@ public class EventRequest extends Request<DefaultContext> {
         this.headers = headers;
         JsonObject payload = GsonFactory.createSnakeCase().fromJson(requestBody, JsonElement.class).getAsJsonObject();
         this.eventType = payload.get("event").getAsJsonObject().get("type").getAsString();
+        this.getContext().setTeamId(payload.get("team_id").getAsString());
     }
 
     private DefaultContext context = new DefaultContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/MessageActionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/MessageActionRequest.java
@@ -22,8 +22,11 @@ public class MessageActionRequest extends Request<ActionContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, MessageActionPayload.class);
+
         getContext().setResponseUrl(payload.getResponseUrl());
         getContext().setTriggerId(payload.getTriggerId());
+        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+        getContext().setTeamId(payload.getTeam().getId());
         getContext().setRequestUserId(payload.getUser().getId());
     }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/OutgoingWebhooksRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/OutgoingWebhooksRequest.java
@@ -24,6 +24,7 @@ public class OutgoingWebhooksRequest extends Request<OutgoingWebhooksContext> {
         this.headers = headers;
         this.payload = PAYLOAD_PARSER.parse(requestBody);
         getContext().setRequestUserId(payload.getUserId());
+        getContext().setTeamId(payload.getTeamId());
     }
 
     private OutgoingWebhooksContext context = new OutgoingWebhooksContext();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/ViewClosedRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/ViewClosedRequest.java
@@ -22,6 +22,9 @@ public class ViewClosedRequest extends Request<DefaultContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, ViewClosedPayload.class);
+
+        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+        getContext().setTeamId(payload.getTeam().getId());
         getContext().setRequestUserId(payload.getUser().getId());
     }
 

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/ViewSubmissionRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/ViewSubmissionRequest.java
@@ -22,6 +22,9 @@ public class ViewSubmissionRequest extends Request<ViewSubmissionContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, ViewSubmissionPayload.class);
+
+        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+        getContext().setTeamId(payload.getTeam().getId());
         getContext().setRequestUserId(payload.getUser().getId());
     }
 


### PR DESCRIPTION
Seems that Requests are responsible for updating their contexts, but only some of them were updating the enterprise and team ids. This is an issue since MultiTeamsAuthorization is expecting these fields in order to find the right bot user.

This goes through all the request types that seem to have access to team id and ensures that it (and it's undocumented buddy enterprise id, if available) are always added to the request context.