### PR TITLE
Fix #260 Enable jSlack users to configure API url prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ cache:
   directories:
   - $HOME/.m2
 install: echo 'skipped'
-script: travis_retry "./mvnw test-compile && ./mvnw '-Dtest=test_locally.**.*Test' test -DfailIfNoTests=false && ./mvnw install -Dmaven.test.skip=true && ./mvnw duplicate-finder:check"
+script:
+  - travis_retry ./mvnw test-compile && ./mvnw '-Dtest=test_locally.**.*Test' test -DfailIfNoTests=false && ./mvnw install -Dmaven.test.skip=true && ./mvnw duplicate-finder:check

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ cache:
   directories:
   - $HOME/.m2
 install: echo 'skipped'
-script: ./mvnw test-compile && ./mvnw '-Dtest=test_locally.**.*Test' test -DfailIfNoTests=false && ./mvnw install -Dmaven.test.skip=true && ./mvnw duplicate-finder:check
+script: travis_retry "./mvnw test-compile && ./mvnw '-Dtest=test_locally.**.*Test' test -DfailIfNoTests=false && ./mvnw install -Dmaven.test.skip=true && ./mvnw duplicate-finder:check"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
-install: echo 'skipped'
+install:
+  - echo 'skipped'
 script:
-  - travis_retry ./mvnw test-compile && ./mvnw '-Dtest=test_locally.**.*Test' test -DfailIfNoTests=false && ./mvnw install -Dmaven.test.skip=true && ./mvnw duplicate-finder:check
+  - travis_retry ./mvnw test-compile
+  - travis_retry ./mvnw '-Dtest=test_locally.**.*Test' test -DfailIfNoTests=false
+  - travis_retry ./mvnw install -Dmaven.test.skip=true
+  - travis_retry ./mvnw duplicate-finder:check

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/Slack.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/Slack.java
@@ -207,44 +207,54 @@ public class Slack {
      * Creates a Status API client.
      */
     public LegacyStatusClient statusLegacy() {
-        return new LegacyStatusClientImpl(httpClient);
+        LegacyStatusClientImpl client = new LegacyStatusClientImpl(httpClient);
+        client.setEndpointUrlPrefix(config.getLegacyStatusEndpointUrlPrefix());
+        return client;
     }
 
     public StatusClient status() {
-        return new StatusClientImpl(httpClient);
+        StatusClientImpl client = new StatusClientImpl(httpClient);
+        client.setEndpointUrlPrefix(config.getStatusEndpointUrlPrefix());
+        return client;
     }
 
     /**
      * Creates a SCIM API client.
      */
     public SCIMClient scim() {
-        return new SCIMClientImpl(httpClient);
+        return scim(null);
     }
 
     public SCIMClient scim(String token) {
-        return new SCIMClientImpl(httpClient, token);
+        SCIMClientImpl client =  new SCIMClientImpl(httpClient, token);
+        client.setEndpointUrlPrefix(config.getScimEndpointUrlPrefix());
+        return client;
     }
 
     /**
      * Creates a Audit Logs API client.
      */
     public AuditClient audit() {
-        return new AuditClientImpl(httpClient);
+        return audit(null);
     }
 
     public AuditClient audit(String token) {
-        return new AuditClientImpl(httpClient, token);
+        AuditClientImpl client = new AuditClientImpl(httpClient, token);
+        client.setEndpointUrlPrefix(config.getAuditEndpointUrlPrefix());
+        return client;
     }
 
     /**
      * Creates a Methods API client.
      */
     public MethodsClient methods() {
-        return new MethodsClientImpl(httpClient);
+        return methods(null);
     }
 
     public MethodsClient methods(String token) {
-        return new MethodsClientImpl(httpClient, token);
+        MethodsClientImpl client =  new MethodsClientImpl(httpClient, token);
+        client.setEndpointUrlPrefix(config.getMethodsEndpointUrlPrefix());
+        return client;
     }
 
     public Shortcut shortcut() {

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/Slack.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/Slack.java
@@ -226,7 +226,7 @@ public class Slack {
     }
 
     public SCIMClient scim(String token) {
-        SCIMClientImpl client =  new SCIMClientImpl(httpClient, token);
+        SCIMClientImpl client = new SCIMClientImpl(httpClient, token);
         client.setEndpointUrlPrefix(config.getScimEndpointUrlPrefix());
         return client;
     }
@@ -252,7 +252,7 @@ public class Slack {
     }
 
     public MethodsClient methods(String token) {
-        MethodsClientImpl client =  new MethodsClientImpl(httpClient, token);
+        MethodsClientImpl client = new MethodsClientImpl(httpClient, token);
         client.setEndpointUrlPrefix(config.getMethodsEndpointUrlPrefix());
         return client;
     }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/SlackConfig.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/SlackConfig.java
@@ -1,5 +1,10 @@
 package com.github.seratch.jslack;
 
+import com.github.seratch.jslack.api.audit.AuditClient;
+import com.github.seratch.jslack.api.methods.MethodsClient;
+import com.github.seratch.jslack.api.scim.SCIMClient;
+import com.github.seratch.jslack.api.status.v1.LegacyStatusClient;
+import com.github.seratch.jslack.api.status.v2.StatusClient;
 import com.github.seratch.jslack.common.http.listener.DetailedLoggingListener;
 import com.github.seratch.jslack.common.http.listener.HttpResponseListener;
 import com.github.seratch.jslack.common.http.listener.ResponsePrettyPrintingListener;
@@ -12,14 +17,54 @@ import java.util.List;
 public class SlackConfig {
 
     public static final SlackConfig DEFAULT = new SlackConfig() {
-        @Override
-        public void setPrettyResponseLoggingEnabled(boolean prettyResponseLoggingEnabled) {
+
+        void throwException() {
             throw new UnsupportedOperationException("This config is immutable");
         }
 
         @Override
+        public void setPrettyResponseLoggingEnabled(boolean prettyResponseLoggingEnabled) {
+            throwException();
+        }
+
+        @Override
         public void setLibraryMaintainerMode(boolean libraryMaintainerMode) {
-            throw new UnsupportedOperationException("This config is immutable");
+            throwException();
+        }
+
+        @Override
+        public void setTokenExistenceVerificationEnabled(boolean tokenExistenceVerificationEnabled) {
+            throwException();
+        }
+
+        @Override
+        public void setHttpClientResponseHandlers(List<HttpResponseListener> httpClientResponseHandlers) {
+            throwException();
+        }
+
+        @Override
+        public void setAuditEndpointUrlPrefix(String auditEndpointUrlPrefix) {
+            throwException();
+        }
+
+        @Override
+        public void setMethodsEndpointUrlPrefix(String methodsEndpointUrlPrefix) {
+            throwException();
+        }
+
+        @Override
+        public void setScimEndpointUrlPrefix(String scimEndpointUrlPrefix) {
+            throwException();
+        }
+
+        @Override
+        public void setStatusEndpointUrlPrefix(String statusEndpointUrlPrefix) {
+            throwException();
+        }
+
+        @Override
+        public void setLegacyStatusEndpointUrlPrefix(String legacyStatusEndpointUrlPrefix) {
+            throwException();
         }
     };
 
@@ -41,5 +86,15 @@ public class SlackConfig {
     private boolean tokenExistenceVerificationEnabled = false;
 
     private List<HttpResponseListener> httpClientResponseHandlers = new ArrayList<>();
+
+    private String auditEndpointUrlPrefix = AuditClient.ENDPOINT_URL_PREFIX;
+
+    private String methodsEndpointUrlPrefix = MethodsClient.ENDPOINT_URL_PREFIX;
+
+    private String scimEndpointUrlPrefix = SCIMClient.ENDPOINT_URL_PREFIX;
+
+    private String statusEndpointUrlPrefix = StatusClient.ENDPOINT_URL_PREFIX;
+
+    private String legacyStatusEndpointUrlPrefix = LegacyStatusClient.ENDPOINT_URL_PREFIX;
 
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/audit/AuditClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/audit/AuditClient.java
@@ -15,6 +15,8 @@ import java.io.IOException;
  */
 public interface AuditClient {
 
+    String ENDPOINT_URL_PREFIX = "https://api.slack.com/audit/v1/";
+
     SchemasResponse getSchemas() throws IOException, AuditApiException;
 
     SchemasResponse getSchemas(SchemasRequest req) throws IOException, AuditApiException;

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/audit/impl/AuditClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/audit/impl/AuditClientImpl.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 public class AuditClientImpl implements AuditClient {
 
-    private static final String BASE_URL = "https://api.slack.com/audit/v1/";
+    private String endpointUrlPrefix = getEndpointUrlPrefix();
 
     private final SlackHttpClient slackHttpClient;
     private final String token;
@@ -34,6 +34,14 @@ public class AuditClientImpl implements AuditClient {
         this.token = token;
     }
 
+    public String getEndpointUrlPrefix() {
+        return endpointUrlPrefix;
+    }
+
+    public void setEndpointUrlPrefix(String endpointUrlPrefix) {
+        this.endpointUrlPrefix = endpointUrlPrefix;
+    }
+
     @Override
     public SchemasResponse getSchemas() throws IOException, AuditApiException {
         return getSchemas(SchemasRequest.builder().build());
@@ -41,7 +49,7 @@ public class AuditClientImpl implements AuditClient {
 
     @Override
     public SchemasResponse getSchemas(SchemasRequest req) throws IOException, AuditApiException {
-        return doGet(BASE_URL + "schemas", null, getToken(req), SchemasResponse.class);
+        return doGet(getEndpointUrlPrefix() + "schemas", null, getToken(req), SchemasResponse.class);
     }
 
     @Override
@@ -56,7 +64,7 @@ public class AuditClientImpl implements AuditClient {
 
     @Override
     public ActionsResponse getActions(ActionsRequest req) throws IOException, AuditApiException {
-        return doGet(BASE_URL + "actions", null, getToken(req), ActionsResponse.class);
+        return doGet(getEndpointUrlPrefix() + "actions", null, getToken(req), ActionsResponse.class);
     }
 
     @Override
@@ -85,7 +93,7 @@ public class AuditClientImpl implements AuditClient {
         if (req.getEntity() != null) {
             query.put("entity", req.getEntity());
         }
-        return doGet(BASE_URL + "logs", query, getToken(req), LogsResponse.class);
+        return doGet(getEndpointUrlPrefix() + "logs", query, getToken(req), LogsResponse.class);
     }
 
     @Override

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
@@ -149,6 +149,10 @@ import java.io.IOException;
  */
 public interface MethodsClient {
 
+    String ENDPOINT_URL_PREFIX = "https://slack.com/api/";
+
+    String getEndpointUrlPrefix();
+
     void setEndpointUrlPrefix(String endpointUrlPrefix);
 
     Response runPostForm(

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
@@ -155,7 +155,7 @@ import static com.github.seratch.jslack.api.methods.RequestFormBuilder.toMultipa
 @Slf4j
 public class MethodsClientImpl implements MethodsClient {
 
-    private String endpointUrlPrefix = "https://slack.com/api/";
+    private String endpointUrlPrefix = MethodsClient.ENDPOINT_URL_PREFIX;
 
     private final SlackHttpClient slackHttpClient;
     private final Optional<String> token;
@@ -167,6 +167,11 @@ public class MethodsClientImpl implements MethodsClient {
     public MethodsClientImpl(SlackHttpClient slackHttpClient, String token) {
         this.slackHttpClient = slackHttpClient;
         this.token = Optional.ofNullable(token);
+    }
+
+    @Override
+    public String getEndpointUrlPrefix() {
+        return endpointUrlPrefix;
     }
 
     @Override

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/teams/AdminTeamsAdminsListResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/teams/AdminTeamsAdminsListResponse.java
@@ -2,7 +2,6 @@ package com.github.seratch.jslack.api.methods.response.admin.teams;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
 import com.github.seratch.jslack.api.model.ResponseMetadata;
-import com.github.seratch.jslack.api.model.admin.AppRequest;
 import lombok.Data;
 
 import java.util.List;

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/pins/PinsListResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/pins/PinsListResponse.java
@@ -4,7 +4,6 @@ import com.github.seratch.jslack.api.methods.SlackApiResponse;
 import com.github.seratch.jslack.api.model.File;
 import com.github.seratch.jslack.api.model.FileComment;
 import com.github.seratch.jslack.api.model.Message;
-import com.github.seratch.jslack.api.model.MessageItem;
 import lombok.Data;
 
 import java.util.List;

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/SCIMClient.java
@@ -11,6 +11,10 @@ import java.io.IOException;
  */
 public interface SCIMClient {
 
+    String ENDPOINT_URL_PREFIX = "https://api.slack.com/scim/v1/";
+
+    String getEndpointUrlPrefix();
+
     void setEndpointUrlPrefix(String endpointUrlPrefix);
 
     // --------------------

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/impl/SCIMClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/scim/impl/SCIMClientImpl.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 public class SCIMClientImpl implements SCIMClient {
 
-    private String endpointUrlPrefix = "https://api.slack.com/scim/v1/";
+    private String endpointUrlPrefix = ENDPOINT_URL_PREFIX;
 
     private final SlackHttpClient slackHttpClient;
     private final String token;
@@ -34,6 +34,11 @@ public class SCIMClientImpl implements SCIMClient {
     // ------------------------------------------
     // public methods
     // ------------------------------------------
+
+    @Override
+    public String getEndpointUrlPrefix() {
+        return this.endpointUrlPrefix;
+    }
 
     @Override
     public void setEndpointUrlPrefix(String endpointUrlPrefix) {

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/status/v1/LegacyStatusClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/status/v1/LegacyStatusClient.java
@@ -11,6 +11,12 @@ import java.util.List;
  */
 public interface LegacyStatusClient {
 
+    String ENDPOINT_URL_PREFIX = "https://status.slack.com/api/v1.0.0/";
+
+    String getEndpointUrlPrefix();
+
+    void setEndpointUrlPrefix(String endpointUrlPrefix);
+
     LegacyCurrentStatus current() throws IOException, LegacyStatusApiException;
 
     List<LegacySlackIssue> history() throws IOException, LegacyStatusApiException;

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/status/v1/impl/LegacyStatusClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/status/v1/impl/LegacyStatusClientImpl.java
@@ -16,8 +16,7 @@ import java.util.List;
 
 public class LegacyStatusClientImpl implements LegacyStatusClient {
 
-    private static final String BASE_URL = "https://status.slack.com/api/v1.0.0/";
-
+    private String endpointUrlPrefix = ENDPOINT_URL_PREFIX;
     private final SlackHttpClient slackHttpClient;
 
     public LegacyStatusClientImpl(SlackHttpClient slackHttpClient) {
@@ -25,8 +24,18 @@ public class LegacyStatusClientImpl implements LegacyStatusClient {
     }
 
     @Override
+    public String getEndpointUrlPrefix() {
+        return this.endpointUrlPrefix;
+    }
+
+    @Override
+    public void setEndpointUrlPrefix(String endpointUrlPrefix) {
+        this.endpointUrlPrefix = endpointUrlPrefix;
+    }
+
+    @Override
     public LegacyCurrentStatus current() throws IOException, LegacyStatusApiException {
-        Response response = slackHttpClient.get(BASE_URL + "current", null, null);
+        Response response = slackHttpClient.get(endpointUrlPrefix + "current", null, null);
         String body = response.body().string();
         slackHttpClient.runHttpResponseListeners(response, body);
         if (response.isSuccessful()) {
@@ -38,7 +47,7 @@ public class LegacyStatusClientImpl implements LegacyStatusClient {
 
     @Override
     public List<LegacySlackIssue> history() throws IOException, LegacyStatusApiException {
-        Response response = slackHttpClient.get(BASE_URL + "history", null, null);
+        Response response = slackHttpClient.get(endpointUrlPrefix + "history", null, null);
         Type listType = new TypeToken<ArrayList<LegacySlackIssue>>() {
         }.getType();
         String body = response.body().string();

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/status/v2/StatusClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/status/v2/StatusClient.java
@@ -11,6 +11,12 @@ import java.util.List;
  */
 public interface StatusClient {
 
+    String ENDPOINT_URL_PREFIX = "https://status.slack.com/api/v2.0.0/";
+
+    String getEndpointUrlPrefix();
+
+    void setEndpointUrlPrefix(String endpointUrlPrefix);
+
     CurrentStatus current() throws IOException, StatusApiException;
 
     List<SlackIssue> history() throws IOException, StatusApiException;

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/status/v2/impl/StatusClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/status/v2/impl/StatusClientImpl.java
@@ -16,8 +16,7 @@ import java.util.List;
 
 public class StatusClientImpl implements StatusClient {
 
-    private static final String BASE_URL = "https://status.slack.com/api/v2.0.0/";
-
+    private String endpointUrlPrefix = ENDPOINT_URL_PREFIX;
     private final SlackHttpClient slackHttpClient;
 
     public StatusClientImpl(SlackHttpClient slackHttpClient) {
@@ -25,8 +24,18 @@ public class StatusClientImpl implements StatusClient {
     }
 
     @Override
+    public String getEndpointUrlPrefix() {
+        return this.endpointUrlPrefix;
+    }
+
+    @Override
+    public void setEndpointUrlPrefix(String endpointUrlPrefix) {
+        this.endpointUrlPrefix = endpointUrlPrefix;
+    }
+
+    @Override
     public CurrentStatus current() throws IOException, StatusApiException {
-        Response response = slackHttpClient.get(BASE_URL + "current", null, null);
+        Response response = slackHttpClient.get(endpointUrlPrefix + "current", null, null);
         String body = response.body().string();
         slackHttpClient.runHttpResponseListeners(response, body);
         if (response.isSuccessful()) {
@@ -38,7 +47,7 @@ public class StatusClientImpl implements StatusClient {
 
     @Override
     public List<SlackIssue> history() throws IOException, StatusApiException {
-        Response response = slackHttpClient.get(BASE_URL + "history", null, null);
+        Response response = slackHttpClient.get(endpointUrlPrefix + "history", null, null);
         Type listType = new TypeToken<ArrayList<SlackIssue>>() {
         }.getType();
         String body = response.body().string();

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/shortcut/impl/ShortcutImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/shortcut/impl/ShortcutImpl.java
@@ -35,6 +35,10 @@ public class ShortcutImpl implements Shortcut {
 
     private final Slack slack;
 
+    public Slack getSlack() {
+        return slack;
+    }
+
     private List<Channel> channels = new ArrayList<>();
 
     public ShortcutImpl(Slack slack) {

--- a/jslack-api-client/src/test/java/test_locally/api/audit/ApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/audit/ApiTest.java
@@ -1,0 +1,65 @@
+package test_locally.api.audit;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.SlackConfig;
+import com.github.seratch.jslack.api.audit.response.LogsResponse;
+import com.github.seratch.jslack.api.methods.response.api.ApiTestResponse;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import test_locally.api.util.PortProvider;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ApiTest {
+
+    @WebServlet
+    public static class SampleServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            if (!req.getRequestURI().equals("/api/logs")) {
+                resp.setStatus(400);
+                return;
+            }
+            resp.setStatus(200);
+            resp.getWriter().write("{\"ok\":true}");
+            resp.setContentType("application/json");
+        }
+    }
+
+    int port = PortProvider.getPort(ApiTest.class.getName());
+    Server server = new Server(port);
+    {
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(SampleServlet.class, "/*");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void apiTest() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setAuditEndpointUrlPrefix("http://localhost:" + port + "/api/");
+
+        LogsResponse response = Slack.getInstance(config).audit("token").getLogs(r -> r.action("something"));
+        assertThat(response.isOk(), is(true));
+    }
+}

--- a/jslack-api-client/src/test/java/test_locally/api/audit/ApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/audit/ApiTest.java
@@ -3,7 +3,6 @@ package test_locally.api.audit;
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.SlackConfig;
 import com.github.seratch.jslack.api.audit.response.LogsResponse;
-import com.github.seratch.jslack.api.methods.response.api.ApiTestResponse;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.junit.After;
@@ -38,6 +37,7 @@ public class ApiTest {
 
     int port = PortProvider.getPort(ApiTest.class.getName());
     Server server = new Server(port);
+
     {
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);

--- a/jslack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
@@ -5,14 +5,15 @@ import com.github.seratch.jslack.SlackConfig;
 import com.github.seratch.jslack.api.methods.response.api.ApiTestResponse;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import test_locally.api.util.PortProvider;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -36,6 +37,7 @@ public class ApiTest {
 
     int port = PortProvider.getPort(ApiTest.class.getName());
     Server server = new Server(port);
+
     {
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);

--- a/jslack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
@@ -1,0 +1,64 @@
+package test_locally.api.methods;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.SlackConfig;
+import com.github.seratch.jslack.api.methods.response.api.ApiTestResponse;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.*;
+import test_locally.api.util.PortProvider;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ApiTest {
+
+    @WebServlet
+    public static class SampleServlet extends HttpServlet {
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            if (!req.getRequestURI().equals("/api/api.test")) {
+                resp.setStatus(400);
+                return;
+            }
+            resp.setStatus(200);
+            resp.getWriter().write("{\"ok\":true, \"args\":{\"foo\":\"" + req.getParameter("foo") + "\"}}");
+            resp.setContentType("application/json");
+        }
+    }
+
+    int port = PortProvider.getPort(ApiTest.class.getName());
+    Server server = new Server(port);
+    {
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(SampleServlet.class, "/*");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void apiTest() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix("http://localhost:" + port + "/api/");
+
+        ApiTestResponse response = Slack.getInstance(config).methods().apiTest(r -> r.foo("bar"));
+        assertThat(response.isOk(), is(true));
+        assertThat(response.getArgs().getFoo(), is("bar"));
+    }
+}

--- a/jslack-api-client/src/test/java/test_locally/api/scim/ApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/scim/ApiTest.java
@@ -2,7 +2,6 @@ package test_locally.api.scim;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.SlackConfig;
-import com.github.seratch.jslack.api.audit.response.LogsResponse;
 import com.github.seratch.jslack.api.scim.response.UsersSearchResponse;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
@@ -39,6 +38,7 @@ public class ApiTest {
 
     int port = PortProvider.getPort(ApiTest.class.getName());
     Server server = new Server(port);
+
     {
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);

--- a/jslack-api-client/src/test/java/test_locally/api/scim/ApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/scim/ApiTest.java
@@ -1,0 +1,66 @@
+package test_locally.api.scim;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.SlackConfig;
+import com.github.seratch.jslack.api.audit.response.LogsResponse;
+import com.github.seratch.jslack.api.scim.response.UsersSearchResponse;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import test_locally.api.util.PortProvider;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ApiTest {
+
+    @WebServlet
+    public static class SampleServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            if (!req.getRequestURI().equals("/api/Users")) {
+                resp.setStatus(400);
+                return;
+            }
+            resp.setStatus(200);
+            resp.getWriter().write("{}");
+            resp.setContentType("application/json");
+        }
+    }
+
+    int port = PortProvider.getPort(ApiTest.class.getName());
+    Server server = new Server(port);
+    {
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(SampleServlet.class, "/*");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void apiTest() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setScimEndpointUrlPrefix("http://localhost:" + port + "/api/");
+
+        UsersSearchResponse response = Slack.getInstance(config).scim("token").searchUsers(r -> r.filter("some filter"));
+        assertThat(response, is(notNullValue()));
+    }
+}

--- a/jslack-api-client/src/test/java/test_locally/api/status/ApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/status/ApiTest.java
@@ -2,7 +2,6 @@ package test_locally.api.status;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.SlackConfig;
-import com.github.seratch.jslack.api.scim.response.UsersSearchResponse;
 import com.github.seratch.jslack.api.status.v2.model.CurrentStatus;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
@@ -39,6 +38,7 @@ public class ApiTest {
 
     int port = PortProvider.getPort(ApiTest.class.getName());
     Server server = new Server(port);
+
     {
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);

--- a/jslack-api-client/src/test/java/test_locally/api/status/ApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/status/ApiTest.java
@@ -1,0 +1,66 @@
+package test_locally.api.status;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.SlackConfig;
+import com.github.seratch.jslack.api.scim.response.UsersSearchResponse;
+import com.github.seratch.jslack.api.status.v2.model.CurrentStatus;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import test_locally.api.util.PortProvider;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ApiTest {
+
+    @WebServlet
+    public static class SampleServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            if (!req.getRequestURI().equals("/api/current")) {
+                resp.setStatus(400);
+                return;
+            }
+            resp.setStatus(200);
+            resp.getWriter().write("{}");
+            resp.setContentType("application/json");
+        }
+    }
+
+    int port = PortProvider.getPort(ApiTest.class.getName());
+    Server server = new Server(port);
+    {
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(SampleServlet.class, "/*");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void current() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setStatusEndpointUrlPrefix("http://localhost:" + port + "/api/");
+
+        CurrentStatus response = Slack.getInstance(config).status().current();
+        assertThat(response, is(notNullValue()));
+    }
+}

--- a/jslack-api-client/src/test/java/test_locally/api/status/LegacyApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/status/LegacyApiTest.java
@@ -1,0 +1,65 @@
+package test_locally.api.status;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.SlackConfig;
+import com.github.seratch.jslack.api.status.v1.model.LegacyCurrentStatus;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import test_locally.api.util.PortProvider;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class LegacyApiTest {
+
+    @WebServlet
+    public static class SampleServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            if (!req.getRequestURI().equals("/api/current")) {
+                resp.setStatus(400);
+                return;
+            }
+            resp.setStatus(200);
+            resp.getWriter().write("{}");
+            resp.setContentType("application/json");
+        }
+    }
+
+    int port = PortProvider.getPort(LegacyApiTest.class.getName());
+    Server server = new Server(port);
+    {
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(SampleServlet.class, "/*");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void current() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setLegacyStatusEndpointUrlPrefix("http://localhost:" + port + "/api/");
+
+        LegacyCurrentStatus response = Slack.getInstance(config).statusLegacy().current();
+        assertThat(response, is(notNullValue()));
+    }
+}

--- a/jslack-api-client/src/test/java/test_locally/api/status/LegacyApiTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/status/LegacyApiTest.java
@@ -38,6 +38,7 @@ public class LegacyApiTest {
 
     int port = PortProvider.getPort(LegacyApiTest.class.getName());
     Server server = new Server(port);
+
     {
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);

--- a/jslack-api-client/src/test/java/test_locally/api/util/PortProvider.java
+++ b/jslack-api-client/src/test/java/test_locally/api/util/PortProvider.java
@@ -1,0 +1,36 @@
+package test_locally.api.util;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.security.SecureRandom;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class PortProvider {
+
+    private PortProvider() {}
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
+
+    public static int getPort(String name) {
+        return PORTS.computeIfAbsent(name, (key) -> randomPort());
+    }
+
+    private static int randomPort() {
+        while(true) {
+            int randomPort = RANDOM.nextInt(9999);
+            if (isAvailable(randomPort)) {
+                return randomPort;
+            }
+        }
+    }
+
+    private static boolean isAvailable(int port) {
+        try (Socket ignored = new Socket("localhost", port)) {
+            return false;
+        } catch (IOException ignored) {
+            return true;
+        }
+    }
+}

--- a/jslack-api-client/src/test/java/test_locally/api/util/PortProvider.java
+++ b/jslack-api-client/src/test/java/test_locally/api/util/PortProvider.java
@@ -8,7 +8,8 @@ import java.util.concurrent.ConcurrentMap;
 
 public class PortProvider {
 
-    private PortProvider() {}
+    private PortProvider() {
+    }
 
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
@@ -18,7 +19,7 @@ public class PortProvider {
     }
 
     private static int randomPort() {
-        while(true) {
+        while (true) {
             int randomPort = RANDOM.nextInt(9999);
             if (isAvailable(randomPort)) {
                 return randomPort;

--- a/jslack-api-client/src/test/resources/logback.xml
+++ b/jslack-api-client/src/test/resources/logback.xml
@@ -5,6 +5,8 @@
             <pattern>%date %level [%thread] %logger{64} %msg%n</pattern>
         </encoder>
     </appender>
+
+    <logger name="org.eclipse.jetty" level="warn"/>
     <root level="debug">
         <appender-ref ref="default"/>
     </root>


### PR DESCRIPTION
This pull request fixes #260 by providing ways to configure the base URLs for all supported APIs.