### PR TITLE
Bump the versions of okhttp, gson, lombok, slf4j-api

### DIFF
--- a/jslack-lightning-kotlin-examples/pom.xml
+++ b/jslack-lightning-kotlin-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <kotlin.version>1.3.50</kotlin.version>
+        <kotlin.version>1.3.60</kotlin.version>
     </properties>
 
     <groupId>com.github.seratch</groupId>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.11.648</version>
+            <version>1.11.676</version>
         </dependency>
 
         <dependency>

--- a/jslack-lightning/pom.xml
+++ b/jslack-lightning/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.11.648</version>
+            <version>1.11.676</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty.version>9.2.27.v20190403</jetty.version>
-        <okhttp.version>4.1.0</okhttp.version>
-        <gson.version>2.8.5</gson.version>
-        <lombok.version>1.18.8</lombok.version>
-        <slf4j.version>1.7.28</slf4j.version>
+        <okhttp.version>4.2.2</okhttp.version>
+        <gson.version>2.8.6</gson.version>
+        <lombok.version>1.18.10</lombok.version>
+        <slf4j.version>1.7.29</slf4j.version>
     </properties>
 
     <licenses>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13-rc-1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This pull request upgrades some of the essential dependencies like okhttp, gson, lombok, and slf4j-api. I don't think these are risky upgrades. So, I will ship the changes as a patch release (=3.1.1).