### PR TITLE
Remove conversation.members as it has not been working

### DIFF
--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Conversation.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/Conversation.java
@@ -38,7 +38,6 @@ public class Conversation {
     private List<String> previousNames;
     @SerializedName("num_members")
     private Integer numOfMembers;
-    private List<String> members;
     private Latest latest;
     private String locale;
     @SerializedName("unread_count")


### PR DESCRIPTION
I just noticed somehow `Conversation` class has `members` field in it but it has not been working from the beginning. When API users need to know user ids that belong to a channel, calling `conversations.members` API is necessary.

I don't think this is a breaking change as it never worked correctly and nobody depends on the field.