### PR TITLE
Add bot_id in response for auth.test

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/auth/AuthTestResponse.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/methods/response/auth/AuthTestResponse.java
@@ -15,6 +15,7 @@ public class AuthTestResponse implements SlackApiResponse {
     private String url;
     private String team;
     private String user;
+    private String botId; // only for bot token
     private String teamId;
     private String userId;
     private String enterpriseId;

--- a/jslack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
@@ -29,7 +29,7 @@ public class auth_Test {
     }
 
     @Test
-    public void authTest() throws IOException, SlackApiException {
+    public void authTest_user() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
         AuthTestResponse response = slack.methods().authTest(req -> req.token(token));
         assertThat(response.getError(), is(nullValue()));
@@ -38,8 +38,17 @@ public class auth_Test {
     }
 
     @Test
-    public void authTest2() throws IOException, SlackApiException {
+    public void authTest_user_2() throws IOException, SlackApiException {
         String token = System.getenv(Constants.SLACK_TEST_OAUTH_ACCESS_TOKEN);
+        AuthTestResponse response = slack.methods(token).authTest(req -> req);
+        assertThat(response.getError(), is(nullValue()));
+        assertThat(response.isOk(), is(true));
+        assertThat(response.getUrl(), is(notNullValue()));
+    }
+
+    @Test
+    public void authTest_bot() throws IOException, SlackApiException {
+        String token = System.getenv(Constants.SLACK_BOT_USER_TEST_OAUTH_ACCESS_TOKEN);
         AuthTestResponse response = slack.methods(token).authTest(req -> req);
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));

--- a/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/util/JsonPayloadExtractor.java
+++ b/jslack-app-backend/src/main/java/com/github/seratch/jslack/app_backend/util/JsonPayloadExtractor.java
@@ -19,7 +19,7 @@ public class JsonPayloadExtractor {
 
     public String extractIfExists(String requestBody) {
 
-        if (requestBody == null) {
+        if (requestBody == null || requestBody.trim().length() == 0) {
             return null;
         }
 

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/app.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/app.kt
@@ -2,6 +2,7 @@ package examples.oauth_flow
 
 import com.github.seratch.jslack.lightning.App
 import com.github.seratch.jslack.lightning.jetty.SlackAppServer
+import com.github.seratch.jslack.lightning.response.Response
 import org.slf4j.LoggerFactory
 import util.ResourceLoader
 
@@ -32,6 +33,13 @@ fun main() {
 
     val oauthConfig = ResourceLoader.loadAppConfig()
     val oauthApp = App(oauthConfig).asOAuthApp(true)
+
+    oauthApp.endpoint("GET", "/slack/oauth/completion") { _, _ ->
+        Response.json(200, mapOf("message" to "Thanks!"))
+    }
+    oauthApp.endpoint("GET", "/slack/oauth/cancellation") { _, _ ->
+        Response.json(200, mapOf("message" to "Something wrong!"))
+    }
 
     val server = SlackAppServer(mapOf(
             "/slack/events" to mainApp,

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/aws.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/aws.kt
@@ -2,6 +2,7 @@ package examples.oauth_flow
 
 import com.github.seratch.jslack.lightning.App
 import com.github.seratch.jslack.lightning.jetty.SlackAppServer
+import com.github.seratch.jslack.lightning.response.Response
 import com.github.seratch.jslack.lightning.service.builtin.AmazonS3InstallationService
 import com.github.seratch.jslack.lightning.service.builtin.AmazonS3OAuthStateService
 import org.slf4j.LoggerFactory
@@ -45,6 +46,13 @@ fun main() {
     oauthApp.service(installationService)
     // for state parameter in OAuth flow
     oauthApp.service(AmazonS3OAuthStateService(awsS3BucketName))
+
+    oauthApp.endpoint("GET", "/slack/oauth/completion") { _, _ ->
+        Response.json(200, mapOf("message" to "Thanks!"))
+    }
+    oauthApp.endpoint("GET", "/slack/oauth/cancellation") { _, _ ->
+        Response.json(200, mapOf("message" to "Something wrong!"))
+    }
 
     val server = SlackAppServer(mapOf(
             "/slack/events" to mainApp,

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow_v2/v2_app.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow_v2/v2_app.kt
@@ -2,6 +2,7 @@ package examples.oauth_flow_v2
 
 import com.github.seratch.jslack.lightning.App
 import com.github.seratch.jslack.lightning.jetty.SlackAppServer
+import com.github.seratch.jslack.lightning.response.Response
 import org.slf4j.LoggerFactory
 import util.ResourceLoader
 
@@ -34,6 +35,13 @@ fun main() {
     val oauthConfig = ResourceLoader.loadAppConfig("appConfig_GBP.json")
     oauthConfig.isGranularBotPermissionsEnabled = true
     val oauthApp = App(oauthConfig).asOAuthApp(true)
+
+    oauthApp.endpoint("GET", "/slack/oauth/completion") { _, _ ->
+        Response.json(200, mapOf("message" to "Thanks!"))
+    }
+    oauthApp.endpoint("GET", "/slack/oauth/cancellation") { _, _ ->
+        Response.json(200, mapOf("message" to "Something wrong!"))
+    }
 
     val server = SlackAppServer(mapOf(
             "/slack/events" to mainApp,

--- a/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow_v2/v2_aws.kt
+++ b/jslack-lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow_v2/v2_aws.kt
@@ -2,6 +2,7 @@ package examples.oauth_flow_v2
 
 import com.github.seratch.jslack.lightning.App
 import com.github.seratch.jslack.lightning.jetty.SlackAppServer
+import com.github.seratch.jslack.lightning.response.Response
 import com.github.seratch.jslack.lightning.service.builtin.AmazonS3InstallationService
 import com.github.seratch.jslack.lightning.service.builtin.AmazonS3OAuthStateService
 import org.slf4j.LoggerFactory
@@ -47,6 +48,13 @@ fun main() {
     oauthApp.service(installationService)
     // for state parameter in OAuth flow
     oauthApp.service(AmazonS3OAuthStateService(awsS3BucketName))
+
+    oauthApp.endpoint("GET", "/slack/oauth/completion") { _, _ ->
+        Response.json(200, mapOf("message" to "Thanks!"))
+    }
+    oauthApp.endpoint("GET", "/slack/oauth/cancellation") { _, _ ->
+        Response.json(200, mapOf("message" to "Something wrong!"))
+    }
 
     val server = SlackAppServer(mapOf(
             "/slack/events" to mainApp,

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultStateErrorHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultStateErrorHandler.java
@@ -13,7 +13,7 @@ public class OAuthDefaultStateErrorHandler implements OAuthStateErrorHandler {
 
     @Override
     public Response handle(OAuthCallbackRequest req) {
-        log.warn("Invalid state parameter detected - TODO");
+        log.warn("Invalid state parameter detected - payload: {}",  req.getPayload());
         Map<String, String> headers = new HashMap<>();
         headers.put("Location", req.getContext().getOauthCancellationUrl());
         return Response.builder().statusCode(302).headers(headers).build();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultSuccessHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthDefaultSuccessHandler.java
@@ -1,8 +1,8 @@
 package com.github.seratch.jslack.lightning.handler.builtin;
 
 import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.methods.response.auth.AuthTestResponse;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthAccessResponse;
-import com.github.seratch.jslack.api.methods.response.users.UsersInfoResponse;
 import com.github.seratch.jslack.lightning.context.builtin.OAuthCallbackContext;
 import com.github.seratch.jslack.lightning.handler.OAuthSuccessHandler;
 import com.github.seratch.jslack.lightning.model.Installer;
@@ -54,14 +54,14 @@ public class OAuthDefaultSuccessHandler implements OAuthSuccessHandler {
             i = i.botUserId(o.getBot().getBotUserId());
             i = i.botAccessToken(o.getBot().getBotAccessToken());
             try {
-                UsersInfoResponse user = context.client().usersInfo(r -> r.user(o.getBot().getBotUserId()));
-                if (user.isOk()) {
-                    i = i.botId(user.getUser().getProfile().getBotId());
+                AuthTestResponse authTest = context.client().authTest(r -> r);
+                if (authTest.isOk()) {
+                    i = i.botId(authTest.getBotId());
                 } else {
-                    log.warn("Failed to call users.info to fetch botId for the user: {} - {}", o.getBot().getBotUserId(), user.getError());
+                    log.warn("Failed to call auth.test to fetch botId for the user: {} - {}", o.getBot().getBotUserId(), authTest.getError());
                 }
             } catch (SlackApiException | IOException e) {
-                log.warn("Failed to call users.info to fetch botId for the user: {}", o.getBot().getBotUserId(), e);
+                log.warn("Failed to call auth.test to fetch botId for the user: {}", o.getBot().getBotUserId(), e);
             }
         }
         Installer installer = i.build();

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthV2DefaultSuccessHandler.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/handler/builtin/OAuthV2DefaultSuccessHandler.java
@@ -1,8 +1,8 @@
 package com.github.seratch.jslack.lightning.handler.builtin;
 
 import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.methods.response.auth.AuthTestResponse;
 import com.github.seratch.jslack.api.methods.response.oauth.OAuthV2AccessResponse;
-import com.github.seratch.jslack.api.methods.response.users.UsersInfoResponse;
 import com.github.seratch.jslack.lightning.context.builtin.OAuthCallbackContext;
 import com.github.seratch.jslack.lightning.handler.OAuthV2SuccessHandler;
 import com.github.seratch.jslack.lightning.model.Installer;
@@ -56,14 +56,14 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
 
         if (o.getBotUserId() != null) {
             try {
-                UsersInfoResponse user = context.client().usersInfo(r -> r.user(o.getBotUserId()));
-                if (user.isOk()) {
-                    i = i.botId(user.getUser().getProfile().getBotId());
+                AuthTestResponse authTest = context.client().authTest(r -> r);
+                if (authTest.isOk()) {
+                    i = i.botId(authTest.getBotId());
                 } else {
-                    log.warn("Failed to call users.info to fetch botId for the user: {} - {}", o.getBotUserId(), user.getError());
+                    log.warn("Failed to call auth.test to fetch botId for the user: {} - {}", o.getBotUserId(), authTest.getError());
                 }
             } catch (SlackApiException | IOException e) {
-                log.warn("Failed to call users.info to fetch botId for the user: {}", o.getBotUserId(), e);
+                log.warn("Failed to call auth.test to fetch botId for the user: {}", o.getBotUserId(), e);
             }
         }
 

--- a/json-logs/samples/api/auth.test.json
+++ b/json-logs/samples/api/auth.test.json
@@ -6,6 +6,7 @@
   "team_id": "T00000000",
   "user_id": "U00000000",
   "enterprise_id": "E00000000",
+  "bot_id": "B00000000",
   "error": "",
   "needed": "",
   "provided": ""


### PR DESCRIPTION
This pull request adds `bot_id` in response for `auth.test` API. https://api.slack.com/methods/auth.test