### PR TITLE
Add admin.inviteRequests.* APIs

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/Methods.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/Methods.java
@@ -19,6 +19,16 @@ public class Methods {
     public static final String ADMIN_APPS_REQUESTS_LIST = "admin.apps.requests.list";
 
     // ------------------------------
+    // admin.inviteRequests
+    // ------------------------------
+
+    public static final String ADMIN_INVITE_REQUESTS_APPROVE = "admin.inviteRequests.approve";
+    public static final String ADMIN_INVITE_REQUESTS_DENY = "admin.inviteRequests.deny";
+    public static final String ADMIN_INVITE_REQUESTS_LIST = "admin.inviteRequests.list";
+    public static final String ADMIN_INVITE_REQUESTS_APPROVED_LIST = "admin.inviteRequests.approved.list";
+    public static final String ADMIN_INVITE_REQUESTS_DENIED_LIST = "admin.inviteRequests.denied.list";
+
+    // ------------------------------
     // admin.teams.admins
     // ------------------------------
 

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/MethodsClient.java
@@ -4,6 +4,7 @@ import com.github.seratch.jslack.api.RequestConfigurator;
 import com.github.seratch.jslack.api.methods.request.admin.apps.AdminAppsApproveRequest;
 import com.github.seratch.jslack.api.methods.request.admin.apps.AdminAppsRequestsListRequest;
 import com.github.seratch.jslack.api.methods.request.admin.apps.AdminAppsRestrictRequest;
+import com.github.seratch.jslack.api.methods.request.admin.invite_requests.*;
 import com.github.seratch.jslack.api.methods.request.admin.teams.AdminTeamsAdminsListRequest;
 import com.github.seratch.jslack.api.methods.request.admin.teams.AdminTeamsCreateRequest;
 import com.github.seratch.jslack.api.methods.request.admin.teams.AdminTeamsOwnersListRequest;
@@ -72,6 +73,7 @@ import com.github.seratch.jslack.api.methods.request.views.ViewsUpdateRequest;
 import com.github.seratch.jslack.api.methods.response.admin.apps.AdminAppsApproveResponse;
 import com.github.seratch.jslack.api.methods.response.admin.apps.AdminAppsRequestsListResponse;
 import com.github.seratch.jslack.api.methods.response.admin.apps.AdminAppsRestrictResponse;
+import com.github.seratch.jslack.api.methods.response.admin.invite_requests.*;
 import com.github.seratch.jslack.api.methods.response.admin.teams.AdminTeamsAdminsListResponse;
 import com.github.seratch.jslack.api.methods.response.admin.teams.AdminTeamsCreateResponse;
 import com.github.seratch.jslack.api.methods.response.admin.teams.AdminTeamsOwnersListResponse;
@@ -191,6 +193,30 @@ public interface MethodsClient {
     AdminAppsRequestsListResponse adminAppsRequestsList(RequestConfigurator<AdminAppsRequestsListRequest.AdminAppsRequestsListRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
+    // admin.inviteRequests
+    // ------------------------------
+
+    AdminInviteRequestsApproveResponse adminInviteRequestsApprove(AdminInviteRequestsApproveRequest req) throws IOException, SlackApiException;
+
+    AdminInviteRequestsApproveResponse adminInviteRequestsApprove(RequestConfigurator<AdminInviteRequestsApproveRequest.AdminInviteRequestsApproveRequestBuilder> req) throws IOException, SlackApiException;
+
+    AdminInviteRequestsDenyResponse adminInviteRequestsDeny(AdminInviteRequestsDenyRequest req) throws IOException, SlackApiException;
+
+    AdminInviteRequestsDenyResponse adminInviteRequestsDeny(RequestConfigurator<AdminInviteRequestsDenyRequest.AdminInviteRequestsDenyRequestBuilder> req) throws IOException, SlackApiException;
+
+    AdminInviteRequestsListResponse adminInviteRequestsList(AdminInviteRequestsListRequest req) throws IOException, SlackApiException;
+
+    AdminInviteRequestsListResponse adminInviteRequestsList(RequestConfigurator<AdminInviteRequestsListRequest.AdminInviteRequestsListRequestBuilder> req) throws IOException, SlackApiException;
+
+    AdminInviteRequestsApprovedListResponse adminInviteRequestsApprovedList(AdminInviteRequestsApprovedListRequest req) throws IOException, SlackApiException;
+
+    AdminInviteRequestsApprovedListResponse adminInviteRequestsApprovedList(RequestConfigurator<AdminInviteRequestsApprovedListRequest.AdminInviteRequestsApprovedListRequestBuilder> req) throws IOException, SlackApiException;
+
+    AdminInviteRequestsDeniedListResponse adminInviteRequestsDeniedList(AdminInviteRequestsDeniedListRequest req) throws IOException, SlackApiException;
+
+    AdminInviteRequestsDeniedListResponse adminInviteRequestsDeniedList(RequestConfigurator<AdminInviteRequestsDeniedListRequest.AdminInviteRequestsDeniedListRequestBuilder> req) throws IOException, SlackApiException;
+
+    // ------------------------------
     // admin.teams.admins
     // ------------------------------
 
@@ -270,12 +296,32 @@ public interface MethodsClient {
     // apps.permissions
     // ------------------------------
 
+    // Developer preview has ended
+    // This feature was exclusive to our workspace apps developer preview.
+    // The preview has now ended, but fan-favorite features such as token rotation
+    // and the Conversations API will become available to classic Slack apps over the coming months.
+    @Deprecated
     AppsPermissionsInfoResponse appsPermissionsInfo(AppsPermissionsInfoRequest req) throws IOException, SlackApiException;
 
+    // Developer preview has ended
+    // This feature was exclusive to our workspace apps developer preview.
+    // The preview has now ended, but fan-favorite features such as token rotation
+    // and the Conversations API will become available to classic Slack apps over the coming months.
+    @Deprecated
     AppsPermissionsInfoResponse appsPermissionsInfo(RequestConfigurator<AppsPermissionsInfoRequest.AppsPermissionsInfoRequestBuilder> req) throws IOException, SlackApiException;
 
+    // Developer preview has ended
+    // This feature was exclusive to our workspace apps developer preview.
+    // The preview has now ended, but fan-favorite features such as token rotation
+    // and the Conversations API will become available to classic Slack apps over the coming months.
+    @Deprecated
     AppsPermissionsRequestResponse appsPermissionsRequest(AppsPermissionsRequestRequest req) throws IOException, SlackApiException;
 
+    // Developer preview has ended
+    // This feature was exclusive to our workspace apps developer preview.
+    // The preview has now ended, but fan-favorite features such as token rotation
+    // and the Conversations API will become available to classic Slack apps over the coming months.
+    @Deprecated
     AppsPermissionsRequestResponse appsPermissionsRequest(RequestConfigurator<AppsPermissionsRequestRequest.AppsPermissionsRequestRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/RequestFormBuilder.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/RequestFormBuilder.java
@@ -3,6 +3,7 @@ package com.github.seratch.jslack.api.methods;
 import com.github.seratch.jslack.api.methods.request.admin.apps.AdminAppsApproveRequest;
 import com.github.seratch.jslack.api.methods.request.admin.apps.AdminAppsRequestsListRequest;
 import com.github.seratch.jslack.api.methods.request.admin.apps.AdminAppsRestrictRequest;
+import com.github.seratch.jslack.api.methods.request.admin.invite_requests.*;
 import com.github.seratch.jslack.api.methods.request.admin.teams.AdminTeamsAdminsListRequest;
 import com.github.seratch.jslack.api.methods.request.admin.teams.AdminTeamsCreateRequest;
 import com.github.seratch.jslack.api.methods.request.admin.teams.AdminTeamsOwnersListRequest;
@@ -67,6 +68,7 @@ import com.github.seratch.jslack.api.methods.request.views.ViewsOpenRequest;
 import com.github.seratch.jslack.api.methods.request.views.ViewsPublishRequest;
 import com.github.seratch.jslack.api.methods.request.views.ViewsPushRequest;
 import com.github.seratch.jslack.api.methods.request.views.ViewsUpdateRequest;
+import com.github.seratch.jslack.api.methods.response.admin.invite_requests.AdminInviteRequestsDenyResponse;
 import com.github.seratch.jslack.api.model.ConversationType;
 import com.github.seratch.jslack.common.json.GsonFactory;
 import lombok.extern.slf4j.Slf4j;
@@ -111,6 +113,44 @@ public class RequestFormBuilder {
     }
 
     public static FormBody.Builder toForm(AdminAppsRequestsListRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("cursor", req.getCursor(), form);
+        setIfNotNull("limit", req.getLimit(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AdminInviteRequestsApproveRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("invite_request_id", req.getInviteRequestId(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AdminInviteRequestsDenyRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("invite_request_id", req.getInviteRequestId(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AdminInviteRequestsListRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("cursor", req.getCursor(), form);
+        setIfNotNull("limit", req.getLimit(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AdminInviteRequestsApprovedListRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("cursor", req.getCursor(), form);
+        setIfNotNull("limit", req.getLimit(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AdminInviteRequestsDeniedListRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("cursor", req.getCursor(), form);
         setIfNotNull("limit", req.getLimit(), form);

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/impl/MethodsClientImpl.java
@@ -5,6 +5,7 @@ import com.github.seratch.jslack.api.methods.*;
 import com.github.seratch.jslack.api.methods.request.admin.apps.AdminAppsApproveRequest;
 import com.github.seratch.jslack.api.methods.request.admin.apps.AdminAppsRequestsListRequest;
 import com.github.seratch.jslack.api.methods.request.admin.apps.AdminAppsRestrictRequest;
+import com.github.seratch.jslack.api.methods.request.admin.invite_requests.*;
 import com.github.seratch.jslack.api.methods.request.admin.teams.AdminTeamsAdminsListRequest;
 import com.github.seratch.jslack.api.methods.request.admin.teams.AdminTeamsCreateRequest;
 import com.github.seratch.jslack.api.methods.request.admin.teams.AdminTeamsOwnersListRequest;
@@ -73,6 +74,7 @@ import com.github.seratch.jslack.api.methods.request.views.ViewsUpdateRequest;
 import com.github.seratch.jslack.api.methods.response.admin.apps.AdminAppsApproveResponse;
 import com.github.seratch.jslack.api.methods.response.admin.apps.AdminAppsRequestsListResponse;
 import com.github.seratch.jslack.api.methods.response.admin.apps.AdminAppsRestrictResponse;
+import com.github.seratch.jslack.api.methods.response.admin.invite_requests.*;
 import com.github.seratch.jslack.api.methods.response.admin.teams.AdminTeamsAdminsListResponse;
 import com.github.seratch.jslack.api.methods.response.admin.teams.AdminTeamsCreateResponse;
 import com.github.seratch.jslack.api.methods.response.admin.teams.AdminTeamsOwnersListResponse;
@@ -211,6 +213,56 @@ public class MethodsClientImpl implements MethodsClient {
     @Override
     public AdminAppsRequestsListResponse adminAppsRequestsList(RequestConfigurator<AdminAppsRequestsListRequest.AdminAppsRequestsListRequestBuilder> req) throws IOException, SlackApiException {
         return adminAppsRequestsList(req.configure(AdminAppsRequestsListRequest.builder()).build());
+    }
+
+    @Override
+    public AdminInviteRequestsApproveResponse adminInviteRequestsApprove(AdminInviteRequestsApproveRequest req) throws IOException, SlackApiException {
+        return doPostFormWithToken(toForm(req), Methods.ADMIN_INVITE_REQUESTS_APPROVE, getToken(req), AdminInviteRequestsApproveResponse.class);
+    }
+
+    @Override
+    public AdminInviteRequestsApproveResponse adminInviteRequestsApprove(RequestConfigurator<AdminInviteRequestsApproveRequest.AdminInviteRequestsApproveRequestBuilder> req) throws IOException, SlackApiException {
+        return adminInviteRequestsApprove(req.configure(AdminInviteRequestsApproveRequest.builder()).build());
+    }
+
+    @Override
+    public AdminInviteRequestsDenyResponse adminInviteRequestsDeny(AdminInviteRequestsDenyRequest req) throws IOException, SlackApiException {
+        return doPostFormWithToken(toForm(req), Methods.ADMIN_INVITE_REQUESTS_DENY, getToken(req), AdminInviteRequestsDenyResponse.class);
+    }
+
+    @Override
+    public AdminInviteRequestsDenyResponse adminInviteRequestsDeny(RequestConfigurator<AdminInviteRequestsDenyRequest.AdminInviteRequestsDenyRequestBuilder> req) throws IOException, SlackApiException {
+        return adminInviteRequestsDeny(req.configure(AdminInviteRequestsDenyRequest.builder()).build());
+    }
+
+    @Override
+    public AdminInviteRequestsListResponse adminInviteRequestsList(AdminInviteRequestsListRequest req) throws IOException, SlackApiException {
+        return doPostFormWithToken(toForm(req), Methods.ADMIN_INVITE_REQUESTS_LIST, getToken(req), AdminInviteRequestsListResponse.class);
+    }
+
+    @Override
+    public AdminInviteRequestsListResponse adminInviteRequestsList(RequestConfigurator<AdminInviteRequestsListRequest.AdminInviteRequestsListRequestBuilder> req) throws IOException, SlackApiException {
+        return adminInviteRequestsList(req.configure(AdminInviteRequestsListRequest.builder()).build());
+    }
+
+    @Override
+    public AdminInviteRequestsApprovedListResponse adminInviteRequestsApprovedList(AdminInviteRequestsApprovedListRequest req) throws IOException, SlackApiException {
+        return doPostFormWithToken(toForm(req), Methods.ADMIN_INVITE_REQUESTS_APPROVED_LIST, getToken(req), AdminInviteRequestsApprovedListResponse.class);
+    }
+
+    @Override
+    public AdminInviteRequestsApprovedListResponse adminInviteRequestsApprovedList(RequestConfigurator<AdminInviteRequestsApprovedListRequest.AdminInviteRequestsApprovedListRequestBuilder> req) throws IOException, SlackApiException {
+        return adminInviteRequestsApprovedList(req.configure(AdminInviteRequestsApprovedListRequest.builder()).build());
+    }
+
+    @Override
+    public AdminInviteRequestsDeniedListResponse adminInviteRequestsDeniedList(AdminInviteRequestsDeniedListRequest req) throws IOException, SlackApiException {
+        return doPostFormWithToken(toForm(req), Methods.ADMIN_INVITE_REQUESTS_DENIED_LIST, getToken(req), AdminInviteRequestsDeniedListResponse.class);
+    }
+
+    @Override
+    public AdminInviteRequestsDeniedListResponse adminInviteRequestsDeniedList(RequestConfigurator<AdminInviteRequestsDeniedListRequest.AdminInviteRequestsDeniedListRequestBuilder> req) throws IOException, SlackApiException {
+        return adminInviteRequestsDeniedList(req.configure(AdminInviteRequestsDeniedListRequest.builder()).build());
     }
 
     @Override

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsApproveRequest.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsApproveRequest.java
@@ -1,0 +1,29 @@
+package com.github.seratch.jslack.api.methods.request.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/admin.inviteRequests.approve
+ */
+@Data
+@Builder
+public class AdminInviteRequestsApproveRequest implements SlackApiRequest {
+
+    /**
+     * Authentication token bearing required scopes.
+     */
+    private String token;
+
+    /**
+     * ID of the request to invite.
+     */
+    private String inviteRequestId;
+
+    /**
+     * ID for the workspace where the invite request was made.
+     */
+    private String teamId;
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsApprovedListRequest.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsApprovedListRequest.java
@@ -1,0 +1,34 @@
+package com.github.seratch.jslack.api.methods.request.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/admin.inviteRequests.approved.list
+ */
+@Data
+@Builder
+public class AdminInviteRequestsApprovedListRequest implements SlackApiRequest {
+
+    /**
+     * Authentication token bearing required scopes.
+     */
+    private String token;
+
+    /**
+     * Set cursor to next_cursor returned by the previous call to list items in the next page
+     */
+    private String cursor;
+
+    /**
+     * The maximum number of items to return. Must be between 1 - 1000 both inclusive.
+     */
+    private Integer limit;
+
+    /**
+     * Workspace Id.
+     */
+    private String teamId;
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsDeniedListRequest.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsDeniedListRequest.java
@@ -1,0 +1,34 @@
+package com.github.seratch.jslack.api.methods.request.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/admin.inviteRequests.denied.list
+ */
+@Data
+@Builder
+public class AdminInviteRequestsDeniedListRequest implements SlackApiRequest {
+
+    /**
+     * Authentication token bearing required scopes.
+     */
+    private String token;
+
+    /**
+     * Set cursor to next_cursor returned by the previous call to list items in the next page
+     */
+    private String cursor;
+
+    /**
+     * The maximum number of items to return. Must be between 1 - 1000 both inclusive.
+     */
+    private Integer limit;
+
+    /**
+     * Workspace Id.
+     */
+    private String teamId;
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsDenyRequest.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsDenyRequest.java
@@ -1,0 +1,29 @@
+package com.github.seratch.jslack.api.methods.request.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/admin.inviteRequests.deny
+ */
+@Data
+@Builder
+public class AdminInviteRequestsDenyRequest implements SlackApiRequest {
+
+    /**
+     * Authentication token bearing required scopes.
+     */
+    private String token;
+
+    /**
+     * ID of the request to deny.
+     */
+    private String inviteRequestId;
+
+    /**
+     * ID for the workspace where the invite request was made.
+     */
+    private String teamId;
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsListRequest.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/request/admin/invite_requests/AdminInviteRequestsListRequest.java
@@ -1,0 +1,34 @@
+package com.github.seratch.jslack.api.methods.request.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/admin.inviteRequests.list
+ */
+@Data
+@Builder
+public class AdminInviteRequestsListRequest implements SlackApiRequest {
+
+    /**
+     * Authentication token bearing required scopes.
+     */
+    private String token;
+
+    /**
+     * Set cursor to next_cursor returned by the previous call to list items in the next page
+     */
+    private String cursor;
+
+    /**
+     * The maximum number of items to return. Must be between 1 - 1000 both inclusive.
+     */
+    private Integer limit;
+
+    /**
+     * Workspace Id.
+     */
+    private String teamId;
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsApproveResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsApproveResponse.java
@@ -1,0 +1,15 @@
+package com.github.seratch.jslack.api.methods.response.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import lombok.Data;
+
+@Data
+public class AdminInviteRequestsApproveResponse implements SlackApiResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsApprovedListResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsApprovedListResponse.java
@@ -1,0 +1,19 @@
+package com.github.seratch.jslack.api.methods.response.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AdminInviteRequestsApprovedListResponse implements SlackApiResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private List<String> approvedRequests;
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsDeniedListResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsDeniedListResponse.java
@@ -1,0 +1,19 @@
+package com.github.seratch.jslack.api.methods.response.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AdminInviteRequestsDeniedListResponse implements SlackApiResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private List<String> deniedRequests;
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsDenyResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsDenyResponse.java
@@ -1,0 +1,15 @@
+package com.github.seratch.jslack.api.methods.response.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import lombok.Data;
+
+@Data
+public class AdminInviteRequestsDenyResponse implements SlackApiResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+}

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsListResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/invite_requests/AdminInviteRequestsListResponse.java
@@ -1,0 +1,19 @@
+package com.github.seratch.jslack.api.methods.response.admin.invite_requests;
+
+import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AdminInviteRequestsListResponse implements SlackApiResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private List<String> inviteRequests;
+
+}

--- a/jslack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
@@ -248,7 +248,7 @@ public class IncomingWebhooksTest {
 
         Payload payload = Payload.builder()
                 .threadTs(chatPostMessageResponse.getMessage().getTs())
-                .text("Reply via Imcoming Webhook!").build();
+                .text("Reply via Incoming Webhook!").build();
 
         WebhookResponse response = slack.send(url, payload);
         log.info(response.toString());

--- a/jslack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
@@ -1,4 +1,4 @@
-package test_with_remote_apis.web_api;
+package test_with_remote_apis.audit;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.audit.Actions;
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 
 // required scope - auditlogs:read
 @Slf4j
-public class audit_Test {
+public class ApiTest {
 
     Slack slack = Slack.getInstance(SlackTestConfig.get());
     String token = System.getenv(Constants.SLACK_TEST_ADMIN_OAUTH_ACCESS_TOKEN);

--- a/jslack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApiTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApiTest.java
@@ -1,11 +1,18 @@
-package test_with_remote_apis.web_api;
+package test_with_remote_apis.methods_admin_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.admin.users.*;
+import com.github.seratch.jslack.api.methods.request.admin.invite_requests.AdminInviteRequestsApprovedListRequest;
+import com.github.seratch.jslack.api.methods.request.admin.invite_requests.AdminInviteRequestsDeniedListRequest;
+import com.github.seratch.jslack.api.methods.request.admin.invite_requests.AdminInviteRequestsDenyRequest;
+import com.github.seratch.jslack.api.methods.request.admin.users.AdminUsersAssignRequest;
+import com.github.seratch.jslack.api.methods.request.admin.users.AdminUsersInviteRequest;
+import com.github.seratch.jslack.api.methods.request.admin.users.AdminUsersRemoveRequest;
+import com.github.seratch.jslack.api.methods.request.admin.users.AdminUsersSessionResetRequest;
 import com.github.seratch.jslack.api.methods.response.admin.apps.AdminAppsApproveResponse;
 import com.github.seratch.jslack.api.methods.response.admin.apps.AdminAppsRequestsListResponse;
 import com.github.seratch.jslack.api.methods.response.admin.apps.AdminAppsRestrictResponse;
+import com.github.seratch.jslack.api.methods.response.admin.invite_requests.*;
 import com.github.seratch.jslack.api.methods.response.admin.teams.AdminTeamsAdminsListResponse;
 import com.github.seratch.jslack.api.methods.response.admin.teams.AdminTeamsCreateResponse;
 import com.github.seratch.jslack.api.methods.response.admin.teams.AdminTeamsOwnersListResponse;
@@ -20,7 +27,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,7 +35,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 @Slf4j
-public class admin_Test {
+public class AdminApiTest {
 
     Slack slack = Slack.getInstance(SlackTestConfig.get());
     String email = System.getenv(Constants.SLACK_TEST_EMAIL);
@@ -81,6 +87,36 @@ public class admin_Test {
                         .teamId(adminAppsTeamId));
                 assertThat(restriction.getError(), is(nullValue()));
             }
+        }
+    }
+
+    @Test
+    public void inviteRequests() throws Exception {
+        if (orgAdminToken != null) {
+            AdminInviteRequestsApproveResponse approval = slack.methods(orgAdminToken).adminInviteRequestsApprove(r -> r
+                    .teamId(adminAppsTeamId)
+                    .inviteRequestId("I12345678"));
+            assertThat(approval.getError(), is("invalid_request"));
+
+            AdminInviteRequestsDenyResponse denial = slack.methods(orgAdminToken).adminInviteRequestsDeny(r -> r
+                    .teamId(adminAppsTeamId)
+                    .inviteRequestId("I12345678"));
+            assertThat(denial.getError(), is("invalid_request"));
+
+            AdminInviteRequestsListResponse list = slack.methods(orgAdminToken).adminInviteRequestsList(r -> r
+                    .limit(1000)
+                    .teamId(adminAppsTeamId));
+            assertThat(list.getError(), is(nullValue()));
+
+            AdminInviteRequestsApprovedListResponse approvedList = slack.methods(orgAdminToken).adminInviteRequestsApprovedList(r -> r
+                    .limit(1000)
+                    .teamId(adminAppsTeamId));
+            assertThat(approvedList.getError(), is(nullValue()));
+
+            AdminInviteRequestsDeniedListResponse deniedList = slack.methods(orgAdminToken).adminInviteRequestsDeniedList(r -> r
+                    .limit(1000)
+                    .teamId(adminAppsTeamId));
+            assertThat(deniedList.getError(), is(nullValue()));
         }
     }
 

--- a/jslack-api-client/src/test/java/test_with_remote_apis/status/StatusApiV1Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/status/StatusApiV1Test.java
@@ -1,4 +1,4 @@
-package test_with_remote_apis.web_api;
+package test_with_remote_apis.status;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.status.v1.LegacyStatusApiException;
@@ -16,7 +16,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 @Slf4j
-public class status_v1_Test {
+public class StatusApiV1Test {
 
     Slack slack = Slack.getInstance(SlackTestConfig.get());
 

--- a/jslack-api-client/src/test/java/test_with_remote_apis/status/StatusApiV2Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/status/StatusApiV2Test.java
@@ -1,4 +1,4 @@
-package test_with_remote_apis.web_api;
+package test_with_remote_apis.status;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.status.v2.StatusApiException;
@@ -16,7 +16,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 @Slf4j
-public class status_v2_Test {
+public class StatusApiV2Test {
 
     Slack slack = Slack.getInstance(SlackTestConfig.get());
 

--- a/jslack-api-client/src/test/java/test_with_remote_apis/web_api/apps_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/web_api/apps_Test.java
@@ -2,17 +2,7 @@ package test_with_remote_apis.web_api;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
-import com.github.seratch.jslack.api.methods.request.apps.permissions.resources.AppsPermissionsResourcesListRequest;
-import com.github.seratch.jslack.api.methods.request.apps.permissions.scopes.AppsPermissionsScopesListRequest;
-import com.github.seratch.jslack.api.methods.request.apps.permissions.users.AppsPermissionsUsersListRequest;
-import com.github.seratch.jslack.api.methods.request.apps.permissions.users.AppsPermissionsUsersRequestRequest;
 import com.github.seratch.jslack.api.methods.response.apps.AppsUninstallResponse;
-import com.github.seratch.jslack.api.methods.response.apps.permissions.AppsPermissionsInfoResponse;
-import com.github.seratch.jslack.api.methods.response.apps.permissions.AppsPermissionsRequestResponse;
-import com.github.seratch.jslack.api.methods.response.apps.permissions.resources.AppsPermissionsResourcesListResponse;
-import com.github.seratch.jslack.api.methods.response.apps.permissions.scopes.AppsPermissionsScopesListResponse;
-import com.github.seratch.jslack.api.methods.response.apps.permissions.users.AppsPermissionsUsersListResponse;
-import com.github.seratch.jslack.api.methods.response.apps.permissions.users.AppsPermissionsUsersRequestResponse;
 import config.Constants;
 import config.SlackTestConfig;
 import lombok.extern.slf4j.Slf4j;
@@ -30,73 +20,10 @@ public class apps_Test {
     Slack slack = Slack.getInstance(SlackTestConfig.get());
 
     @Test
-    public void appsPermissionsRequest() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AppsPermissionsRequestResponse response = slack.methods().appsPermissionsRequest(req -> req
-                .token(token)
-                .triggerId("dummy"));
-        assertThat(response.getError(), is("not_allowed_token_type"));
-        assertThat(response.isOk(), is(false));
-    }
-
-    @Test
-    public void appsPermissionsInfo() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AppsPermissionsInfoResponse response = slack.methods().appsPermissionsInfo(req -> req
-                .token(token));
-        assertThat(response.getError(), is("not_allowed_token_type"));
-        assertThat(response.isOk(), is(false));
-    }
-
-    @Test
     public void appsUninstall() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         AppsUninstallResponse response = slack.methods().appsUninstall(req -> req
                 .token(token));
-        assertThat(response.getError(), is("not_allowed_token_type"));
-        assertThat(response.isOk(), is(false));
-    }
-
-    @Test
-    public void appsPermissionsResourcesList() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AppsPermissionsResourcesListResponse response = slack.methods().appsPermissionsResourcesList(AppsPermissionsResourcesListRequest.builder()
-                .token(token)
-                .limit(10)
-                .build());
-        assertThat(response.getError(), is("not_allowed_token_type"));
-        assertThat(response.isOk(), is(false));
-    }
-
-    @Test
-    public void appsPermissionsScopesList() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AppsPermissionsScopesListResponse response = slack.methods().appsPermissionsScopesList(AppsPermissionsScopesListRequest.builder()
-                .token(token)
-                .build());
-        assertThat(response.getError(), is("not_allowed_token_type"));
-        assertThat(response.isOk(), is(false));
-    }
-
-    @Test
-    public void appsPermissionsUsersList() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AppsPermissionsUsersListResponse response = slack.methods().appsPermissionsUsersList(AppsPermissionsUsersListRequest.builder()
-                .token(token)
-                .limit(10)
-                .build());
-        assertThat(response.getError(), is("not_allowed_token_type"));
-        assertThat(response.isOk(), is(false));
-    }
-
-    @Test
-    public void appsPermissionsUsersRequest() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
-        AppsPermissionsUsersRequestResponse response = slack.methods().appsPermissionsUsersRequest(AppsPermissionsUsersRequestRequest.builder()
-                .token(token)
-                .triggerId("abc")
-                .user("U0000000")
-                .build());
         assertThat(response.getError(), is("not_allowed_token_type"));
         assertThat(response.isOk(), is(false));
     }

--- a/jslack-api-client/src/test/java/test_with_remote_apis/workspace_apps/WorkspaceAppApiTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/workspace_apps/WorkspaceAppApiTest.java
@@ -1,0 +1,94 @@
+package test_with_remote_apis.workspace_apps;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.methods.request.apps.permissions.resources.AppsPermissionsResourcesListRequest;
+import com.github.seratch.jslack.api.methods.request.apps.permissions.scopes.AppsPermissionsScopesListRequest;
+import com.github.seratch.jslack.api.methods.request.apps.permissions.users.AppsPermissionsUsersListRequest;
+import com.github.seratch.jslack.api.methods.request.apps.permissions.users.AppsPermissionsUsersRequestRequest;
+import com.github.seratch.jslack.api.methods.response.apps.permissions.AppsPermissionsInfoResponse;
+import com.github.seratch.jslack.api.methods.response.apps.permissions.AppsPermissionsRequestResponse;
+import com.github.seratch.jslack.api.methods.response.apps.permissions.resources.AppsPermissionsResourcesListResponse;
+import com.github.seratch.jslack.api.methods.response.apps.permissions.scopes.AppsPermissionsScopesListResponse;
+import com.github.seratch.jslack.api.methods.response.apps.permissions.users.AppsPermissionsUsersListResponse;
+import com.github.seratch.jslack.api.methods.response.apps.permissions.users.AppsPermissionsUsersRequestResponse;
+import config.Constants;
+import config.SlackTestConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+// TODO: valid test
+@Slf4j
+public class WorkspaceAppApiTest {
+
+    Slack slack = Slack.getInstance(SlackTestConfig.get());
+
+    @Test
+    public void appsPermissionsRequest() throws IOException, SlackApiException {
+        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+        AppsPermissionsRequestResponse response = slack.methods().appsPermissionsRequest(req -> req
+                .token(token)
+                .triggerId("dummy"));
+        assertThat(response.getError(), is("not_allowed_token_type"));
+        assertThat(response.isOk(), is(false));
+    }
+
+    @Test
+    public void appsPermissionsInfo() throws IOException, SlackApiException {
+        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+        AppsPermissionsInfoResponse response = slack.methods().appsPermissionsInfo(req -> req
+                .token(token));
+        assertThat(response.getError(), is("not_allowed_token_type"));
+        assertThat(response.isOk(), is(false));
+    }
+
+    @Test
+    public void appsPermissionsResourcesList() throws IOException, SlackApiException {
+        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+        AppsPermissionsResourcesListResponse response = slack.methods().appsPermissionsResourcesList(AppsPermissionsResourcesListRequest.builder()
+                .token(token)
+                .limit(10)
+                .build());
+        assertThat(response.getError(), is("not_allowed_token_type"));
+        assertThat(response.isOk(), is(false));
+    }
+
+    @Test
+    public void appsPermissionsScopesList() throws IOException, SlackApiException {
+        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+        AppsPermissionsScopesListResponse response = slack.methods().appsPermissionsScopesList(AppsPermissionsScopesListRequest.builder()
+                .token(token)
+                .build());
+        assertThat(response.getError(), is("not_allowed_token_type"));
+        assertThat(response.isOk(), is(false));
+    }
+
+    @Test
+    public void appsPermissionsUsersList() throws IOException, SlackApiException {
+        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+        AppsPermissionsUsersListResponse response = slack.methods().appsPermissionsUsersList(AppsPermissionsUsersListRequest.builder()
+                .token(token)
+                .limit(10)
+                .build());
+        assertThat(response.getError(), is("not_allowed_token_type"));
+        assertThat(response.isOk(), is(false));
+    }
+
+    @Test
+    public void appsPermissionsUsersRequest() throws IOException, SlackApiException {
+        String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+        AppsPermissionsUsersRequestResponse response = slack.methods().appsPermissionsUsersRequest(AppsPermissionsUsersRequestRequest.builder()
+                .token(token)
+                .triggerId("abc")
+                .user("U0000000")
+                .build());
+        assertThat(response.getError(), is("not_allowed_token_type"));
+        assertThat(response.isOk(), is(false));
+    }
+
+}

--- a/json-logs/samples/api/admin.inviteRequests.approve.json
+++ b/json-logs/samples/api/admin.inviteRequests.approve.json
@@ -1,0 +1,6 @@
+{
+  "ok": false,
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/admin.inviteRequests.approved.list.json
+++ b/json-logs/samples/api/admin.inviteRequests.approved.list.json
@@ -1,0 +1,9 @@
+{
+  "ok": false,
+  "approved_requests": [
+    ""
+  ],
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/admin.inviteRequests.denied.list.json
+++ b/json-logs/samples/api/admin.inviteRequests.denied.list.json
@@ -1,0 +1,9 @@
+{
+  "ok": false,
+  "denied_requests": [
+    ""
+  ],
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/admin.inviteRequests.deny.json
+++ b/json-logs/samples/api/admin.inviteRequests.deny.json
@@ -1,0 +1,6 @@
+{
+  "ok": false,
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/admin.inviteRequests.list.json
+++ b/json-logs/samples/api/admin.inviteRequests.list.json
@@ -1,0 +1,9 @@
+{
+  "ok": false,
+  "error": "",
+  "needed": "",
+  "provided": "",
+  "invite_requests": [
+    ""
+  ]
+}


### PR DESCRIPTION
This pull request adds newly added admin APIs.

* admin.inviteRequests.approve
* admin.inviteRequests.deny
* admin.inviteRequests.list
* admin.inviteRequests.approved.list
* admin.inviteRequests.denied.list

Also, I marked some workspace app-related APIs as deprecated and re-organized the tests.
