### PR TITLE
Add object builders to attachments, views, dialogs, and incoming webhooks

### DIFF
--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Action.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Action.java
@@ -56,12 +56,14 @@ public class Action {
     private String url;
 
     @Data
+    @Builder
     public static class OptionGroup {
         private String text;
         private List<Option> options;
     }
 
     @Data
+    @Builder
     public static class Option {
         private String text;
         private String value;

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Attachment.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Attachment.java
@@ -275,6 +275,7 @@ public class Attachment {
     private AttachmentMetadata metadata;
 
     @Data
+    @Builder
     public static class AttachmentMetadata {
 
         @SerializedName("thumb_64")

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Attachments.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Attachments.java
@@ -1,0 +1,62 @@
+package com.github.seratch.jslack.api.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Attachments {
+
+    private Attachments() {}
+
+    public static List<Attachment> asAttachments(Attachment... attachments) {
+        return Arrays.asList(attachments);
+    }
+
+    public static Attachment attachment(ModelConfigurator<Attachment.AttachmentBuilder> configurator) {
+        return configurator.configure(Attachment.builder()).build();
+    }
+
+    public static Attachment.AttachmentMetadata attachmentMetadata(ModelConfigurator<Attachment.AttachmentMetadata.AttachmentMetadataBuilder> configurator) {
+        return configurator.configure(Attachment.AttachmentMetadata.builder()).build();
+    }
+
+    public static Field field(ModelConfigurator<Field.FieldBuilder> configurator) {
+        return configurator.configure(Field.builder()).build();
+    }
+
+    public static Action action(ModelConfigurator<Action.ActionBuilder> configurator) {
+        return configurator.configure(Action.builder()).build();
+    }
+
+    public static Confirmation confirm(ModelConfigurator<Confirmation.ConfirmationBuilder> configurator) {
+        return configurator.configure(Confirmation.builder()).build();
+    }
+
+    public static Action.OptionGroup optionGroup(ModelConfigurator<Action.OptionGroup.OptionGroupBuilder> configurator) {
+        return configurator.configure(Action.OptionGroup.builder()).build();
+    }
+
+    public static Action.Option option(ModelConfigurator<Action.Option.OptionBuilder> configurator) {
+        return configurator.configure(Action.Option.builder()).build();
+    }
+
+    public static List<Action> asActions(Action... actions) {
+        return Arrays.asList(actions);
+    }
+
+    public static List<Field> asFields(Field... fields) {
+        return Arrays.asList(fields);
+    }
+
+    public static List<Action.OptionGroup> asOptionGroups(Action.OptionGroup... optionGroups) {
+        return Arrays.asList(optionGroups);
+    }
+
+    public static List<Action.Option> asOptions(Action.Option... options) {
+        return Arrays.asList(options);
+    }
+
+    public static List<String> asList(String... values) {
+        return Arrays.asList(values);
+    }
+
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/dialog/Dialogs.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/dialog/Dialogs.java
@@ -1,0 +1,40 @@
+package com.github.seratch.jslack.api.model.dialog;
+
+import com.github.seratch.jslack.api.model.ModelConfigurator;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Dialogs {
+
+    private Dialogs() {}
+
+    public static List<DialogElement> asElements(DialogElement... elements) {
+        return Arrays.asList(elements);
+    }
+
+    public static List<DialogOption> asOptions(DialogOption... options) {
+        return Arrays.asList(options);
+    }
+
+    public static Dialog dialog(ModelConfigurator<Dialog.DialogBuilder> configurator) {
+        return configurator.configure(Dialog.builder()).build();
+    }
+
+    public static DialogOption dialogOption(ModelConfigurator<DialogOption.DialogOptionBuilder> configurator) {
+        return configurator.configure(DialogOption.builder()).build();
+    }
+
+    public static DialogSelectElement dialogSelect(ModelConfigurator<DialogSelectElement.DialogSelectElementBuilder> configurator) {
+        return configurator.configure(DialogSelectElement.builder()).build();
+    }
+
+    public static DialogTextElement dialogText(ModelConfigurator<DialogTextElement.DialogTextElementBuilder> configurator) {
+        return configurator.configure(DialogTextElement.builder()).build();
+    }
+
+    public static DialogTextAreaElement dialogTextArea(ModelConfigurator<DialogTextAreaElement.DialogTextAreaElementBuilder> configurator) {
+        return configurator.configure(DialogTextAreaElement.builder()).build();
+    }
+
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/view/Views.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/view/Views.java
@@ -1,0 +1,29 @@
+package com.github.seratch.jslack.api.model.view;
+
+import com.github.seratch.jslack.api.model.ModelConfigurator;
+
+public class Views {
+
+    private Views() {}
+
+    public static View view(ModelConfigurator<View.ViewBuilder> configurator) {
+        return configurator.configure(View.builder()).build();
+    }
+
+    public static ViewClose viewClose(ModelConfigurator<ViewClose.ViewCloseBuilder> configurator) {
+        return configurator.configure(ViewClose.builder()).build();
+    }
+
+    public static ViewState viewState(ModelConfigurator<ViewState.ViewStateBuilder> configurator) {
+        return configurator.configure(ViewState.builder()).build();
+    }
+
+    public static ViewSubmit viewSubmit(ModelConfigurator<ViewSubmit.ViewSubmitBuilder> configurator) {
+        return configurator.configure(ViewSubmit.builder()).build();
+    }
+
+    public static ViewTitle viewTitle(ModelConfigurator<ViewTitle.ViewTitleBuilder> configurator) {
+        return configurator.configure(ViewTitle.builder()).build();
+    }
+
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/webhook/WebhookPayloads.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/webhook/WebhookPayloads.java
@@ -1,0 +1,13 @@
+package com.github.seratch.jslack.api.webhook;
+
+import com.github.seratch.jslack.api.model.ModelConfigurator;
+
+public class WebhookPayloads {
+
+    private WebhookPayloads() {}
+
+    public static Payload payload(ModelConfigurator<Payload.PayloadBuilder> configurator) {
+        return configurator.configure(Payload.builder()).build();
+    }
+
+}

--- a/jslack-api-model/src/test/java/test_locally/api/model/attachment/AttachmentsTest.java
+++ b/jslack-api-model/src/test/java/test_locally/api/model/attachment/AttachmentsTest.java
@@ -1,9 +1,11 @@
 package test_locally.api.model.attachment;
 
+import com.github.seratch.jslack.api.model.Attachment;
 import com.github.seratch.jslack.api.model.Message;
 import org.junit.Test;
 import test_locally.unit.GsonFactory;
 
+import static com.github.seratch.jslack.api.model.Attachments.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -124,6 +126,24 @@ public class AttachmentsTest {
         assertThat(message.getFiles().size(), is(1));
         assertThat(message.getFiles().get(0).getAttachments().size(), is(3));
         assertThat(message.getFiles().get(0).getAttachments().get(0).getMetadata(), is(notNullValue()));
+    }
+
+    @Test
+    public void builder() {
+        Attachment attachment = attachment(att -> {
+            return att.text("Hello")
+                    .fields(asFields(field(f -> f)))
+                    .actions(asActions(
+                            action(a -> a.confirm(confirm(c -> c.title("Confirmation").text("Are your sure?")))),
+                            action(a -> a.optionGroups(asOptionGroups(optionGroup(og ->
+                                    og.options(asOptions(
+                                            option(o -> o.text("Option 1")),
+                                            option(o -> o.text("Option 2"))
+                                    ))))))
+                    ))
+                    .mrkdwnIn(asList("foo", "bar"));
+        });
+        assertThat(attachment, is(notNullValue()));
     }
 
 }

--- a/jslack-api-model/src/test/java/test_locally/api/model/dialog/DialogsTest.java
+++ b/jslack-api-model/src/test/java/test_locally/api/model/dialog/DialogsTest.java
@@ -1,0 +1,29 @@
+package test_locally.api.model.dialog;
+
+import com.github.seratch.jslack.api.model.dialog.Dialog;
+import com.github.seratch.jslack.api.model.dialog.DialogSubType;
+import org.junit.Test;
+
+import static com.github.seratch.jslack.api.model.dialog.Dialogs.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class DialogsTest {
+
+    @Test
+    public void test() {
+        Dialog dialog = dialog(d -> {
+            return d.elements(asElements(
+                    dialogSelect(ds ->
+                            ds.label("aaa")
+                                    .name("nnnn")
+                                    .options(asOptions(dialogOption(opt -> opt.label("l").value("v"))))
+                    ),
+                    dialogText(dt -> dt.name("foo")),
+                    dialogTextArea(dta -> dta.subtype(DialogSubType.NUMBER))
+            ));
+        });
+        assertThat(dialog, is(notNullValue()));
+    }
+}

--- a/jslack-api-model/src/test/java/test_locally/api/model/view/ViewsTest.java
+++ b/jslack-api-model/src/test/java/test_locally/api/model/view/ViewsTest.java
@@ -1,0 +1,28 @@
+package test_locally.api.model.view;
+
+import com.github.seratch.jslack.api.model.view.View;
+import org.junit.Test;
+
+import static com.github.seratch.jslack.api.model.block.Blocks.*;
+import static com.github.seratch.jslack.api.model.block.composition.BlockCompositions.plainText;
+import static com.github.seratch.jslack.api.model.view.Views.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ViewsTest {
+
+    @Test
+    public void testView() {
+        View view = view(r -> {
+            return r.title(viewTitle(t -> t.text("My App")))
+                    .close(viewClose(c -> c.text("Close")))
+                    .submit(viewSubmit(s -> s.text("Submit")))
+                    .blocks(asBlocks(
+                            section(sec -> sec.text(plainText(pt -> pt.text("Hi")))),
+                            image(img -> img.imageUrl("https://www.example.com/foo.png"))
+                    ));
+        });
+        assertThat(view, is(notNullValue()));
+    }
+}

--- a/jslack-api-model/src/test/java/test_locally/api/webhook/WebhookPayloadsTest.java
+++ b/jslack-api-model/src/test/java/test_locally/api/webhook/WebhookPayloadsTest.java
@@ -1,0 +1,30 @@
+package test_locally.api.webhook;
+
+import com.github.seratch.jslack.api.webhook.Payload;
+import org.junit.Test;
+
+import static com.github.seratch.jslack.api.model.Attachments.*;
+import static com.github.seratch.jslack.api.model.block.Blocks.*;
+import static com.github.seratch.jslack.api.model.block.composition.BlockCompositions.plainText;
+import static com.github.seratch.jslack.api.webhook.WebhookPayloads.payload;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class WebhookPayloadsTest {
+
+    @Test
+    public void test() {
+        Payload payload = payload(it -> {
+            return it.text("fallback")
+                    .blocks(asBlocks(
+                            section(s -> s.text(plainText("Hi"))),
+                            image(i -> i.imageUrl("https://www.example.com/foo.png"))
+                    ))
+                    .attachments(asAttachments(
+                            attachment(a -> a.actions(asActions(action(ac -> ac.name("foo"))))),
+                            attachment(a -> a.fields(asFields(field(f -> f.title("title")))))
+                    ));
+        });
+        assertThat(payload, is(notNullValue()));
+    }
+}


### PR DESCRIPTION
The PR #284 is greatly helpful but the PR covered only Block Kit. This pull request adds similar ones to the rest.