### PR TITLE
Fix View object to be compatible with App Home

### DIFF
--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/view/View.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/view/View.java
@@ -31,8 +31,8 @@ public class View {
     private String externalId;
     private ViewState state;
     private String hash;
-    private boolean clearOnClose;
-    private boolean notifyOnClose;
+    private Boolean clearOnClose; // must be nullable for App Home
+    private Boolean notifyOnClose;  // must be nullable for App Home
     private String rootViewId;
     private String previousViewId; // views.update
     private String appId;


### PR DESCRIPTION
This pull request fixes a bug where `com.github.seratch.jslack.api.model.view. View` is not compatible with App Home tab. We cannot have `clear_on_close` and `notify_on_close` in views for Home tab. 