### PR TITLE
[Breaking change] Commonize response_metadata for error messages

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/teams/AdminTeamsCreateResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/teams/AdminTeamsCreateResponse.java
@@ -1,9 +1,8 @@
 package com.github.seratch.jslack.api.methods.response.admin.teams;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class AdminTeamsCreateResponse implements SlackApiResponse {
@@ -15,11 +14,6 @@ public class AdminTeamsCreateResponse implements SlackApiResponse {
     private String provided;
 
     private String team; // created team id
-    private ResponseMetadata responseMetadata;
 
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
-
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersAssignResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersAssignResponse.java
@@ -1,9 +1,8 @@
 package com.github.seratch.jslack.api.methods.response.admin.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class AdminUsersAssignResponse implements SlackApiResponse {
@@ -14,10 +13,5 @@ public class AdminUsersAssignResponse implements SlackApiResponse {
     private String needed;
     private String provided;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersInviteResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersInviteResponse.java
@@ -1,9 +1,8 @@
 package com.github.seratch.jslack.api.methods.response.admin.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class AdminUsersInviteResponse implements SlackApiResponse {
@@ -14,11 +13,5 @@ public class AdminUsersInviteResponse implements SlackApiResponse {
     private String needed;
     private String provided;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
-
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersRemoveResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersRemoveResponse.java
@@ -1,9 +1,8 @@
 package com.github.seratch.jslack.api.methods.response.admin.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class AdminUsersRemoveResponse implements SlackApiResponse {
@@ -14,11 +13,5 @@ public class AdminUsersRemoveResponse implements SlackApiResponse {
     private String needed;
     private String provided;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
-
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersSetAdminResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersSetAdminResponse.java
@@ -1,9 +1,8 @@
 package com.github.seratch.jslack.api.methods.response.admin.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class AdminUsersSetAdminResponse implements SlackApiResponse {
@@ -14,11 +13,5 @@ public class AdminUsersSetAdminResponse implements SlackApiResponse {
     private String needed;
     private String provided;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
-
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersSetOwnerResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersSetOwnerResponse.java
@@ -1,9 +1,8 @@
 package com.github.seratch.jslack.api.methods.response.admin.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class AdminUsersSetOwnerResponse implements SlackApiResponse {
@@ -14,11 +13,5 @@ public class AdminUsersSetOwnerResponse implements SlackApiResponse {
     private String needed;
     private String provided;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
-
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersSetRegularResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/admin/users/AdminUsersSetRegularResponse.java
@@ -1,9 +1,8 @@
 package com.github.seratch.jslack.api.methods.response.admin.users;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class AdminUsersSetRegularResponse implements SlackApiResponse {
@@ -14,11 +13,5 @@ public class AdminUsersSetRegularResponse implements SlackApiResponse {
     private String needed;
     private String provided;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
-
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/chat/ChatPostMessageResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/chat/ChatPostMessageResponse.java
@@ -1,10 +1,9 @@
 package com.github.seratch.jslack.api.methods.response.chat;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import com.github.seratch.jslack.api.model.Message;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class ChatPostMessageResponse implements SlackApiResponse {
@@ -15,12 +14,7 @@ public class ChatPostMessageResponse implements SlackApiResponse {
     private String needed;
     private String provided;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
+    private ErrorResponseMetadata responseMetadata;
 
     private String channel;
     private String ts;

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/pins/PinsAddResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/pins/PinsAddResponse.java
@@ -1,9 +1,8 @@
 package com.github.seratch.jslack.api.methods.response.pins;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class PinsAddResponse implements SlackApiResponse {
@@ -14,11 +13,5 @@ public class PinsAddResponse implements SlackApiResponse {
     private String needed;
     private String provided;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
-
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/views/ViewsOpenResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/views/ViewsOpenResponse.java
@@ -1,10 +1,9 @@
 package com.github.seratch.jslack.api.methods.response.views;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import com.github.seratch.jslack.api.model.view.View;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class ViewsOpenResponse implements SlackApiResponse {
@@ -17,10 +16,5 @@ public class ViewsOpenResponse implements SlackApiResponse {
 
     private View view;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/views/ViewsPublishResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/views/ViewsPublishResponse.java
@@ -1,10 +1,9 @@
 package com.github.seratch.jslack.api.methods.response.views;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import com.github.seratch.jslack.api.model.view.View;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class ViewsPublishResponse implements SlackApiResponse {
@@ -17,10 +16,5 @@ public class ViewsPublishResponse implements SlackApiResponse {
 
     private View view;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/views/ViewsPushResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/views/ViewsPushResponse.java
@@ -1,10 +1,9 @@
 package com.github.seratch.jslack.api.methods.response.views;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import com.github.seratch.jslack.api.model.view.View;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class ViewsPushResponse implements SlackApiResponse {
@@ -17,10 +16,5 @@ public class ViewsPushResponse implements SlackApiResponse {
 
     private View view;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/views/ViewsUpdateResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/views/ViewsUpdateResponse.java
@@ -1,10 +1,9 @@
 package com.github.seratch.jslack.api.methods.response.views;
 
 import com.github.seratch.jslack.api.methods.SlackApiResponse;
+import com.github.seratch.jslack.api.model.ErrorResponseMetadata;
 import com.github.seratch.jslack.api.model.view.View;
 import lombok.Data;
-
-import java.util.List;
 
 @Data
 public class ViewsUpdateResponse implements SlackApiResponse {
@@ -17,10 +16,5 @@ public class ViewsUpdateResponse implements SlackApiResponse {
 
     private View view;
 
-    private ResponseMetadata responseMetadata;
-
-    @Data
-    public static class ResponseMetadata {
-        private List<String> messages;
-    }
+    private ErrorResponseMetadata responseMetadata;
 }

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/ErrorResponseMetadata.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/ErrorResponseMetadata.java
@@ -1,0 +1,11 @@
+package com.github.seratch.jslack.api.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ErrorResponseMetadata {
+
+    private List<String> messages;
+}

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -469,9 +469,14 @@
           ""
         ],
         "video": [
-          ""
+          {
+            "id": "",
+            "name": "",
+            "image": ""
+          }
         ]
-      }
+      },
+      "received_esc_route_to_channel_awareness_message": false
     },
     "icon": {
       "image_34": "https://www.example.com/",


### PR DESCRIPTION
This pull request commonizes existing `response_metadata` fields to a single class. The data structure tends to be widely used in recently added Slack APIs. I've been working with them by having internal classes but it's about time to stop doing that.

```js
{
  "ok": false,
  "error": "invalid_arguments",
  "response_metadata": {
    "messages": [
      "[ERROR] missing required field: title [json-pointer:/view]",
      "[ERROR] missing required field: blocks [json-pointer:/view]",
      "[ERROR] missing required field: type [json-pointer:/view]"
    ]
  }
}
```

This one may be a breaking change to existing apps. I will bump the minor version since the next release.