### PR TITLE
Add failOnUnknownProperties flag to make JSON parser's behavior consistent

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/SlackConfig.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/SlackConfig.java
@@ -23,6 +23,11 @@ public class SlackConfig {
         }
 
         @Override
+        public void setFailOnUnknownProperties(boolean failOnUnknownProperties) {
+            throwException();
+        }
+
+        @Override
         public void setPrettyResponseLoggingEnabled(boolean prettyResponseLoggingEnabled) {
             throwException();
         }
@@ -79,6 +84,11 @@ public class SlackConfig {
      * Don't enable this flag in production. This flag enables some validation features for development.
      */
     private boolean libraryMaintainerMode = false;
+
+    /**
+     * If you would like to detect unknown properties by throwing exceptions, set this flag as true.
+     */
+    private boolean failOnUnknownProperties = false;
 
     /**
      * Slack Web API client verifies the existence of tokens before sending HTTP requests to Slack servers.

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/common/json/GsonFactory.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/common/json/GsonFactory.java
@@ -28,12 +28,12 @@ public class GsonFactory {
     public static Gson createSnakeCase(SlackConfig config) {
         GsonBuilder gsonBuilder = new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory())
-                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory())
-                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory())
-                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory())
-                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory());
-        if (config.isLibraryMaintainerMode()) {
+                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory(config.isFailOnUnknownProperties()))
+                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory(config.isFailOnUnknownProperties()))
+                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory(config.isFailOnUnknownProperties()))
+                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory(config.isFailOnUnknownProperties()))
+                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(config.isFailOnUnknownProperties()));
+        if (config.isFailOnUnknownProperties() || config.isLibraryMaintainerMode()) {
             gsonBuilder = gsonBuilder.registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory());
         }
         if (config.isPrettyResponseLoggingEnabled()) {
@@ -44,12 +44,12 @@ public class GsonFactory {
 
     public static Gson createCamelCase(SlackConfig config) {
         GsonBuilder gsonBuilder = new GsonBuilder()
-                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory())
-                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory())
-                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory())
-                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory())
-                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory());
-        if (config.isLibraryMaintainerMode()) {
+                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory(config.isFailOnUnknownProperties()))
+                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory(config.isFailOnUnknownProperties()))
+                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory(config.isFailOnUnknownProperties()))
+                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory(config.isFailOnUnknownProperties()))
+                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(config.isFailOnUnknownProperties()));
+        if (config.isFailOnUnknownProperties() || config.isLibraryMaintainerMode()) {
             gsonBuilder = gsonBuilder.registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory());
         }
         if (config.isPrettyResponseLoggingEnabled()) {

--- a/jslack-api-client/src/test/java/test_locally/SlackConfigTest.java
+++ b/jslack-api-client/src/test/java/test_locally/SlackConfigTest.java
@@ -25,4 +25,9 @@ public class SlackConfigTest {
         SlackConfig.DEFAULT.setLibraryMaintainerMode(false);
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void immutableDefaultConfig_setFailOnUnknownProperties() {
+        SlackConfig.DEFAULT.setFailOnUnknownProperties(false);
+    }
+
 }

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/UnknownBlock.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/UnknownBlock.java
@@ -1,0 +1,18 @@
+package com.github.seratch.jslack.api.model.block;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnknownBlock implements LayoutBlock {
+    private String type;
+    private String blockId;
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/UnknownBlockElement.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/UnknownBlockElement.java
@@ -1,0 +1,15 @@
+package com.github.seratch.jslack.api.model.block;
+
+import com.github.seratch.jslack.api.model.block.element.BlockElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnknownBlockElement extends BlockElement {
+    private String type;
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/UnknownContextBlockElement.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/UnknownContextBlockElement.java
@@ -1,0 +1,14 @@
+package com.github.seratch.jslack.api.model.block;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnknownContextBlockElement implements ContextBlockElement {
+    private String type;
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/composition/UnknownTextObject.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/composition/UnknownTextObject.java
@@ -1,0 +1,16 @@
+package com.github.seratch.jslack.api.model.block.composition;
+
+import lombok.*;
+
+/**
+ * https://api.slack.com/reference/messaging/composition-objects#text
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnknownTextObject extends TextObject {
+    private String type;
+    private String text;
+}

--- a/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/element/RichTextUnknownElement.java
+++ b/jslack-api-model/src/main/java/com/github/seratch/jslack/api/model/block/element/RichTextUnknownElement.java
@@ -1,0 +1,12 @@
+package com.github.seratch.jslack.api.model.block.element;
+
+import lombok.*;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RichTextUnknownElement extends BlockElement implements RichTextElement {
+    private String type;
+}

--- a/jslack-api-model/src/test/java/test_locally/unit/GsonFactory.java
+++ b/jslack-api-model/src/test/java/test_locally/unit/GsonFactory.java
@@ -14,14 +14,26 @@ public class GsonFactory {
     }
 
     public static Gson createSnakeCase() {
-        return new GsonBuilder()
+        return createSnakeCase(false, true);
+    }
+
+    public static Gson createSnakeCaseWithoutUnknownPropertyDetection(boolean failOnUnknownProperties) {
+        return createSnakeCase(failOnUnknownProperties, false);
+    }
+
+    public static Gson createSnakeCase(boolean failOnUnknownProperties, boolean unknownPropertyDetection) {
+        GsonBuilder builder = new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory())
-                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory())
-                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory())
-                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory())
-                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory())
-                .registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory())
-                .create();
+                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory(failOnUnknownProperties))
+                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory(failOnUnknownProperties))
+                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory(failOnUnknownProperties))
+                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory(failOnUnknownProperties))
+                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(failOnUnknownProperties));
+
+        if (unknownPropertyDetection) {
+            return builder.registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory()).create();
+        } else {
+            return builder.create();
+        }
     }
 }


### PR DESCRIPTION
This pull request improves jSlack's JSON parsing strategy to be more consistent.

Currently, the gson parser fails if it encounters unknown properties only when parsing JSON data utilizing custom type adapters. The behavior has been detecting the issues with unknown properties - #266 #268 #298 - but it's not expected behavior from jSlack users' perspective.

With the changes in this PR, jSlack never fails to parse JSON data even when it finds unknown properties in the ones covered by type adapters. If a jSlack user wants to detect unknown properties, turning failOnUnknownProperties in SlackConfig on works for the use case.