### PR TITLE
Add three missing `TeamID` members to Conversation model

### DIFF
--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Conversation.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Conversation.java
@@ -26,6 +26,8 @@ public class Conversation {
     private String nameNormalized;
     @SerializedName("pending_shared")
     private List<String> pendingShared;
+    @SerializedName("pending_connected_team_ids")
+    private List<String> pendingConnectedTeamIds;
     @SerializedName("last_read")
     private String lastRead;
     private Topic topic;
@@ -44,7 +46,12 @@ public class Conversation {
     private String user; // conversations.open
     private Double priority;
 
+    @SerializedName("shared_team_ids")
     private List<String> sharedTeamIds;
+    @SerializedName("internal_team_ids")
+    private List<String> internalTeamIds;
+    @SerializedName("connected_team_ids")
+    private List<String> connectedTeamIds;
 
     private String parentConversation;
     private List<String> pendingConnectedTeamIds;


### PR DESCRIPTION
Hi @seratch,  It's been a while. 👋 

This PR adds three missing members to the Conversation model:

- `pending_connected_team_ids`
- `internal_team_ids`
- `connected_team_ids`

All three of these properties are shown in this [conversations.info.json](https://github.com/seratch/jslack/blob/773a6990d8e0a2a2ed0de6cd51a902afcb958f5a/json-logs/samples/api/conversations.info.json) added by @seratch last month.