### PR TITLE
Skip team auth for URL verification requests

### DIFF
--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/MultiTeamsAuthorization.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/middleware/builtin/MultiTeamsAuthorization.java
@@ -9,6 +9,7 @@ import com.github.seratch.jslack.lightning.middleware.MiddlewareChain;
 import com.github.seratch.jslack.lightning.model.Bot;
 import com.github.seratch.jslack.lightning.model.Installer;
 import com.github.seratch.jslack.lightning.request.Request;
+import com.github.seratch.jslack.lightning.request.RequestType;
 import com.github.seratch.jslack.lightning.response.Response;
 import com.github.seratch.jslack.lightning.service.InstallationService;
 import lombok.extern.slf4j.Slf4j;
@@ -39,9 +40,11 @@ public class MultiTeamsAuthorization implements Middleware {
 
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
-        if (isNoSlackSignatureRequest(req.getRequestType())) {
+        if (isNoSlackSignatureRequest(req.getRequestType())
+                || req.getRequestType() == RequestType.UrlVerification) {
             return chain.next(req);
         }
+
         Context context = req.getContext();
 
         String botToken = null;


### PR DESCRIPTION
URL verification requests are teamless, so we cannot verify our connectivity to them.