### PR TITLE
Add query string support in Lightning web endpoints

### DIFF
--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/WebEndpointRequest.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/request/WebEndpointRequest.java
@@ -8,12 +8,15 @@ public class WebEndpointRequest {
 
     private String clientIpAddress;
 
+    private final String queryString;
     private final String requestBody;
     private final RequestHeaders headers;
 
     public WebEndpointRequest(
+            String queryString,
             String requestBody,
             RequestHeaders headers) {
+        this.queryString = queryString;
         this.requestBody = requestBody;
         this.headers = headers;
     }
@@ -22,6 +25,10 @@ public class WebEndpointRequest {
 
     public WebEndpointContext getContext() {
         return context;
+    }
+
+    public String getQueryString() {
+        return queryString;
     }
 
     public String getRequestBodyAsString() {

--- a/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/WebEndpointServletAdapter.java
+++ b/jslack-lightning/src/main/java/com/github/seratch/jslack/lightning/servlet/WebEndpointServletAdapter.java
@@ -21,11 +21,12 @@ public class WebEndpointServletAdapter {
     }
 
     public WebEndpointRequest buildSlackRequest(HttpServletRequest req) throws IOException {
+        String queryString = req.getQueryString();
         String requestBody = doReadRequestBodyAsString(req);
         RequestHeaders headers = new RequestHeaders(toHeaderMap(req));
         WebEndpointRequest slackRequest = null;
         try {
-            slackRequest = new WebEndpointRequest(requestBody, headers);
+            slackRequest = new WebEndpointRequest(queryString, requestBody, headers);
             return slackRequest;
         } finally {
             if (slackRequest != null) {

--- a/jslack-lightning/src/test/java/test_locally/servlet_test/EndpointTest.java
+++ b/jslack-lightning/src/test/java/test_locally/servlet_test/EndpointTest.java
@@ -1,0 +1,89 @@
+package test_locally.servlet_test;
+
+import com.github.seratch.jslack.lightning.App;
+import com.github.seratch.jslack.lightning.AppConfig;
+import com.github.seratch.jslack.lightning.WebEndpoint;
+import com.github.seratch.jslack.lightning.handler.WebEndpointHandler;
+import com.github.seratch.jslack.lightning.response.Response;
+import com.github.seratch.jslack.lightning.servlet.WebEndpointServlet;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlet.ServletTester;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Slf4j
+public class EndpointTest {
+
+    private AppConfig appConfig = new AppConfig();
+    // For real apps, you should not go with empty middleware
+    private App app = new App(appConfig, Collections.emptyList());
+
+    {
+        app.endpoint("GET", "/hello-world", (req, ctx) -> {
+            Map<String, String> body = new HashMap<>();
+            body.put("message", "Hello World!");
+            body.put("query", req.getQueryString());
+            return Response.json(200, body);
+        });
+    }
+
+    @Before
+    public void setUp() {
+        app.start();
+    }
+
+    @After
+    public void tearDown() {
+        app.stop();
+    }
+
+    @Test
+    public void helloWorld() throws Exception {
+        ServletTester tester = new ServletTester();
+        Map.Entry<WebEndpoint, WebEndpointHandler> e = app.getWebEndpointHandlers().entrySet().iterator().next();
+        WebEndpointServlet app = new WebEndpointServlet(e.getKey(), e.getValue(), appConfig);
+        tester.addServlet(new ServletHolder(app), "/");
+        tester.start();
+
+        HttpTester.Request request = TestUtils.prepareRequest();
+        request.setURI("/hello-world");
+        request.setMethod("GET");
+        request.setContent("dummy");
+
+        HttpTester.Response response = HttpTester.parseResponse(tester.getResponses(request.generate()));
+
+        assertThat(response.getStatus(), is(equalTo(200)));
+        assertThat(response.getContent(), is(equalTo("{\"message\":\"Hello World!\"}")));
+    }
+
+    @Test
+    public void helloWorld_with_query_string() throws Exception {
+        ServletTester tester = new ServletTester();
+        Map.Entry<WebEndpoint, WebEndpointHandler> e = app.getWebEndpointHandlers().entrySet().iterator().next();
+        WebEndpointServlet app = new WebEndpointServlet(e.getKey(), e.getValue(), appConfig);
+        tester.addServlet(new ServletHolder(app), "/");
+        tester.start();
+
+        HttpTester.Request request = TestUtils.prepareRequest();
+        request.setURI("/hello-world?foo=bar&baz=var");
+        request.setMethod("GET");
+        request.setContent("dummy");
+
+        HttpTester.Response response = HttpTester.parseResponse(tester.getResponses(request.generate()));
+
+        assertThat(response.getStatus(), is(equalTo(200)));
+        assertThat(response.getContent(),
+                is(equalTo("{\"query\":\"foo\\u003dbar\\u0026baz\\u003dvar\",\"message\":\"Hello World!\"}")));
+    }
+}


### PR DESCRIPTION
This pull request adds query string data to the arguments of Lightning web endpoint handler. This may be helpful for some situations like having tracking parameters.