### PR TITLE
Add oauth.v2.access error handler

### DIFF
--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/App.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/App.java
@@ -69,6 +69,7 @@ public class App {
     private OAuthV2SuccessHandler oAuthV2SuccessHandler = new OAuthV2DefaultSuccessHandler(installationService);
     private OAuthErrorHandler oAuthErrorHandler = new OAuthDefaultErrorHandler();
     private OAuthAccessErrorHandler oAuthAccessErrorHandler = new OAuthDefaultAccessErrorHandler();
+    private OAuthV2AccessErrorHandler oAuthV2AccessErrorHandler = new OAuthV2DefaultAccessErrorHandler();
     private OAuthStateErrorHandler oAuthStateErrorHandler = new OAuthDefaultStateErrorHandler();
     private OAuthExceptionHandler oAuthExceptionHandler = new OAuthDefaultExceptionHandler();
 
@@ -380,6 +381,11 @@ public class App {
 
     public App oauthCallbackAccessError(OAuthAccessErrorHandler handler) {
         oAuthAccessErrorHandler = handler;
+        return this;
+    }
+
+    public App oauthCallbackAccessError(OAuthV2AccessErrorHandler handler) {
+        oAuthV2AccessErrorHandler = handler;
         return this;
     }
 
@@ -728,6 +734,7 @@ public class App {
                         oAuthErrorHandler,
                         oAuthStateErrorHandler,
                         oAuthAccessErrorHandler,
+                        oAuthV2AccessErrorHandler,
                         oAuthExceptionHandler
                 );
             }

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthV2AccessErrorHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/OAuthV2AccessErrorHandler.java
@@ -1,0 +1,12 @@
+package com.github.seratch.jslack.lightning.handler;
+
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+
+@FunctionalInterface
+public interface OAuthV2AccessErrorHandler {
+
+    Response handle(OAuthCallbackRequest req, OAuthV2AccessResponse apiResponse);
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthV2DefaultAccessErrorHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthV2DefaultAccessErrorHandler.java
@@ -1,0 +1,23 @@
+package com.github.seratch.jslack.lightning.handler.builtin;
+
+import com.github.seratch.jslack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.github.seratch.jslack.lightning.handler.OAuthV2AccessErrorHandler;
+import com.github.seratch.jslack.lightning.request.builtin.OAuthCallbackRequest;
+import com.github.seratch.jslack.lightning.response.Response;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class OAuthV2DefaultAccessErrorHandler implements OAuthV2AccessErrorHandler {
+
+    @Override
+    public Response handle(OAuthCallbackRequest req, OAuthV2AccessResponse apiResponse) {
+        log.error("Failed to run an oauth.v2.access API call: {} - {}", apiResponse.getError(), apiResponse);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Location", req.getContext().getOauthCancellationUrl());
+        return Response.builder().statusCode(302).headers(headers).build();
+    }
+
+}

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/DefaultOAuthCallbackService.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/service/builtin/DefaultOAuthCallbackService.java
@@ -24,6 +24,7 @@ public class DefaultOAuthCallbackService implements OAuthCallbackService {
     private final OAuthErrorHandler errorHandler;
     private final OAuthStateErrorHandler stateErrorHandler;
     private final OAuthAccessErrorHandler accessErrorHandler;
+    private final OAuthV2AccessErrorHandler accessV2ErrorHandler;
     private final OAuthExceptionHandler exceptionHandler;
 
     public DefaultOAuthCallbackService(
@@ -34,6 +35,7 @@ public class DefaultOAuthCallbackService implements OAuthCallbackService {
             OAuthErrorHandler errorHandler,
             OAuthStateErrorHandler stateErrorHandler,
             OAuthAccessErrorHandler accessErrorHandler,
+            OAuthV2AccessErrorHandler accessV2ErrorHandler,
             OAuthExceptionHandler exceptionHandler) {
         this.config = config;
         this.stateService = stateService;
@@ -42,6 +44,7 @@ public class DefaultOAuthCallbackService implements OAuthCallbackService {
         this.errorHandler = errorHandler;
         this.stateErrorHandler = stateErrorHandler;
         this.accessErrorHandler = accessErrorHandler;
+        this.accessV2ErrorHandler = accessV2ErrorHandler;
         this.exceptionHandler = exceptionHandler;
 
         SlackAppConfig slackAppConfig = SlackAppConfig.builder()
@@ -65,7 +68,7 @@ public class DefaultOAuthCallbackService implements OAuthCallbackService {
                         stateService.consume(payload.getState());
                         return successV2Handler.handle(request, oauthAccess);
                     } else {
-                        return successV2Handler.handle(request, oauthAccess);
+                        return accessV2ErrorHandler.handle(request, oauthAccess);
                     }
                 } else {
                     OAuthAccessResponse oauthAccess = operator.callOAuthAccessMethod(payload);


### PR DESCRIPTION
This pull request fixes a bug where Lightning apps don't have any error handlers for `oauth.v2.access` error patterns.