### PR TITLE
Lightning: Add App#status() and allow skipping calling App#start() method

### DIFF
--- a/jslack-lightning-micronaut/src/test/java/example/app/AppProvider.java
+++ b/jslack-lightning-micronaut/src/test/java/example/app/AppProvider.java
@@ -21,7 +21,6 @@ public class AppProvider implements Provider<App> {
         app.command("/hello", (req, ctx) -> {
             return ctx.ack(r -> r.text("Thanks!"));
         });
-        app.start();
         return app;
     }
 }

--- a/jslack-lightning-quarkus-examples/src/main/java/example/QuarkusSlackApp.java
+++ b/jslack-lightning-quarkus-examples/src/main/java/example/QuarkusSlackApp.java
@@ -27,7 +27,6 @@ public class QuarkusSlackApp extends SlackAppServlet {
         app.command("/hello", (ctx, req) -> {
             return Response.ok("Thanks!");
         });
-        app.start();
         return app;
     }
 }

--- a/jslack-lightning-spring-boot-examples/src/main/java/example/SlackApp.java
+++ b/jslack-lightning-spring-boot-examples/src/main/java/example/SlackApp.java
@@ -48,7 +48,6 @@ public class SlackApp {
         app.command("/hello", (req, ctx) -> {
             return ctx.ack(r -> r.text("Thanks!"));
         });
-        app.start();
         return app;
     }
 

--- a/jslack-lightning/src/test/java/test_locally/AppTest.java
+++ b/jslack-lightning/src/test/java/test_locally/AppTest.java
@@ -1,0 +1,27 @@
+package test_locally;
+
+import com.github.seratch.jslack.lightning.App;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AppTest {
+
+    @Test
+    public void status() {
+        App app = new App();
+        assertThat(app.status(), is(App.Status.Stopped));
+        app.start();
+        assertThat(app.status(), is(App.Status.Running));
+        app.stop();
+        assertThat(app.status(), is(App.Status.Stopped));
+        app.start();
+        assertThat(app.status(), is(App.Status.Running));
+        app.stop();
+        assertThat(app.status(), is(App.Status.Stopped));
+        app.start();
+        app.start();
+        assertThat(app.status(), is(App.Status.Running));
+    }
+}


### PR DESCRIPTION
This pull request adds `App#status()` to test `App`'s status and also modifies `App` to allow Lightning users to skip calling `App#start()` method.