### PR TITLE
Handle message-related events appropriately (breaking change)

### DIFF
--- a/jslack-api-client/src/test/java/test_locally/sample_json_generation/RTMPayloadDumpTest.java
+++ b/jslack-api-client/src/test/java/test_locally/sample_json_generation/RTMPayloadDumpTest.java
@@ -260,8 +260,6 @@ public class RTMPayloadDumpTest {
 
     private MessageEvent buildMessageEvent() {
         MessageEvent event = new MessageEvent();
-        event.setReactions(Arrays.asList(Reaction.builder().users(Arrays.asList("")).build()));
-        event.setPinnedTo(Arrays.asList(""));
         event.setBlocks(SampleObjects.Blocks);
         event.setAttachments(SampleObjects.Attachments);
         return event;

--- a/jslack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApiTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApiTest.java
@@ -25,6 +25,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -199,9 +200,13 @@ public class AdminApiTest {
                     .adminTeamsSettingsSetName(r -> r.teamId(adminAppsTeamId).name("Kaz's Awesome Engineering Team"));
             assertThat(setName.getError(), is(nullValue()));
 
-            AdminTeamsSettingsSetIconResponse setIcon = slack.methods(orgAdminToken)
-                    .adminTeamsSettingsSetIcon(r -> r.teamId(adminAppsTeamId).imageUrl("https://avatars.slack-edge.com/2019-05-24/634650041250_0c70b65cdfc88ac9ef96_192.jpg"));
-            assertThat(setIcon.getError(), is(nullValue()));
+            try {
+                AdminTeamsSettingsSetIconResponse setIcon = slack.methods(orgAdminToken)
+                        .adminTeamsSettingsSetIcon(r -> r.teamId(adminAppsTeamId).imageUrl("https://avatars.slack-edge.com/2019-05-24/634650041250_0c70b65cdfc88ac9ef96_192.jpg"));
+                assertThat(setIcon.getError(), is(nullValue()));
+            } catch (SocketTimeoutException e) {
+                log.warn("timed out", e);
+            }
         }
     }
 

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/Event.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/Event.java
@@ -6,4 +6,8 @@ public interface Event extends Serializable {
 
     String getType();
 
+    default String getSubtype() {
+        return null;
+    }
+
 }

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageBotEvent.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageBotEvent.java
@@ -1,0 +1,36 @@
+package com.github.seratch.jslack.api.model.event;
+
+import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.Message;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/events/message/bot_message
+ */
+@Data
+public class MessageBotEvent implements Event {
+
+    public static final String TYPE_NAME = "message";
+    public static final String SUBTYPE_NAME = "bot_message";
+
+    private final String type = TYPE_NAME;
+    private final String subtype = SUBTYPE_NAME;
+
+    private String botId;
+    private String username;
+    private Message.Icons icons;
+
+    private String channel;
+
+    private String text;
+    private List<LayoutBlock> blocks;
+    private List<Attachment> attachments;
+
+    private String ts;
+
+    private String eventTs;
+    private String channelType; // app_home, channel, group, im, mpim
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageChangedEvent.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageChangedEvent.java
@@ -1,0 +1,65 @@
+package com.github.seratch.jslack.api.model.event;
+
+import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.Reaction;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/events/message/message_changed
+ */
+@Data
+public class MessageChangedEvent implements Event {
+
+    public static final String TYPE_NAME = "message";
+    public static final String SUBTYPE_NAME = "message_changed";
+
+    private final String type = TYPE_NAME;
+    private final String subtype = SUBTYPE_NAME;
+    private String channel;
+
+    private boolean hidden;
+
+    private Message message;
+    private Message previousMessage;
+
+    private String eventTs;
+    private String ts;
+    private String channelType; // app_home, channel, group, im, mpim
+
+    @Data
+    public static class Message {
+        private String clientMsgId;
+
+        private final String type = TYPE_NAME;
+        private String subtype;
+
+        private String user;
+        private String team;
+
+        private MessageEvent.Edited edited;
+
+        private String text;
+        private List<LayoutBlock> blocks;
+        private List<Attachment> attachments;
+
+        private String ts;
+        private String userTeam;
+        private String sourceTeam;
+
+        @SerializedName("is_starred")
+        private boolean starred;
+        private List<String> pinnedTo;
+        private List<Reaction> reactions;
+    }
+
+    @Data
+    public static class Edited {
+        private String user;
+        private String ts;
+    }
+
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageDeletedEvent.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageDeletedEvent.java
@@ -1,0 +1,62 @@
+package com.github.seratch.jslack.api.model.event;
+
+import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.Reaction;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/events/message/message_deleted
+ */
+@Data
+public class MessageDeletedEvent implements Event {
+
+    public static final String TYPE_NAME = "message";
+    public static final String SUBTYPE_NAME = "message_deleted";
+
+    private final String type = TYPE_NAME;
+    private final String subtype = SUBTYPE_NAME;
+    private String channel;
+
+    private boolean hidden;
+    private String deletedTs;
+
+    private Message previousMessage;
+
+    private String eventTs;
+    private String ts;
+    private String channelType; // app_home, channel, group, im, mpim
+
+    @Data
+    public static class Message {
+        private String clientMsgId;
+
+        private final String type = TYPE_NAME;
+        private String subtype;
+        private String user;
+        private String team;
+
+        private MessageEvent.Edited edited;
+
+        private String text;
+        private List<LayoutBlock> blocks;
+        private List<Attachment> attachments;
+
+        @SerializedName("is_starred")
+        private boolean starred;
+        private List<String> pinnedTo;
+        private List<Reaction> reactions;
+
+        private String ts;
+    }
+
+    @Data
+    public static class Edited {
+        private String user;
+        private String ts;
+    }
+
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageEkmAccessDeniedEvent.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageEkmAccessDeniedEvent.java
@@ -1,0 +1,32 @@
+package com.github.seratch.jslack.api.model.event;
+
+import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/events/message/ekm_access_denied
+ */
+@Data
+public class MessageEkmAccessDeniedEvent implements Event {
+
+    public static final String TYPE_NAME = "message";
+    public static final String SUBTYPE_NAME = "ekm_access_denied";
+
+    private final String type = TYPE_NAME;
+    private final String subtype = SUBTYPE_NAME;
+    private String channel;
+    private boolean hidden;
+
+    private String user;
+
+    private String text;
+    private List<LayoutBlock> blocks;
+    private List<Attachment> attachments;
+
+    private String eventTs;
+    private String ts;
+    private String channelType; // app_home, channel, group, im, mpim
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageEvent.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageEvent.java
@@ -35,7 +35,10 @@ public class MessageEvent implements Event {
     private List<Attachment> attachments;
 
     private String ts;
-    private String threadTs;
+
+    private String parentUserId; // in the case of replies in thread
+    private String threadTs; // in the case of replies in thread
+
     private String eventTs;
     private String channelType; // app_home, channel, group, im, mpim
 
@@ -46,18 +49,4 @@ public class MessageEvent implements Event {
         private String user;
         private String ts;
     }
-
-    private String subtype;
-    private boolean hidden;
-    private String deletedTs;
-
-    @SerializedName("is_starred")
-    private boolean starred;
-    private List<String> pinnedTo;
-    private List<Reaction> reactions;
-
-    // bot_message
-    private String botId;
-    private String username;
-    private Message.Icons icons;
 }

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageMeEvent.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageMeEvent.java
@@ -1,0 +1,26 @@
+package com.github.seratch.jslack.api.model.event;
+
+import lombok.Data;
+
+/**
+ * https://api.slack.com/events/message/me_message
+ */
+@Data
+public class MessageMeEvent implements Event {
+
+    public static final String TYPE_NAME = "message";
+    public static final String SUBTYPE_NAME = "me_message";
+
+    private final String type = TYPE_NAME;
+    private final String subtype = SUBTYPE_NAME;
+    private String channel;
+
+    private String username;
+    private String botId;
+
+    private String text;
+
+    private String eventTs;
+    private String ts;
+    private String channelType; // app_home, channel, group, im, mpim
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageThreadBroadcastEvent.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/event/MessageThreadBroadcastEvent.java
@@ -1,0 +1,38 @@
+package com.github.seratch.jslack.api.model.event;
+
+import com.github.seratch.jslack.api.model.Attachment;
+import com.github.seratch.jslack.api.model.Message;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/events/message/thread_broadcast
+ */
+@Data
+public class MessageThreadBroadcastEvent implements Event {
+
+    public static final String TYPE_NAME = "message";
+    public static final String SUBTYPE_NAME = "thread_broadcast";
+
+    private String clientMsgId;
+
+    private final String type = TYPE_NAME;
+    private final String subtype = SUBTYPE_NAME;
+    private String channel;
+    private String user;
+
+    private Message.MessageRoot root;
+
+    private String text;
+    private List<LayoutBlock> blocks;
+    private List<Attachment> attachments;
+
+    private String ts;
+    private String threadTs;
+
+    private String eventTs;
+    private String channelType; // app_home, channel, group, im, mpim
+
+}

--- a/jslack-api-model/src/test/java/test_locally/api/model/event/MessageEventTest.java
+++ b/jslack-api-model/src/test/java/test_locally/api/model/event/MessageEventTest.java
@@ -1,5 +1,6 @@
 package test_locally.api.model.event;
 
+import com.github.seratch.jslack.api.model.event.MessageBotEvent;
 import com.github.seratch.jslack.api.model.event.MessageEvent;
 import com.google.gson.Gson;
 import org.junit.Test;
@@ -169,7 +170,6 @@ public class MessageEventTest {
                 "        \"type\": \"message\",\n" +
                 "        \"subtype\": \"bot_message\",\n" +
                 "        \"channel\": \"G024BE91L\",\n" +
-                "        \"user\": \"U2147483697\",\n" +
                 "        \"text\": \"Let's make a pact.\",\n" +
                 "        \"username\": \"seanbot\",\n" +
                 "        \"bot_id\": \"ABC1234\",\n" +
@@ -178,11 +178,10 @@ public class MessageEventTest {
                 "        \"event_ts\": \"1355517523.000005\",\n" +
                 "        \"channel_type\": \"mpim\"\n" +
                 "}";
-        MessageEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageEvent.class);
+        MessageBotEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageBotEvent.class);
         assertThat(event.getType(), is("message"));
         assertThat(event.getSubtype(), is("bot_message"));
         assertThat(event.getChannel(), is("G024BE91L"));
-        assertThat(event.getUser(), is("U2147483697"));
         assertThat(event.getText(), is("Let's make a pact."));
         assertThat(event.getTs(), is("1355517523.000005"));
         assertThat(event.getEventTs(), is("1355517523.000005"));
@@ -198,7 +197,7 @@ public class MessageEventTest {
         Gson gson = GsonFactory.createSnakeCase();
         MessageEvent event = new MessageEvent();
         String generatedJson = gson.toJson(event);
-        String expectedJson = "{\"type\":\"message\",\"hidden\":false,\"is_starred\":false}";
+        String expectedJson = "{\"type\":\"message\"}";
         assertThat(generatedJson, is(expectedJson));
     }
 

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventHandler.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventHandler.java
@@ -20,6 +20,13 @@ public abstract class EventHandler<E extends EventsApiPayload<?>> {
     public abstract String getEventType();
 
     /**
+     * Returns the subtype of the event (e.g., "message_changed" for type: message)
+     */
+    public String getEventSubtype() {
+        return null;
+    }
+
+    /**
      * Returns the Class object of the EventApiPayload implementation.
      */
     public Class<E> getEventPayloadClass() {

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventTypeExtractor.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventTypeExtractor.java
@@ -4,4 +4,6 @@ public interface EventTypeExtractor {
 
     String extractEventType(String json);
 
+    String extractEventSubtype(String json);
+
 }

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventTypeExtractorImpl.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/EventTypeExtractorImpl.java
@@ -48,4 +48,53 @@ public class EventTypeExtractorImpl implements EventTypeExtractor {
         return sb.toString();
     }
 
+    @Override
+    public String extractEventSubtype(String json) {
+        StringBuilder sb = new StringBuilder();
+        char[] chars = json.toCharArray();
+        boolean isInsideEventData = false;
+        for (int idx = 0; idx < (chars.length - 7); idx++) {
+            if (!isInsideEventData && chars[idx] == '"'
+                    && chars[idx + 1] == 'e'
+                    && chars[idx + 2] == 'v'
+                    && chars[idx + 3] == 'e'
+                    && chars[idx + 4] == 'n'
+                    && chars[idx + 5] == 't'
+                    && chars[idx + 6] == '"'
+                    && chars[idx + 7] == ':') {
+                idx = idx + 8;
+                isInsideEventData = true;
+            }
+
+            if (isInsideEventData && chars[idx] == '"'
+                    && chars[idx + 1] == 's'
+                    && chars[idx + 2] == 'u'
+                    && chars[idx + 3] == 'b'
+                    && chars[idx + 4] == 't'
+                    && chars[idx + 5] == 'y'
+                    && chars[idx + 6] == 'p'
+                    && chars[idx + 7] == 'e'
+                    && chars[idx + 8] == '"'
+                    && chars[idx + 9] == ':') {
+                idx = idx + 10;
+                int doubleQuoteCount = 0;
+                boolean isPreviousCharEscape = false;
+                while (doubleQuoteCount < 2 && idx < chars.length) {
+                    char c = chars[idx];
+                    if (c == '"' && !isPreviousCharEscape) {
+                        doubleQuoteCount++;
+                    } else {
+                        if (doubleQuoteCount == 1) {
+                            sb.append(c);
+                        }
+                    }
+                    isPreviousCharEscape = c == '\\';
+                    idx++;
+                }
+                break;
+            }
+        }
+        return sb.toString();
+    }
+
 }

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageBotHandler.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageBotHandler.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.app_backend.events.handler;
+
+import com.github.seratch.jslack.api.model.event.MessageBotEvent;
+import com.github.seratch.jslack.app_backend.events.EventHandler;
+import com.github.seratch.jslack.app_backend.events.payload.MessageBotPayload;
+
+public abstract class MessageBotHandler extends EventHandler<MessageBotPayload> {
+
+    @Override
+    public String getEventType() {
+        return MessageBotEvent.TYPE_NAME;
+    }
+
+    @Override
+    public String getEventSubtype() {
+        return MessageBotEvent.SUBTYPE_NAME;
+    }
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageChangedHandler.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageChangedHandler.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.app_backend.events.handler;
+
+import com.github.seratch.jslack.api.model.event.MessageChangedEvent;
+import com.github.seratch.jslack.app_backend.events.EventHandler;
+import com.github.seratch.jslack.app_backend.events.payload.MessageChangedPayload;
+
+public abstract class MessageChangedHandler extends EventHandler<MessageChangedPayload> {
+
+    @Override
+    public String getEventType() {
+        return MessageChangedEvent.TYPE_NAME;
+    }
+
+    @Override
+    public String getEventSubtype() {
+        return MessageChangedEvent.SUBTYPE_NAME;
+    }
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageDeletedHandler.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageDeletedHandler.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.app_backend.events.handler;
+
+import com.github.seratch.jslack.api.model.event.MessageDeletedEvent;
+import com.github.seratch.jslack.app_backend.events.EventHandler;
+import com.github.seratch.jslack.app_backend.events.payload.MessageDeletedPayload;
+
+public abstract class MessageDeletedHandler extends EventHandler<MessageDeletedPayload> {
+
+    @Override
+    public String getEventType() {
+        return MessageDeletedEvent.TYPE_NAME;
+    }
+
+    @Override
+    public String getEventSubtype() {
+        return MessageDeletedEvent.SUBTYPE_NAME;
+    }
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageEkmAccessDeniedHandler.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageEkmAccessDeniedHandler.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.app_backend.events.handler;
+
+import com.github.seratch.jslack.api.model.event.MessageEkmAccessDeniedEvent;
+import com.github.seratch.jslack.app_backend.events.EventHandler;
+import com.github.seratch.jslack.app_backend.events.payload.MessageEkmAccessDeniedPayload;
+
+public abstract class MessageEkmAccessDeniedHandler extends EventHandler<MessageEkmAccessDeniedPayload> {
+
+    @Override
+    public String getEventType() {
+        return MessageEkmAccessDeniedEvent.TYPE_NAME;
+    }
+
+    @Override
+    public String getEventSubtype() {
+        return MessageEkmAccessDeniedEvent.SUBTYPE_NAME;
+    }
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageMeHandler.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageMeHandler.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.app_backend.events.handler;
+
+import com.github.seratch.jslack.api.model.event.MessageMeEvent;
+import com.github.seratch.jslack.app_backend.events.EventHandler;
+import com.github.seratch.jslack.app_backend.events.payload.MessageMePayload;
+
+public abstract class MessageMeHandler extends EventHandler<MessageMePayload> {
+
+    @Override
+    public String getEventType() {
+        return MessageMeEvent.TYPE_NAME;
+    }
+
+    @Override
+    public String getEventSubtype() {
+        return MessageMeEvent.SUBTYPE_NAME;
+    }
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageThreadBroadcastHandler.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/handler/MessageThreadBroadcastHandler.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.app_backend.events.handler;
+
+import com.github.seratch.jslack.api.model.event.MessageThreadBroadcastEvent;
+import com.github.seratch.jslack.app_backend.events.EventHandler;
+import com.github.seratch.jslack.app_backend.events.payload.MessageThreadBroadcastPayload;
+
+public abstract class MessageThreadBroadcastHandler extends EventHandler<MessageThreadBroadcastPayload> {
+
+    @Override
+    public String getEventType() {
+        return MessageThreadBroadcastEvent.TYPE_NAME;
+    }
+
+    @Override
+    public String getEventSubtype() {
+        return MessageThreadBroadcastEvent.SUBTYPE_NAME;
+    }
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageBotPayload.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageBotPayload.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.app_backend.events.payload;
+
+import com.github.seratch.jslack.api.model.event.MessageBotEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageBotPayload implements EventsApiPayload<MessageBotEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private String eventId;
+    private Integer eventTime;
+
+    private MessageBotEvent event;
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageChangedPayload.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageChangedPayload.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.app_backend.events.payload;
+
+import com.github.seratch.jslack.api.model.event.MessageChangedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageChangedPayload implements EventsApiPayload<MessageChangedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private String eventId;
+    private Integer eventTime;
+
+    private MessageChangedEvent event;
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageDeletedPayload.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageDeletedPayload.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.app_backend.events.payload;
+
+import com.github.seratch.jslack.api.model.event.MessageDeletedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageDeletedPayload implements EventsApiPayload<MessageDeletedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private String eventId;
+    private Integer eventTime;
+
+    private MessageDeletedEvent event;
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageEkmAccessDeniedPayload.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageEkmAccessDeniedPayload.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.app_backend.events.payload;
+
+import com.github.seratch.jslack.api.model.event.MessageEkmAccessDeniedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageEkmAccessDeniedPayload implements EventsApiPayload<MessageEkmAccessDeniedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private String eventId;
+    private Integer eventTime;
+
+    private MessageEkmAccessDeniedEvent event;
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageMePayload.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageMePayload.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.app_backend.events.payload;
+
+import com.github.seratch.jslack.api.model.event.MessageMeEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageMePayload implements EventsApiPayload<MessageMeEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private String eventId;
+    private Integer eventTime;
+
+    private MessageMeEvent event;
+}

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageThreadBroadcastPayload.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/events/payload/MessageThreadBroadcastPayload.java
@@ -1,0 +1,22 @@
+package com.github.seratch.jslack.app_backend.events.payload;
+
+import com.github.seratch.jslack.api.model.event.MessageThreadBroadcastEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageThreadBroadcastPayload implements EventsApiPayload<MessageThreadBroadcastEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private String eventId;
+    private Integer eventTime;
+
+    private MessageThreadBroadcastEvent event;
+}

--- a/jslack-app-backend/src/test/java/test_locally/sample_json_generation/EventsApiPayloadDumpTest.java
+++ b/jslack-app-backend/src/test/java/test_locally/sample_json_generation/EventsApiPayloadDumpTest.java
@@ -1,5 +1,6 @@
 package test_locally.sample_json_generation;
 
+import com.github.seratch.jslack.api.model.Message;
 import com.github.seratch.jslack.api.model.Reaction;
 import com.github.seratch.jslack.api.model.event.*;
 import com.github.seratch.jslack.app_backend.events.payload.*;
@@ -65,6 +66,12 @@ public class EventsApiPayloadDumpTest {
                 new MemberJoinedChannelPayload(),
                 new MemberLeftChannelPayload(),
                 buildMessagePayload(),
+                buildMessageBotPayload(),
+                buildMessageChangedPayload(),
+                buildMessageDeletedPayload(),
+                buildMessageEkmAccessDeniedPayload(),
+                buildMessageMePayload(),
+                buildMessageThreadBroadcastPayload(),
                 buildPinAddedPayload(),
                 buildPinRemovedPayload(),
                 new ReactionAddedPayload(),
@@ -255,8 +262,64 @@ public class EventsApiPayloadDumpTest {
         payload.setEvent(new MessageEvent());
         payload.getEvent().setAttachments(SampleObjects.Attachments);
         payload.getEvent().setBlocks(SampleObjects.Blocks);
-        payload.getEvent().setPinnedTo(Arrays.asList(""));
-        payload.getEvent().setReactions(Arrays.asList(initProperties(Reaction.builder().users(Arrays.asList("")).build())));
         return payload;
     }
+
+    private MessageBotPayload buildMessageBotPayload() {
+        MessageBotPayload payload = new MessageBotPayload();
+        payload.setEvent(new MessageBotEvent());
+        payload.getEvent().setAttachments(SampleObjects.Attachments);
+        payload.getEvent().setBlocks(SampleObjects.Blocks);
+        return payload;
+    }
+
+    private MessageChangedPayload buildMessageChangedPayload() {
+        MessageChangedPayload payload = new MessageChangedPayload();
+        MessageChangedEvent event = new MessageChangedEvent();
+        MessageChangedEvent.Message message = new MessageChangedEvent.Message();
+        message.setAttachments(SampleObjects.Attachments);
+        message.setBlocks(SampleObjects.Blocks);
+        event.setMessage(message);
+        event.setPreviousMessage(message);
+        payload.setEvent(event);
+        return payload;
+    }
+
+    private MessageDeletedPayload buildMessageDeletedPayload() {
+        MessageDeletedPayload payload = new MessageDeletedPayload();
+        MessageDeletedEvent event = new MessageDeletedEvent();
+        MessageDeletedEvent.Message message = new MessageDeletedEvent.Message();
+        message.setAttachments(SampleObjects.Attachments);
+        message.setBlocks(SampleObjects.Blocks);
+        event.setPreviousMessage(message);
+        payload.setEvent(event);
+        return payload;
+    }
+
+    private MessageEkmAccessDeniedPayload buildMessageEkmAccessDeniedPayload() {
+        MessageEkmAccessDeniedPayload payload = new MessageEkmAccessDeniedPayload();
+        MessageEkmAccessDeniedEvent event = new MessageEkmAccessDeniedEvent();
+        event.setAttachments(SampleObjects.Attachments);
+        event.setBlocks(SampleObjects.Blocks);
+        payload.setEvent(event);
+        return payload;
+    }
+
+    private MessageMePayload buildMessageMePayload() {
+        MessageMePayload payload = new MessageMePayload();
+        MessageMeEvent event = new MessageMeEvent();
+        payload.setEvent(event);
+        return payload;
+    }
+
+    private MessageThreadBroadcastPayload buildMessageThreadBroadcastPayload() {
+        MessageThreadBroadcastPayload payload = new MessageThreadBroadcastPayload();
+        MessageThreadBroadcastEvent event = new MessageThreadBroadcastEvent();
+        event.setRoot(new Message.MessageRoot());
+        event.setAttachments(SampleObjects.Attachments);
+        event.setBlocks(SampleObjects.Blocks);
+        payload.setEvent(event);
+        return payload;
+    }
+
 }

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/EventRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/builtin/EventRequest.java
@@ -15,6 +15,7 @@ public class EventRequest extends Request<DefaultContext> {
     private final String requestBody;
     private final RequestHeaders headers;
     private final String eventType;
+    private final String eventSubtype;
 
     public EventRequest(
             String requestBody,
@@ -22,7 +23,13 @@ public class EventRequest extends Request<DefaultContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         JsonObject payload = GsonFactory.createSnakeCase().fromJson(requestBody, JsonElement.class).getAsJsonObject();
-        this.eventType = payload.get("event").getAsJsonObject().get("type").getAsString();
+        JsonObject event = payload.get("event").getAsJsonObject();
+        this.eventType = event.get("type").getAsString();
+        if (event.get("subtype") != null) {
+            this.eventSubtype = event.get("subtype").getAsString();
+        } else {
+            this.eventSubtype = null;
+        }
         this.getContext().setTeamId(payload.get("team_id").getAsString());
         JsonElement enterpriseId = payload.get("enterprise_id");
         if (enterpriseId != null) {
@@ -54,5 +61,9 @@ public class EventRequest extends Request<DefaultContext> {
 
     public String getEventType() {
         return eventType;
+    }
+
+    public String getEventTypeAndSubtype() {
+        return eventType + ":" + eventSubtype;
     }
 }

--- a/jslack-lightning/src/test/java/samples/EventsSample.java
+++ b/jslack-lightning/src/test/java/samples/EventsSample.java
@@ -1,6 +1,9 @@
 package samples;
 
+import com.github.seratch.jslack.api.model.event.MessageBotEvent;
+import com.github.seratch.jslack.api.model.event.MessageDeletedEvent;
 import com.github.seratch.jslack.api.model.event.MessageEvent;
+import com.github.seratch.jslack.api.rtm.message.Message;
 import com.github.seratch.jslack.app_backend.events.handler.MessageHandler;
 import com.github.seratch.jslack.app_backend.events.payload.MessagePayload;
 import com.github.seratch.jslack.lightning.App;
@@ -17,9 +20,21 @@ public class EventsSample {
         App app = new App(config);
 
         app.event(MessageEvent.class, (event, ctx) -> {
-            log.info("message event (LightningEventHandler) - {}", event);
+            log.info("new message by a user - {}", event);
+            ctx.client().chatPostMessage(r -> r
+                    .text("Hi there!")
+                    .channel(event.getEvent().getChannel()));
             return ctx.ack();
         });
+        app.event(MessageBotEvent.class, (event, ctx) -> {
+            log.info("bot message - {}", event);
+            return ctx.ack();
+        });
+        app.event(MessageDeletedEvent.class, (event, ctx) -> {
+            log.info("message deleted - {}", event);
+            return ctx.ack();
+        });
+
         app.event(new MessageHandler() {
             @Override
             public void handle(MessagePayload payload) {

--- a/json-logs/samples/api/files.remote.share.json
+++ b/json-logs/samples/api/files.remote.share.json
@@ -86,7 +86,8 @@
     "thumb_1024_h": 12345,
     "image_exif_rotation": 12345,
     "original_w": 12345,
-    "original_h": 12345
+    "original_h": 12345,
+    "thumb_tiny": ""
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/events/MessageBotPayload.json
+++ b/json-logs/samples/events/MessageBotPayload.json
@@ -13,10 +13,18 @@
   "event_id": "",
   "event_time": 123,
   "event": {
-    "client_msg_id": "",
     "type": "message",
+    "subtype": "bot_message",
+    "bot_id": "",
+    "username": "",
+    "icons": {
+      "emoji": "",
+      "image_36": "",
+      "image_48": "",
+      "image_64": "",
+      "image_72": ""
+    },
     "channel": "",
-    "user": "",
     "text": "",
     "blocks": [
       {
@@ -465,13 +473,7 @@
       }
     ],
     "ts": "",
-    "parent_user_id": "",
-    "thread_ts": "",
     "event_ts": "",
-    "channel_type": "",
-    "edited": {
-      "user": "",
-      "ts": ""
-    }
+    "channel_type": ""
   }
 }

--- a/json-logs/samples/events/MessageChangedPayload.json
+++ b/json-logs/samples/events/MessageChangedPayload.json
@@ -1,0 +1,948 @@
+{
+  "token": "",
+  "enterprise_id": "",
+  "team_id": "",
+  "api_app_id": "",
+  "type": "",
+  "authed_users": [
+    ""
+  ],
+  "authed_teams": [
+    ""
+  ],
+  "event_id": "",
+  "event_time": 123,
+  "event": {
+    "type": "message",
+    "subtype": "message_changed",
+    "channel": "",
+    "hidden": false,
+    "message": {
+      "client_msg_id": "",
+      "type": "message",
+      "subtype": "",
+      "user": "",
+      "team": "",
+      "edited": {
+        "user": "",
+        "ts": ""
+      },
+      "text": "",
+      "blocks": [
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "fallback": "",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "channels_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channel": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "conversations_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversation": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "datepicker",
+              "fallback": "",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_date": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "external_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": ""
+              },
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "image",
+              "fallback": "",
+              "image_url": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "alt_text": ""
+            },
+            {
+              "type": "overflow",
+              "fallback": "",
+              "action_id": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "static_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "users_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_user": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            }
+          ],
+          "block_id": ""
+        },
+        {
+          "type": "context",
+          "elements": [
+            {
+              "type": "image",
+              "fallback": "",
+              "image_url": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "alt_text": ""
+            }
+          ],
+          "block_id": ""
+        },
+        {
+          "type": "divider",
+          "block_id": ""
+        },
+        {
+          "type": "image",
+          "fallback": "",
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "alt_text": "",
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "block_id": ""
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "block_id": "",
+          "fields": [
+            {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            {
+              "type": "mrkdwn",
+              "text": "",
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "image",
+            "fallback": "",
+            "image_url": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "alt_text": ""
+          }
+        }
+      ],
+      "attachments": [
+        {
+          "msg_subtype": "",
+          "fallback": "",
+          "callback_id": "",
+          "color": "",
+          "pretext": "",
+          "service_url": "",
+          "service_name": "",
+          "service_icon": "",
+          "author_name": "",
+          "author_link": "",
+          "author_icon": "",
+          "from_url": "",
+          "original_url": "",
+          "author_subname": "",
+          "channel_id": "",
+          "channel_name": "",
+          "id": 123,
+          "bot_id": "",
+          "indent": false,
+          "is_msg_unfurl": false,
+          "is_reply_unfurl": false,
+          "is_thread_root_unfurl": false,
+          "is_app_unfurl": false,
+          "app_unfurl_url": "",
+          "title": "",
+          "title_link": "",
+          "text": "",
+          "fields": [
+            {
+              "title": "",
+              "value": "",
+              "short": false
+            }
+          ],
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "thumb_url": "",
+          "thumb_width": 123,
+          "thumb_height": 123,
+          "video_html": "",
+          "video_html_width": 123,
+          "video_html_height": 123,
+          "footer": "",
+          "footer_icon": "",
+          "ts": "",
+          "mrkdwn_in": [
+            ""
+          ],
+          "actions": [
+            {
+              "id": "",
+              "name": "",
+              "text": "",
+              "style": "",
+              "type": "button",
+              "value": "",
+              "confirm": {
+                "title": "",
+                "text": "",
+                "ok_text": "",
+                "dismiss_text": ""
+              },
+              "data_source": "",
+              "min_query_length": 123,
+              "url": ""
+            }
+          ],
+          "filename": "",
+          "size": 123,
+          "mimetype": "",
+          "url": "",
+          "metadata": {
+            "thumb_64": false,
+            "thumb_80": false,
+            "thumb_160": false,
+            "original_w": 123,
+            "original_h": 123,
+            "thumb_360_w": 123,
+            "thumb_360_h": 123,
+            "format": "",
+            "extension": "",
+            "rotation": 123,
+            "thumb_tiny": ""
+          }
+        }
+      ],
+      "ts": "",
+      "user_team": "",
+      "source_team": "",
+      "is_starred": false
+    },
+    "previous_message": {
+      "client_msg_id": "",
+      "type": "message",
+      "subtype": "",
+      "user": "",
+      "team": "",
+      "edited": {
+        "user": "",
+        "ts": ""
+      },
+      "text": "",
+      "blocks": [
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "fallback": "",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "channels_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channel": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "conversations_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversation": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "datepicker",
+              "fallback": "",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_date": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "external_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": ""
+              },
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "image",
+              "fallback": "",
+              "image_url": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "alt_text": ""
+            },
+            {
+              "type": "overflow",
+              "fallback": "",
+              "action_id": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "static_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "users_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_user": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            }
+          ],
+          "block_id": ""
+        },
+        {
+          "type": "context",
+          "elements": [
+            {
+              "type": "image",
+              "fallback": "",
+              "image_url": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "alt_text": ""
+            }
+          ],
+          "block_id": ""
+        },
+        {
+          "type": "divider",
+          "block_id": ""
+        },
+        {
+          "type": "image",
+          "fallback": "",
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "alt_text": "",
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "block_id": ""
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "block_id": "",
+          "fields": [
+            {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            {
+              "type": "mrkdwn",
+              "text": "",
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "image",
+            "fallback": "",
+            "image_url": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "alt_text": ""
+          }
+        }
+      ],
+      "attachments": [
+        {
+          "msg_subtype": "",
+          "fallback": "",
+          "callback_id": "",
+          "color": "",
+          "pretext": "",
+          "service_url": "",
+          "service_name": "",
+          "service_icon": "",
+          "author_name": "",
+          "author_link": "",
+          "author_icon": "",
+          "from_url": "",
+          "original_url": "",
+          "author_subname": "",
+          "channel_id": "",
+          "channel_name": "",
+          "id": 123,
+          "bot_id": "",
+          "indent": false,
+          "is_msg_unfurl": false,
+          "is_reply_unfurl": false,
+          "is_thread_root_unfurl": false,
+          "is_app_unfurl": false,
+          "app_unfurl_url": "",
+          "title": "",
+          "title_link": "",
+          "text": "",
+          "fields": [
+            {
+              "title": "",
+              "value": "",
+              "short": false
+            }
+          ],
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "thumb_url": "",
+          "thumb_width": 123,
+          "thumb_height": 123,
+          "video_html": "",
+          "video_html_width": 123,
+          "video_html_height": 123,
+          "footer": "",
+          "footer_icon": "",
+          "ts": "",
+          "mrkdwn_in": [
+            ""
+          ],
+          "actions": [
+            {
+              "id": "",
+              "name": "",
+              "text": "",
+              "style": "",
+              "type": "button",
+              "value": "",
+              "confirm": {
+                "title": "",
+                "text": "",
+                "ok_text": "",
+                "dismiss_text": ""
+              },
+              "data_source": "",
+              "min_query_length": 123,
+              "url": ""
+            }
+          ],
+          "filename": "",
+          "size": 123,
+          "mimetype": "",
+          "url": "",
+          "metadata": {
+            "thumb_64": false,
+            "thumb_80": false,
+            "thumb_160": false,
+            "original_w": 123,
+            "original_h": 123,
+            "thumb_360_w": 123,
+            "thumb_360_h": 123,
+            "format": "",
+            "extension": "",
+            "rotation": 123,
+            "thumb_tiny": ""
+          }
+        }
+      ],
+      "ts": "",
+      "user_team": "",
+      "source_team": "",
+      "is_starred": false
+    },
+    "event_ts": "",
+    "ts": "",
+    "channel_type": ""
+  }
+}

--- a/json-logs/samples/events/MessageDeletedPayload.json
+++ b/json-logs/samples/events/MessageDeletedPayload.json
@@ -1,0 +1,485 @@
+{
+  "token": "",
+  "enterprise_id": "",
+  "team_id": "",
+  "api_app_id": "",
+  "type": "",
+  "authed_users": [
+    ""
+  ],
+  "authed_teams": [
+    ""
+  ],
+  "event_id": "",
+  "event_time": 123,
+  "event": {
+    "type": "message",
+    "subtype": "message_deleted",
+    "channel": "",
+    "hidden": false,
+    "deleted_ts": "",
+    "previous_message": {
+      "client_msg_id": "",
+      "type": "message",
+      "subtype": "",
+      "user": "",
+      "team": "",
+      "edited": {
+        "user": "",
+        "ts": ""
+      },
+      "text": "",
+      "blocks": [
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "fallback": "",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "channels_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channel": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "conversations_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversation": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "datepicker",
+              "fallback": "",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_date": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "external_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": ""
+              },
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "image",
+              "fallback": "",
+              "image_url": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "alt_text": ""
+            },
+            {
+              "type": "overflow",
+              "fallback": "",
+              "action_id": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "static_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            },
+            {
+              "type": "users_select",
+              "fallback": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_user": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                }
+              }
+            }
+          ],
+          "block_id": ""
+        },
+        {
+          "type": "context",
+          "elements": [
+            {
+              "type": "image",
+              "fallback": "",
+              "image_url": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "alt_text": ""
+            }
+          ],
+          "block_id": ""
+        },
+        {
+          "type": "divider",
+          "block_id": ""
+        },
+        {
+          "type": "image",
+          "fallback": "",
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "alt_text": "",
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "block_id": ""
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "block_id": "",
+          "fields": [
+            {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            {
+              "type": "mrkdwn",
+              "text": "",
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "image",
+            "fallback": "",
+            "image_url": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "alt_text": ""
+          }
+        }
+      ],
+      "attachments": [
+        {
+          "msg_subtype": "",
+          "fallback": "",
+          "callback_id": "",
+          "color": "",
+          "pretext": "",
+          "service_url": "",
+          "service_name": "",
+          "service_icon": "",
+          "author_name": "",
+          "author_link": "",
+          "author_icon": "",
+          "from_url": "",
+          "original_url": "",
+          "author_subname": "",
+          "channel_id": "",
+          "channel_name": "",
+          "id": 123,
+          "bot_id": "",
+          "indent": false,
+          "is_msg_unfurl": false,
+          "is_reply_unfurl": false,
+          "is_thread_root_unfurl": false,
+          "is_app_unfurl": false,
+          "app_unfurl_url": "",
+          "title": "",
+          "title_link": "",
+          "text": "",
+          "fields": [
+            {
+              "title": "",
+              "value": "",
+              "short": false
+            }
+          ],
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "thumb_url": "",
+          "thumb_width": 123,
+          "thumb_height": 123,
+          "video_html": "",
+          "video_html_width": 123,
+          "video_html_height": 123,
+          "footer": "",
+          "footer_icon": "",
+          "ts": "",
+          "mrkdwn_in": [
+            ""
+          ],
+          "actions": [
+            {
+              "id": "",
+              "name": "",
+              "text": "",
+              "style": "",
+              "type": "button",
+              "value": "",
+              "confirm": {
+                "title": "",
+                "text": "",
+                "ok_text": "",
+                "dismiss_text": ""
+              },
+              "data_source": "",
+              "min_query_length": 123,
+              "url": ""
+            }
+          ],
+          "filename": "",
+          "size": 123,
+          "mimetype": "",
+          "url": "",
+          "metadata": {
+            "thumb_64": false,
+            "thumb_80": false,
+            "thumb_160": false,
+            "original_w": 123,
+            "original_h": 123,
+            "thumb_360_w": 123,
+            "thumb_360_h": 123,
+            "format": "",
+            "extension": "",
+            "rotation": 123,
+            "thumb_tiny": ""
+          }
+        }
+      ],
+      "is_starred": false,
+      "ts": ""
+    },
+    "event_ts": "",
+    "ts": "",
+    "channel_type": ""
+  }
+}

--- a/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
+++ b/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
@@ -13,9 +13,10 @@
   "event_id": "",
   "event_time": 123,
   "event": {
-    "client_msg_id": "",
     "type": "message",
+    "subtype": "ekm_access_denied",
     "channel": "",
+    "hidden": false,
     "user": "",
     "text": "",
     "blocks": [
@@ -464,14 +465,8 @@
         }
       }
     ],
-    "ts": "",
-    "parent_user_id": "",
-    "thread_ts": "",
     "event_ts": "",
-    "channel_type": "",
-    "edited": {
-      "user": "",
-      "ts": ""
-    }
+    "ts": "",
+    "channel_type": ""
   }
 }

--- a/json-logs/samples/events/MessageMePayload.json
+++ b/json-logs/samples/events/MessageMePayload.json
@@ -1,0 +1,26 @@
+{
+  "token": "",
+  "enterprise_id": "",
+  "team_id": "",
+  "api_app_id": "",
+  "type": "",
+  "authed_users": [
+    ""
+  ],
+  "authed_teams": [
+    ""
+  ],
+  "event_id": "",
+  "event_time": 123,
+  "event": {
+    "type": "message",
+    "subtype": "me_message",
+    "channel": "",
+    "username": "",
+    "bot_id": "",
+    "text": "",
+    "event_ts": "",
+    "ts": "",
+    "channel_type": ""
+  }
+}

--- a/json-logs/samples/events/MessageThreadBroadcastPayload.json
+++ b/json-logs/samples/events/MessageThreadBroadcastPayload.json
@@ -15,8 +15,25 @@
   "event": {
     "client_msg_id": "",
     "type": "message",
+    "subtype": "thread_broadcast",
     "channel": "",
     "user": "",
+    "root": {
+      "text": "",
+      "username": "",
+      "bot_id": "",
+      "mrkdwn": false,
+      "type": "",
+      "subtype": "",
+      "thread_ts": "",
+      "reply_count": 123,
+      "reply_users_count": 123,
+      "latest_reply": "",
+      "subscribed": false,
+      "last_read": "",
+      "unread_count": 123,
+      "ts": ""
+    },
     "text": "",
     "blocks": [
       {
@@ -465,13 +482,8 @@
       }
     ],
     "ts": "",
-    "parent_user_id": "",
     "thread_ts": "",
     "event_ts": "",
-    "channel_type": "",
-    "edited": {
-      "user": "",
-      "ts": ""
-    }
+    "channel_type": ""
   }
 }

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -451,37 +451,12 @@
     }
   ],
   "ts": "",
+  "parent_user_id": "",
   "thread_ts": "",
   "event_ts": "",
   "channel_type": "",
   "edited": {
     "user": "",
     "ts": ""
-  },
-  "subtype": "",
-  "hidden": false,
-  "deleted_ts": "",
-  "is_starred": false,
-  "pinned_to": [
-    ""
-  ],
-  "reactions": [
-    {
-      "name": "",
-      "count": 123,
-      "users": [
-        ""
-      ],
-      "url": ""
-    }
-  ],
-  "bot_id": "",
-  "username": "",
-  "icons": {
-    "emoji": "",
-    "image_36": "",
-    "image_48": "",
-    "image_64": "",
-    "image_72": ""
   }
 }


### PR DESCRIPTION
I hate to say this but I have to introduce a breaking change. I noticed this library needs to be updated with breaking changes to support type:message-related events correctly.

I believe it used to be different but nowadays there are several patterns with `message` typed events. If they are almost the same, it may be possible to go with a single class that has all the possible fields. However, unfortunately, the structure of the event data varies. So, I decided to have corresponding event data classes for those.

Here are the breaking changes I'm going to introduce:

* Only newly posted messages will be recognized as `MessageEvent`
* Other events having `subtype` (`bot_message`, `message_changed`, `message_deleted`, `thread_broadcast`, `ekm_access_denied`, and `me_message`) are no longer available as `MessageEvent`. They have corresponding classes (e.g., `MessageBotEvent`)

If you have `EventHandler` / `LightningEventHandler` handling `MessageEvent` and the code expects to receive `bot_message` events as `MessageEvent`, the code requires changes to have a `MessageBotEvent` handler as well.

I believe this change is reasonable enough to deal with reality. But I'm sorry to bring this.